### PR TITLE
Fix docker compose pull on arm64 by switching to multi-arch mysql:8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
         condition: service_healthy
 
   db:
-    image: "mysql:8-debian"
+    image: "mysql:8"
     platform: ${DOCKER_PLATFORM:-linux/amd64}
     restart: always
     cap_add:


### PR DESCRIPTION
## Summary
- `docker-compose.yml`: switch `db` image from `mysql:8-debian` (amd64-only) to `mysql:8` (multi-arch), so `docker compose pull`/`up` works on arm64 hosts (Apple Silicon, etc.). `platform: ${DOCKER_PLATFORM:-linux/amd64}` is preserved, so existing amd64 flows are unchanged.

## Test plan
- [x] `docker compose up -d --build` brings up both `db` (healthy) and `app`
- [x] `curl http://127.0.0.1:5000/login` returns 302 (first-run setup redirect, expected)
- [ ] CI e2e harness passes against this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)