### PR TITLE
removed debian tag from docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
         condition: service_healthy
 
   db:
-    image: "mysql:8-debian"
+    image: "mysql"
     restart: always
     cap_add:
       - SYS_NICE


### PR DESCRIPTION
removed `:8-debian` from the mysql image declaration. There is not an ARM version for that specific tag. removing the tag allowed the default image to proceed successfully.  