### PR TITLE
Updated logger version in Gemfile.lock to fix bug on new install

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,7 @@ GEM
       less (~> 2.6.0)
       sprockets (> 2, < 4)
       tilt
-    logger (1.2.8)
+    logger (1.2.8.1)
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)


### PR DESCRIPTION
I attempted to install hashview for the first time today and was unable due to a missing upstream dependency.  Here is a 1 line PR that updates the version of logger in the Gemfile.  It seems to be working fine now.