### PR TITLE
Pushover & Flask-Bcrypt replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Notable changes will be documented here
 - Moved SMTP settings to config file
 - Hashview Agent is now packaged with hashview (server) under install directory. Can be downloaded from agents menu as admin
 - Changed from itsdangerous to authlib for password reset token generation (please make sure to update your environments to include authlib).
+- Changed from the python-pushover package, to a call directly to the Pushover API.
 ### Removed
 - Removed hashview agent from local processing. If you want to run hashview AND crack hashes on the same box run the hashview-agent in a seperate screen/tmux session
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Notable changes will be documented here
 - Hashview Agent is now packaged with hashview (server) under install directory. Can be downloaded from agents menu as admin
 - Changed from itsdangerous to authlib for password reset token generation (please make sure to update your environments to include authlib).
 - Changed from the python-pushover package, to a call directly to the Pushover API.
+- Changed from Flask-Bcrypt to Bcrypt-Flask.
 ### Removed
 - Removed hashview agent from local processing. If you want to run hashview AND crack hashes on the same box run the hashview-agent in a seperate screen/tmux session
 

--- a/hashview.py
+++ b/hashview.py
@@ -42,6 +42,14 @@ with app.app_context():
         print('\nPlease make sure that your dependencies are up to date (including installing requests).')
         exit(1)
 
+    try:
+        import flask_bcrypt
+        if ('1.0.1' < flask_bcrypt.__version__):
+            raise Exception('old version')
+    except:
+        print('\nPlease make sure that your dependencies are up to date (including replacing Flask-Bcrypt with Bcrypt-Flask).')
+        exit(1)
+
     # If no admins exist prompt user to generate new admin account
     if users == 0:
         print('\nInitial setup detected. Hashview will now prompt you to setup an Administrative account.\n')

--- a/hashview.py
+++ b/hashview.py
@@ -57,7 +57,7 @@ with app.app_context():
         admin_lastname = input('Enter Administrator\'s last name: ')
         while len(admin_lastname) == 0:
             print('Error: Firstname must be at least 1 character long')
-            admin_lastname = input('Enter Administrator\'s last name: ')    
+            admin_lastname = input('Enter Administrator\'s last name: ')
 
         print('\nProvisioning account in database.')
         hashed_password = bcrypt.generate_password_hash(admin_password).decode('utf-8')
@@ -73,7 +73,7 @@ with app.app_context():
         while int(retention_period) < 1 or int(retention_period) > 65535:
             print('Error: Retention must be between 1 day and 65535 days')
             retention_period = input("Enter how long data should be retained in DB in days. (note: cracked hashes->plaintext will be be safe from retention culling): ")
-        
+
         with open('VERSION.TXT') as f:
             version = f.readline().rstrip()
 
@@ -87,25 +87,25 @@ with app.app_context():
         wordlist_path = 'hashview/control/wordlists/dynamic-all.txt'
         open(wordlist_path, 'w')
         wordlist = Wordlists(name='All Recovered Hashes',
-                    owner_id='1', 
-                    type='dynamic', 
+                    owner_id='1',
+                    type='dynamic',
                     path=wordlist_path, # Can we make this a relative path?
                     checksum=get_filehash(wordlist_path),
                     size=0)
         db.session.add(wordlist)
         db.session.commit()
-        
+
     # Setup wordlist rockyou
     if static_wordlists == 0:
         print('\nSetting up static wordlist rockyou.')
         cmd = "gzip -d -k install/rockyou.txt.gz"
         os.system(cmd)
         os.replace('install/rockyou.txt', 'hashview/control/wordlists/rockyou.txt')
-    
+
         wordlist_path = 'hashview/control/wordlists/rockyou.txt'
         wordlist = Wordlists(name='Rockyou.txt',
-            owner_id='1', 
-            type='static', 
+            owner_id='1',
+            type='static',
             path=wordlist_path, # Can we make this a relative path?
             checksum=get_filehash(wordlist_path),
             size=get_linecount(wordlist_path))
@@ -120,9 +120,9 @@ with app.app_context():
         os.replace('install/best64.rule', 'hashview/control/rules/best64.rule')
 
         rules_path = 'hashview/control/rules/best64.rule'
-        
-        rule = Rules(   name='Best64 Rule', 
-                        owner_id='1', 
+
+        rule = Rules(   name='Best64 Rule',
+                        owner_id='1',
                         path=rules_path,
                         size=get_linecount(rules_path),
                         checksum=get_filehash(rules_path))
@@ -131,40 +131,40 @@ with app.app_context():
 
     # setup task
     if tasks == 0:
-        
+
         print('\nSetting up default tasks.')
 
         # wordlist only
-        task = Tasks(   name='Rockyou Wordlist', 
+        task = Tasks(   name='Rockyou Wordlist',
                         owner_id='1',
                         wl_id='1',
-                        rule_id=None, 
+                        rule_id=None,
                         hc_attackmode='dictionary',
-        )             
+        )
         db.session.add(task)
         db.session.commit()
 
         # wordlist with best 64 rules
-        task = Tasks(   name='Rockyou Wordlist + Best64 Rules', 
+        task = Tasks(   name='Rockyou Wordlist + Best64 Rules',
                 owner_id='1',
                 wl_id='1',
-                rule_id='1', 
+                rule_id='1',
                 hc_attackmode='dictionary'
-        )             
+        )
         db.session.add(task)
         db.session.commit()
 
-        
+
         # mask mode of all 8 characters
-        task = Tasks(   name='?a?a?a?a?a?a?a?a [8]', 
+        task = Tasks(   name='?a?a?a?a?a?a?a?a [8]',
                         owner_id='1',
                         wl_id=None,
-                        rule_id=None, 
+                        rule_id=None,
                         hc_attackmode='maskmode',
                         hc_mask='?a?a?a?a?a?a?a?a'
-        )   
+        )
         db.session.add(task)
-        db.session.commit() 
+        db.session.commit()
 
     # Check if Version value in DB matches or is less than the version file on disk. This is our way of checking if the end user needs to run db flask upgrade or any other migration
     settings = Settings.query.first()
@@ -239,7 +239,7 @@ def data_retention_cleanup():
 
                 db.session.delete(job)
                 db.session.commit()
-                
+
             # Hashfiles, HashfileHashes and Hash notifications
             print('[DEBUG] Hashfile Name: ' + str(hashfile.name) + '    Owner ID: ' + str(hashfile.owner_id))
             print('[DEBUG] Hashfile ID: ' + str(hashfile.id))
@@ -253,7 +253,7 @@ def data_retention_cleanup():
                 hashes = Hashes.query.filter_by(id=hashfile_hash.hash_id).filter_by(cracked=0).all()
                 for hash in hashes:
                     # Check to see if our hashfile is the ONLY hashfile that has this hash
-                    # if duplicates exist, they can still be removed. Once the hashfile_hash entry is remove, 
+                    # if duplicates exist, they can still be removed. Once the hashfile_hash entry is remove,
                     # the total number of matching hash_id's will be reduced to < 2 and then can be deleted
                     hashfile_cnt = HashfileHashes.query.filter_by(hash_id=hash.id).distinct('hashfile_id').count()
                     if hashfile_cnt < 2:
@@ -290,5 +290,5 @@ if __name__ == '__main__':
     else:
         builtins.state = 'normal'
         log = logging.getLogger('werkzeug')
-        log.setLevel(logging.ERROR)  
+        log.setLevel(logging.ERROR)
         app.run(host='0.0.0.0', port=8443, ssl_context=('./hashview/ssl/cert.pem', './hashview/ssl/key.pem'), debug=False)

--- a/hashview.py
+++ b/hashview.py
@@ -36,6 +36,12 @@ with app.app_context():
         print('\nPlease make sure that your dependencies are up to date (including installing authlib).')
         exit(1)
 
+    try:
+        import requests
+    except:
+        print('\nPlease make sure that your dependencies are up to date (including installing requests).')
+        exit(1)
+
     # If no admins exist prompt user to generate new admin account
     if users == 0:
         print('\nInitial setup detected. Hashview will now prompt you to setup an Administrative account.\n')

--- a/hashview/utils/utils.py
+++ b/hashview/utils/utils.py
@@ -27,7 +27,7 @@ def _count_generator(reader):
         b = reader(1024 * 1024)
 
 def get_linecount(filepath):
-    
+
     with open(filepath, 'rb') as fp:
         c_generator = _count_generator(fp.raw.read)
         count = sum(buffer.count(b'\n') for buffer in c_generator)
@@ -80,12 +80,12 @@ def import_hashfilehashes(hashfile_id, hashfile_path, file_type, hash_type):
     file = open(hashfile_path, 'r')
     lines = file.readlines()
 
-    # for line in file, 
+    # for line in file,
     for line in lines:
         # If line is empty:
         if len(line) > 0:
             if file_type == 'hash_only':
-                # forcing lower casing of hash as hashcat will return lower cased version of the has and we want to match what we imported. 
+                # forcing lower casing of hash as hashcat will return lower cased version of the has and we want to match what we imported.
                 if hash_type == '300':
                     hash_id = import_hash_only(line=line.lower().rstrip(), hash_type=hash_type)
                 else:
@@ -132,7 +132,7 @@ def import_hashfilehashes(hashfile_id, hashfile_path, file_type, hash_type):
                     line_list[5] = line_list[5].lower()
                     line = ':'.join(line_list)
                     hash_id = import_hash_only(line=line.rstrip(), hash_type=hash_type)
-                    username = line.split(':')[0] 
+                    username = line.split(':')[0]
             else:
                 return False
             if username == None:
@@ -140,7 +140,7 @@ def import_hashfilehashes(hashfile_id, hashfile_path, file_type, hash_type):
             else:
                 hashfilehashes = HashfileHashes(hash_id=hash_id, username=username.encode('latin-1').hex(), hashfile_id=hashfile_id)
             db.session.add(hashfilehashes)
-            db.session.commit() 
+            db.session.commit()
 
     return True
 
@@ -211,9 +211,9 @@ def build_hashcat_command(job_id, task_id):
     return cmd
 
 def update_job_task_status(jobtask_id, status):
-    
+
     jobtask = JobTasks.query.get(jobtask_id)
-    
+
     if jobtask is None:
         return False
 
@@ -243,7 +243,7 @@ def update_job_task_status(jobtask_id, status):
     for jobtask in jobtasks:
         if jobtask.status == 'Queued' or jobtask.status == 'Running' or jobtask.status == 'Importing':
             done = False
-    
+
     if done:
         job.status = 'Completed'
         job.ended_at = time.strftime('%Y-%m-%d %H:%M:%S')
@@ -260,7 +260,7 @@ def update_job_task_status(jobtask_id, status):
         # TODO
         # mark all jobtasks as completed
         job_notifications = JobNotifications.query.filter_by(job_id = job.id)
-        
+
         # Send Notifications
         for job_notification in job_notifications:
             user = Users.query.get(job_notification.owner_id)
@@ -275,7 +275,7 @@ def update_job_task_status(jobtask_id, status):
                     send_email(user, 'Hashview: Missing Pushover Key', 'Hello, you were due to recieve a pushover notification, but because your account was not provisioned with an pushover ID and Key, one could not be set. Please log into hashview and set these options under Manage->Profile.')
             db.session.delete(job_notification)
             db.session.commit()
-    
+
     return True
 
 # Dumb way of doing this, we return with an error message if we have an issue with the hashfile
@@ -298,7 +298,7 @@ def validate_hashfile(hashfile_path, file_type, hash_type):
                 list_of_username_and_computers.append(username_computer)
 
     line_number = 0
-    # for line in file, 
+    # for line in file,
     for line in lines:
         line_number += 1
         # TODO
@@ -342,7 +342,7 @@ def validate_hashfile(hashfile_path, file_type, hash_type):
                     if dollar_cnt != 3:
                         return 'Error line ' + str(line_number) + '. Doesnt appear to be of the type: Sha512 Crypt.'
                     if '$6$' not in line:
-                        return 'Error line ' + str(line_number) + '. Doesnt appear to be of the type: Sha512 Crypt.'                        
+                        return 'Error line ' + str(line_number) + '. Doesnt appear to be of the type: Sha512 Crypt.'
                 if hash_type == '3200':
                     if '$' not in line:
                         return 'Error line ' + str(line_number) + ' is missing a $ character. bcrypt Hashes should have these.'
@@ -352,7 +352,7 @@ def validate_hashfile(hashfile_path, file_type, hash_type):
                             dollar_cnt += 1
                     if dollar_cnt != 3:
                         return 'Error line ' + str(line_number) + '. Doesnt appear to be of the type: bcrypt'
-                       
+
             if file_type == 'shadow':
                 if ':' not in line:
                     return 'Error line ' + str(line_number) + ' is missing a : character. shadow file should include usernames.'
@@ -375,15 +375,15 @@ def validate_hashfile(hashfile_path, file_type, hash_type):
                     if char == ':':
                         colon_cnt += 1
                 if colon_cnt < 6:
-                    return 'Error line ' + str(line_number) + '. File does not appear to be be in a pwdump format.' 
+                    return 'Error line ' + str(line_number) + '. File does not appear to be be in a pwdump format.'
                 if hash_type == '1000':
                     if len(line.split(':')[3]) != 32:
                         return 'Error line ' + str(line_number) + ' has an invalid number of characters (' + str(len(line.rstrip())) + ') should be 32'
                 else:
-                    return 'Sorry. The only Hash Type we support for PWDump files is NTLM'   
+                    return 'Sorry. The only Hash Type we support for PWDump files is NTLM'
             elif file_type == 'kerberos':
                 if '$' not in line:
-                    return 'Error line ' + str(line_number) + ' is missing a $ character. kerberos file should include these.'  
+                    return 'Error line ' + str(line_number) + ' is missing a $ character. kerberos file should include these.'
                 if len(line) > 16384:
                     return 'Error line ' + str(line_number) + ' is too long. Max char length is 16384. If you need long please submit an issue on GitHub'
                 dollar_cnt = 0
@@ -408,7 +408,7 @@ def validate_hashfile(hashfile_path, file_type, hash_type):
                     if line.split('$')[1] != 'krb5tgs':
                         return 'Error line ' + str(line_number) + '. Doesnt appear to be of the type: Kerberos 5, etype 23, TGS-REP (2)'
                     if line.split('$')[2] != '23':
-                        return 'Error line ' + str(line_number) + '. Doesnt appear to be of the type: Kerberos 5, etype 23, TGS-REP (3)'                    
+                        return 'Error line ' + str(line_number) + '. Doesnt appear to be of the type: Kerberos 5, etype 23, TGS-REP (3)'
                 elif hash_type == '18200':
                     # This is slow af :(
                     for char in line:
@@ -419,7 +419,7 @@ def validate_hashfile(hashfile_path, file_type, hash_type):
                     if line.split('$')[1] != 'krb5asrep':
                         return 'Error line ' + str(line_number) + '. Doesnt appear to be of the type: Kerberos 5, etype 23, AS-REP (2)'
                     if line.split('$')[2] != '23':
-                        return 'Error line ' + str(line_number) + '. Doesnt appear to be of the type: Kerberos 5, etype 23, AS-REP (3)'                      
+                        return 'Error line ' + str(line_number) + '. Doesnt appear to be of the type: Kerberos 5, etype 23, AS-REP (3)'
                 elif hash_type == '19600':
                     # This is slow af :(
                     for char in line:
@@ -430,7 +430,7 @@ def validate_hashfile(hashfile_path, file_type, hash_type):
                     if line.split('$')[1] != 'krb5tgs':
                         return 'Error line ' + str(line_number) + '. Doesnt appear to be of the type: Kerberos 5, etype 17, TGS-REP (AES128-CTS-HMAC-SHA1-96) (2)'
                     if line.split('$')[2] != '17':
-                        return 'Error line ' + str(line_number) + '. Doesnt appear to be of the type: Kerberos 5, etype 17, TGS-REP (AES128-CTS-HMAC-SHA1-96) (3)'                     
+                        return 'Error line ' + str(line_number) + '. Doesnt appear to be of the type: Kerberos 5, etype 17, TGS-REP (AES128-CTS-HMAC-SHA1-96) (3)'
                 elif hash_type == '19700':
                     # This is slow af :(
                     for char in line:
@@ -441,7 +441,7 @@ def validate_hashfile(hashfile_path, file_type, hash_type):
                     if line.split('$')[1] != 'krb5tgs':
                         return 'Error line ' + str(line_number) + '. Doesnt appear to be of the type: Kerberos 5, etype 18, TGS-REP (AES256-CTS-HMAC-SHA1-96) (2)'
                     if line.split('$')[2] != '18':
-                        return 'Error line ' + str(line_number) + '. Doesnt appear to be of the type: Kerberos 5, etype 18, TGS-REP (AES256-CTS-HMAC-SHA1-96) (3)'      
+                        return 'Error line ' + str(line_number) + '. Doesnt appear to be of the type: Kerberos 5, etype 18, TGS-REP (AES256-CTS-HMAC-SHA1-96) (3)'
                 elif hash_type == '19800':
                     # This is slow af :(
                     for char in line:
@@ -452,7 +452,7 @@ def validate_hashfile(hashfile_path, file_type, hash_type):
                     if line.split('$')[1] != 'krb5pa':
                         return 'Error line ' + str(line_number) + '. Doesnt appear to be of the type: Kerberos 5, etype 17, Pre-Auth (2)'
                     if line.split('$')[2] != '17':
-                        return 'Error line ' + str(line_number) + '. Doesnt appear to be of the type: Kerberos 5, etype 17, Pre-Auth (3)'  
+                        return 'Error line ' + str(line_number) + '. Doesnt appear to be of the type: Kerberos 5, etype 17, Pre-Auth (3)'
                 elif hash_type == '19900':
                     # This is slow af :(
                     for char in line:
@@ -463,7 +463,7 @@ def validate_hashfile(hashfile_path, file_type, hash_type):
                     if line.split('$')[1] != 'krb5pa':
                         return 'Error line ' + str(line_number) + '. Doesnt appear to be of the type: Kerberos 5, etype 18, Pre-Auth (2)'
                     if line.split('$')[2] != '18':
-                        return 'Error line ' + str(line_number) + '. Doesnt appear to be of the type: Kerberos 5, etype 18, Pre-Auth (3)'  
+                        return 'Error line ' + str(line_number) + '. Doesnt appear to be of the type: Kerberos 5, etype 18, Pre-Auth (3)'
                 else:
                     return 'Sorry. The only suppported Hash Types are: 7500, 13100, 18200, 19600, 19700, 19800 and 19900.'
 
@@ -477,22 +477,22 @@ def validate_hashfile(hashfile_path, file_type, hash_type):
                     if char == ':':
                         colon_cnt += 1
                 if colon_cnt < 5:
-                    return 'Error line ' + str(line_number) + '. File does not appear to be be in a NetNTLM format.'    
+                    return 'Error line ' + str(line_number) + '. File does not appear to be be in a NetNTLM format.'
 
     return False
 
 def getTimeFormat(total_runtime): # Runtime in seconds
     if total_runtime >= 604800:
         return str(round(total_runtime/604800)) + " week(s)"
-    elif total_runtime >= 86400: 
+    elif total_runtime >= 86400:
         return str(round(total_runtime/86400)) + " day(s)"
-    elif total_runtime >= 3600: 
+    elif total_runtime >= 3600:
         return str(round(total_runtime/3600)) + " hour(s)"
-    elif total_runtime >= 60: 
+    elif total_runtime >= 60:
         return str(round(total_runtime/60)) + " minute(s)"
     elif total_runtime < 60:
-         return "less then 1 minute"                                        
-                                      
+        return "less then 1 minute"
+
 
 def getHashviewVersion():
     with open('VERSION.TXT') as f:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ flask-wtf
 email_validator
 flask-sqlalchemy
 mysql-connector-python
-flask-bcrypt
+bcrypt-flask
 flask-login
 flask-mail
 flask-migrate

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ flask-mail
 flask-migrate
 flask-script
 flask-apscheduler
-python-pushover
 WTForms-SQLAlchemy
 packaging
 authlib
+requests


### PR DESCRIPTION
The latest published version of the python-pushover package requires `use_2to3` which is no longer provided by [setuptools](https://github.com/pypa/setuptools/blob/main/CHANGES.rst#v5800). In order to resolve this, I walked through the package, as well as the Pushover API, and came to the conclusion that it would be better to use the API directly. (it requires only a handful of lines, instead of an additional dependency).

More info about the Flask-Bcrypt to Bcrypt-Flask switch can be found in the related Issue.

Closes #43