### PR TITLE
Increased SMTP password length

### DIFF
--- a/db/migrations/001_sequel.rb
+++ b/db/migrations/001_sequel.rb
@@ -113,7 +113,7 @@ Sequel.migration do
       String :smtp_server, size: 50
       String :smtp_sender, size: 50
       String :smtp_user, size: 50
-      String :smtp_pass, size: 50
+      String :smtp_pass, size: 100
       TrueClass :smtp_use_tls
       # Options include 'plain', 'login', 'cram_md5', 'none'
       String :smtp_auth_type, size: 50


### PR DESCRIPTION
Increased smtp_pass size to better support transactional emailing services (Like SendGrid) that auto-generate application specific passwords longer than 50 chars and don't let you change them.