### PR TITLE
Fixed limit size calculation causing overlap in chunks

### DIFF
--- a/helpers/build_crack_cmd.rb
+++ b/helpers/build_crack_cmd.rb
@@ -33,12 +33,11 @@ helpers do
       chunk_num = 0
       while chunk_skip < @task.keyspace.to_i
         skip = chunk_skip
-        limit = skip + chunk_size
 
-        chunks[chunk_num] = [skip, limit]
+        chunks[chunk_num] = [skip, chunk_size]
 
         chunk_num += 1
-        chunk_skip = limit
+        chunk_skip = skip + chunk_size
       end
     end
 


### PR DESCRIPTION
Previous calculation of limit caused overlap in chunks. The limit flag does not limit to X words from the start, but rather "Limit X words from the start + skipped words" (according to hashcat manual).

In practical terms, I have observed the following:

Chunk 0: S = 0, L = 500000 (words: 0-500000)
Chunk 1: S = 500000, L = 1000000 (words 500000 - 1500000, but should be words 500000 - 1000000, chunk is 2 x intended size)
Chunk 2: S = 1000000, L = 1500000 (words 1000000 - 2500000, but should be words 1000000 - 2500000, chunk is 3 x intended size)
etc.

I have adjusted chunk/skip calculation to reflect this. Removed limit variable entirely, as it was just a copy of chunk_size, neither of which change during the command building.