### PR TITLE
Bug/db connection refactor: Fix database connection syntax errors.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -36,7 +36,7 @@ def connect_db
   database = config['database']
 
   puts '[*] Connecting to DB'
-  Mysql2::Client.new(:host host, username: user, password: password, database: database)
+  Mysql2::Client.new(host: host, username: user, password: password, database: database)
 end
 
 # Trap ^C

--- a/Rakefile
+++ b/Rakefile
@@ -36,7 +36,7 @@ def connect_db
   database = config['database']
 
   puts '[*] Connecting to DB'
-  conn = Mysql2::Client.new(:host => host, :username => user, :password => password, :database => database)
+  Mysql2::Client.new(:host host, username: user, password: password, database: database)
 end
 
 # Trap ^C


### PR DESCRIPTION
The database connection scheme is extremely cumbersome and error prone within the Rakefile where it could be much more simplified with a single function that returns the database connection as a handler. This ensures the call to Mysql2::Client.new() only needs to happen once throughout the execution of the Rakefile tasks and is far more reliable, and can be changed in the event that the Mysql2 gem changes in the future. If Mysql2's syntax has changed significantly between versions, then a second function should be used as a fallback to a previous version in order to prevent simple connection failures from causing massive cryptic stacktraces.

This PR addresses Issue #435 which allows the rake update to take place properly.

Cheers 🥂 