### PR TITLE
One Time Passwords - Google Authenticator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ ruby '2.2.2'
 group :development do
   gem 'rubocop'
   gem 'factory_girl'
+  gem 'rotp'
 end
 
 group :test do

--- a/models/master.rb
+++ b/models/master.rb
@@ -1,6 +1,7 @@
 require 'rubygems'
 require 'data_mapper'
 require 'bcrypt'
+require 'rotp'
 
 # read config
 options = YAML.load_file('config/database.yml')
@@ -30,6 +31,8 @@ class User
   property :created_at, DateTime, default: DateTime.now
   property :phone, String, required: false
   property :email, String, required: false
+  property :mfa, Boolean
+  property :auth_secret, String
 
   attr_accessor :password
   validates_presence_of :username
@@ -45,7 +48,10 @@ class User
 
   def self.authenticate(username, pass)
     user = User.first(username: username)
-    if user
+  #puts 'ERROR: You must define an evironment. ex: RACK_ENV=production'
+    if user.mfa
+      return user.username if pass == ROTP::TOTP.new(user.auth_secret).now.to_s
+    elsif user
       return user.username if BCrypt::Password.new(user.hashed_password) == pass
     end
   end

--- a/models/master.rb
+++ b/models/master.rb
@@ -48,7 +48,6 @@ class User
 
   def self.authenticate(username, pass)
     user = User.first(username: username)
-  #puts 'ERROR: You must define an evironment. ex: RACK_ENV=production'
     if user.mfa
       return user.username if pass == ROTP::TOTP.new(user.auth_secret).now.to_s
     elsif user

--- a/routes/accounts.rb
+++ b/routes/accounts.rb
@@ -60,8 +60,6 @@ get '/accounts/edit/:account_id' do
   @user = User.first(id: params[:account_id])
   data = Rack::Utils.escape(ROTP::TOTP.new(@user.auth_secret).provisioning_uri(@user.username))
   @otp = "https://chart.googleapis.​com/chart?chs=200x200&chld=M|0&cht=qr&chl=#{data}"
-  puts "DEBUG: opt #{@otp}"
-
   haml :account_edit
 end
 

--- a/routes/accounts.rb
+++ b/routes/accounts.rb
@@ -16,12 +16,12 @@ post '/accounts/create' do
     redirect to('/accounts/create')
   end
 
-  if params[:password].nil? || params[:password].empty?
+  if (params[:password].nil? || params[:password].empty?) && !params[:mfa]
     flash[:error] = 'You must have a password.'
     redirect to('/accounts/create')
   end
 
-  if params[:confirm].nil? || params[:confirm].empty?
+  if params[:confirm].nil? || params[:confirm].empty? && !params[:mfa]
     flash[:error] = 'You must have a password.'
     redirect to('/accounts/create')
   end
@@ -37,6 +37,13 @@ post '/accounts/create' do
       new_user.username = params[:username]
       new_user.password = params[:password]
       new_user.email = params[:email] unless params[:email].nil? || params[:email].empty?
+      if params[:mfa]
+        new_user.mfa = 't'
+        new_user.auth_secret = ROTP::Base32.random_base32
+      else
+        new_user.mfa = 'f'
+        new_user.auth_secret = ''
+      end
       new_user.admin = 't'
       new_user.save
     end
@@ -77,6 +84,15 @@ post '/accounts/save' do
   user.username = params[:username]
   user.password = params[:password] unless params[:password].nil? || params[:password].empty?
   user.email = params[:email] unless params[:email].nil? || params[:email].empty?
+  if params[:mfa] && user.auth_secret = ''
+    user.mfa = 't'
+    user.auth_secret = ROTP::Base32.random_base32
+  elsif params[:mfa]
+    user.mfa='t'
+  else
+    user.mfa = 'f'
+    user.auth_secret = ''
+  end
   user.save
   
   flash[:success] = 'Account successfuly updated.'

--- a/routes/accounts.rb
+++ b/routes/accounts.rb
@@ -58,6 +58,9 @@ get '/accounts/edit/:account_id' do
   varWash(params)
 
   @user = User.first(id: params[:account_id])
+  data = Rack::Utils.escape(ROTP::TOTP.new(@user.auth_secret).provisioning_uri(@user.username))
+  @otp = "https://chart.googleapis.​com/chart?chs=200x200&chld=M|0&cht=qr&chl=#{data}"
+  puts "DEBUG: opt #{@otp}"
 
   haml :account_edit
 end

--- a/views/account_edit.haml
+++ b/views/account_edit.haml
@@ -34,6 +34,13 @@
                   %label.control-label.col-xs-2{:for => ""} MFA (Google Authenticator)
                   .col-md-6
                     %input{:type => 'checkbox', :class => 'form-control', :name => 'mfa', :id => 'mfa', :checked => @user.mfa}
+                - if @user.mfa
+                  .form-group
+                    %label.control-label.col-xs-2{:for => ""} QR Code
+                    .col-md-6
+                      %img{:src => @otp, :alt => "Google Authenticator QR Code" }
+                      %link{:href => "#{@otp}", :rel => "stylesheet"}
+
                 .form-group
                   .col-xs-offset-2.col-xs-10
                     %input{:type => 'hidden', :name => 'account_id', :value => "#{params[:account_id].to_s}"}

--- a/views/account_edit.haml
+++ b/views/account_edit.haml
@@ -31,6 +31,10 @@
                   .col-md-6
                     %input{:type => 'textbox', :class => 'form-control', :name => 'email', :id => 'email', :value => @user.email}
                 .form-group
+                  %label.control-label.col-xs-2{:for => ""} MFA (Google Authenticator)
+                  .col-md-6
+                    %input{:type => 'checkbox', :class => 'form-control', :name => 'mfa', :id => 'mfa', :checked => @user.mfa}
+                .form-group
                   .col-xs-offset-2.col-xs-10
                     %input{:type => 'hidden', :name => 'account_id', :value => "#{params[:account_id].to_s}"}
                     %button.btn.btn-primary{:type => "submit"} Save
@@ -52,6 +56,10 @@
                   %label.control-label.col-xs-2{:for => ""} Email Address (optional)
                   .col-md-6
                     %input{:type => 'textbox', :class => 'form-control', :name => 'email', :id => 'email'}
+                .form-group
+                  %label.control-label.col-xs-2{:for => ""} MFA (Google Authenticator)
+                  .col-md-6
+                    %input{:type => 'checkbox', :class => 'form-control', :name => 'mfa', :id => 'mfa'}
                 .form-group
                   .col-xs-offset-2.col-xs-10
                     %button.btn.btn-primary{:type => "submit"} Create


### PR DESCRIPTION
Added an option to the accounts section to allow for use of google authenticator app  to provide one time passwords.  If the MFA option is checked the base32 secret is generated and stored in the users table.  
If you go back in to edit the user, a QRcode will be available that can be scanned with the Google Authenticator.

As it is setup now the password for an existing user will still exist, and allow them to authenticate.

It could be possible to make this two factor by leaving the password in place and adding a field for the one time code.  

This there is so much sensitive information in the hashview database, and there is no provision to prevent password spraying, this seems like a good security improvement.

Thoughts?