### PR TITLE
Fix docker compose pull on arm64 (mysql:8-debian → mysql:8)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
         condition: service_healthy
 
   db:
-    image: "mysql:8-debian"
+    image: "mysql:8"
     platform: ${DOCKER_PLATFORM:-linux/amd64}
     restart: always
     cap_add:


### PR DESCRIPTION
## Summary
- Swap `db` service image from `mysql:8-debian` to multi-arch `mysql:8` so `docker compose up --pull always` works on Apple Silicon without manual `--platform` workarounds.
- Bonus: `mysql:8` runs natively on arm64 instead of via x86 emulation.

Fixes #164

## Test plan
- [ ] On Apple Silicon: `docker compose up --pull always` pulls and starts the `db` service without manifest errors
- [ ] On Intel/amd64: `docker compose up --pull always` still works
- [ ] App connects to MySQL and existing migrations / queries continue to function (Oracle Linux mysql:8 vs Debian variant should be wire-compatible, but worth a smoke test)
- [ ] e2e harness CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)