### PR TITLE
Fix Users._get_reset_token_salt for password resets

### DIFF
--- a/hashview/models.py
+++ b/hashview/models.py
@@ -40,7 +40,7 @@ class Users(db.Model, UserMixin):
         return json.dumps([
             self.first_name,
             self.last_name,
-            self.password.hash.decode() if self.password is not None else '',
+            self.password if (self.password is not None) else '',
             self.last_login_utc.to('UTC').isoformat() if self.last_login_utc else None
         ])
 


### PR DESCRIPTION
There is no need to decode the password hash for the purposes of the salt.