### PR TITLE
Adds support for $user:$hash:$salt filetype

### DIFF
--- a/helpers/hashimporter.rb
+++ b/helpers/hashimporter.rb
@@ -195,12 +195,11 @@ def importHashSalt(hash, hashfile_id, type)
 end
 
 def importUserHashSalt(hash, hashfile_id, type)
-  data = hash.split(':')
-  hashSalt = data[1] + ':' + data[2]
-  @hash_id = Hashes.first(fields: [:id], originalhash: hashSalt, hashtype: type)
+  data = hash.split(':', 2)
+  @hash_id = Hashes.first(fields: [:id], originalhash: data[1], hashtype: type)
   if @hash_id.nil?
-    addHash(hashSalt, type)
-    @hash_id = Hashes.first(fields: [:id], originalhash: hashSalt, hashtype: type)
+    addHash(data[1], type)
+    @hash_id = Hashes.first(fields: [:id], originalhash: data[1], hashtype: type)
   elsif @hash_id && @hash_id.hashtype.to_s != type.to_s
     unless @hash_id.cracked
       @hash_id.hashtype = type.to_i

--- a/routes/customers.rb
+++ b/routes/customers.rb
@@ -163,7 +163,7 @@ end
 get '/customers/upload/verify_filetype' do
   varWash(params)
 
-  @filetypes = ['pwdump', 'shadow', 'dsusers', 'smart_hashdump', '$hash', '$user:$hash', '$hash:$salt', '$user::$domain:$hash:$hash:$hash (NetNTLMv1)', '$user::$domain:$challenge:$hash:$hash (NetNTLMv2)']
+  @filetypes = ['pwdump', 'shadow', 'dsusers', 'smart_hashdump', '$hash', '$user:$hash', '$hash:$salt', '$user:$hash:$salt', '$user::$domain:$hash:$hash:$hash (NetNTLMv1)', '$user::$domain:$challenge:$hash:$hash (NetNTLMv2)']
   @job = Jobs.first(id: params[:job_id])
   haml :verify_filetypes
 end
@@ -186,6 +186,10 @@ post '/customers/upload/verify_filetype' do
 
   if params[:filetype] == '$hash:$salt'
     params[:filetype] = 'hash_salt'
+  end
+  
+  if params[:filetype] == '$user:$hash:$salt'
+    params[:filetype] = 'user_hash_salt'
   end
 
   if params[:filetype] == '$user::$domain:$hash:$hash:$hash NetNTLMv1'


### PR DESCRIPTION
Adds support to solve #373 

Does not add named support for -m 2611, but allows importing of hashfiles in $user:$hash:$salt format