### PR TITLE
[v0.7.4-beta] Fix race condition

### DIFF
--- a/routes/accounts.rb
+++ b/routes/accounts.rb
@@ -45,7 +45,6 @@ post '/accounts/create' do
         new_user.auth_secret = ''
       end
       new_user.admin = 't'
-      new_user.id = User.last[:id].to_i + 1 # sequel does not understand composite primary keys, and cant figure out which autoincrements
       new_user.save
     end
   else


### PR DESCRIPTION
Sequel already handles primary key incrementation, in addtion this line is not threadsafe. With this line, it's possible to create several users with identical ids at the same time. 

#### Words from @jeremyevans :arrow_down:
>The users table still seems to use [a single primary key](https://github.com/hashview/hashview/blob/master/db/migrations/001_sequel.rb#L159), not a composite primary key.
I would delete the entire line as it is dangerous. If you run anything more than a single thread, single process application, it has a race condition that will cause it to fail.