### PR TITLE
Add server-side conversion for WPA captures and NTDS.dit files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,4 @@ hashview/control/hashes/*
 hashview/control/logs/*
 hashview/control/wordlists_import/*
 hashview/ssl/*
+.scratch/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,9 +26,18 @@ services:
     volumes:
       - db:/var/lib/mysql
     healthcheck:
-      test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
-      timeout: 20s
-      retries: 10
+      # Gate on the REAL server: force TCP (-h 127.0.0.1) and run a query as the
+      # app's user against its database, so the check only passes after init is
+      # fully done. The previous `mysqladmin ping -h localhost` used the unix
+      # socket, which answers during MySQL's temporary init server — letting the
+      # app start and run migrations before the real server accepts TCP. Those
+      # migrations fail (connection refused) and get swallowed, leaving an empty
+      # schema and "Table 'hashview.users' doesn't exist" on every request.
+      test: ["CMD-SHELL", "mysql -h 127.0.0.1 -u hashview -phashview -e 'SELECT 1' hashview || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 30s
 
 volumes:
   db:

--- a/hashview/__init__.py
+++ b/hashview/__init__.py
@@ -69,15 +69,30 @@ def setup_defaults_if_needed():
         logger.exception('Upgrading Database failed.')
 
     try:
-        from hashview.scheduler import data_retention_cleanup, scheduler
+        from hashview.scheduler import (
+            data_retention_cleanup,
+            process_pending_conversions,
+            scheduler,
+        )
         logger.info('Clearing Scheduled Jobs.')
         scheduler.remove_all_jobs()
         logger.info('Adding Default Scheduled Jobs Progressing.')
+        # Pass the real application object, not the current_app proxy: these jobs
+        # run in bare APScheduler threads with no app context, where the proxy
+        # would raise "Working outside of application context" when each job does
+        # `with app.app_context()`.
+        app_obj = current_app._get_current_object()  # pylint: disable=protected-access
         scheduler.add_job(
             id='DATA_RETENTION',
-            func=partial(data_retention_cleanup, current_app),
+            func=partial(data_retention_cleanup, app_obj),
             trigger='cron',
             hour='*',
+        )
+        scheduler.add_job(
+            id='CONVERSION_PROCESSOR',
+            func=partial(process_pending_conversions, app_obj),
+            trigger='interval',
+            seconds=30,
         )
         logger.info('Adding Default Scheduled Jobs is Complete.')
     except Exception:

--- a/hashview/api/routes.py
+++ b/hashview/api/routes.py
@@ -1610,6 +1610,70 @@ def v1_api_post_wpa_pcap_upload(customer_id, hashfile_name):
         'conversion_id': conv.id,
     })
 
+@api.route('/v1/hashfiles/upload/ntds/<int:customer_id>/<hashfile_name>', methods=['POST'])
+def v1_api_post_ntds_upload(customer_id, hashfile_name):
+    if not is_authorized(user=True, agent=False, request=request):
+        return redirect("/v1/not_authorized")
+
+    customer = Customers.query.get(customer_id)
+    if not customer:
+        return jsonify({'status': 400, 'type': 'Error', 'msg': 'Invalid customer ID'})
+
+    user = Users.query.filter_by(api_key=request.cookies.get('uuid')).first()
+
+    ntds_file = request.files.get('ntds_file')
+    system_file = request.files.get('system_file')
+
+    if not ntds_file or not ntds_file.filename:
+        return jsonify({'status': 400, 'type': 'Error', 'msg': 'Missing ntds_file in request'})
+    if not system_file or not system_file.filename:
+        return jsonify({'status': 400, 'type': 'Error', 'msg': 'Missing system_file in request'})
+
+    ntds_path = os.path.abspath(os.path.join(
+        current_app.root_path, 'control/tmp', secrets.token_hex(8) + '.dit'
+    ))
+    system_path = os.path.abspath(os.path.join(
+        current_app.root_path, 'control/tmp', secrets.token_hex(8) + '.sys'
+    ))
+
+    try:
+        ntds_file.save(ntds_path)
+    except Exception as e:
+        return jsonify({'status': 500, 'type': 'Error', 'msg': f'Failed to save NTDS.dit: {e}'})
+
+    try:
+        system_file.save(system_path)
+    except Exception as e:
+        if os.path.exists(ntds_path):
+            os.remove(ntds_path)
+        return jsonify({'status': 500, 'type': 'Error', 'msg': f'Failed to save SYSTEM hive: {e}'})
+
+    hashfile = Hashfiles(name=hashfile_name, customer_id=customer_id, owner_id=user.id)
+    db.session.add(hashfile)
+    db.session.commit()
+
+    conv = HashfileConversions(
+        hashfile_id=hashfile.id,
+        source_type='ntds',
+        status='pending',
+        source_path=ntds_path,
+        system_path=system_path,
+    )
+    db.session.add(conv)
+    db.session.commit()
+
+    log_event('hashfile.create', actor=(user.email_address, user.id),
+              target=f'hashfile:{hashfile.id} {hashfile.name!r}',
+              detail='source_type=ntds status=pending')
+
+    return jsonify({
+        'status': 200,
+        'type': 'message',
+        'msg': 'NTDS.dit uploaded. Conversion queued.',
+        'hashfile_id': hashfile.id,
+        'conversion_id': conv.id,
+    })
+
 @api.route('/v1/hashfiles/<int:hashfile_id>/conversion', methods=['GET'])
 def v1_api_get_conversion_status(hashfile_id):
     if not is_authorized(user=True, agent=False, request=request):

--- a/hashview/api/routes.py
+++ b/hashview/api/routes.py
@@ -1561,6 +1561,55 @@ def v1_api_hashes_import(hash_type):
             }
     return jsonify(message)
 
+@api.route('/v1/hashfiles/upload/wpa_pcap/<int:customer_id>/<hashfile_name>', methods=['POST'])
+def v1_api_post_wpa_pcap_upload(customer_id, hashfile_name):
+    if not is_authorized(user=True, agent=False, request=request):
+        return redirect("/v1/not_authorized")
+
+    customer = Customers.query.get(customer_id)
+    if not customer:
+        return jsonify({'status': 400, 'type': 'Error', 'msg': 'Invalid customer ID'})
+
+    user = Users.query.filter_by(api_key=request.cookies.get('uuid')).first()
+
+    raw_content = request.get_data()
+    if not raw_content:
+        return jsonify({'status': 400, 'type': 'Error', 'msg': 'Missing capture file content in request body'})
+
+    file_path = os.path.abspath(os.path.join(
+        current_app.root_path, 'control/tmp', secrets.token_hex(8) + '.pcapng'
+    ))
+    try:
+        with open(file_path, 'wb') as f:
+            f.write(raw_content)
+    except Exception as e:
+        return jsonify({'status': 500, 'type': 'Error', 'msg': f'Failed to save capture file: {e}'})
+
+    hashfile = Hashfiles(name=hashfile_name, customer_id=customer_id, owner_id=user.id)
+    db.session.add(hashfile)
+    db.session.commit()
+
+    conv = HashfileConversions(
+        hashfile_id=hashfile.id,
+        source_type='wpa_pcap',
+        status='pending',
+        source_path=file_path,
+    )
+    db.session.add(conv)
+    db.session.commit()
+
+    log_event('hashfile.create', actor=(user.email_address, user.id),
+              target=f'hashfile:{hashfile.id} {hashfile.name!r}',
+              detail='source_type=wpa_pcap status=pending')
+
+    return jsonify({
+        'status': 200,
+        'type': 'message',
+        'msg': 'Capture uploaded. Conversion queued.',
+        'hashfile_id': hashfile.id,
+        'conversion_id': conv.id,
+    })
+
 @api.route('/v1/hashfiles/<int:hashfile_id>/conversion', methods=['GET'])
 def v1_api_get_conversion_status(hashfile_id):
     if not is_authorized(user=True, agent=False, request=request):

--- a/hashview/api/routes.py
+++ b/hashview/api/routes.py
@@ -20,6 +20,7 @@ from hashview.models import (
     Agents,
     Customers,
     Hashes,
+    HashfileConversions,
     HashfileHashes,
     Hashfiles,
     JobNotifications,
@@ -1559,3 +1560,26 @@ def v1_api_hashes_import(hash_type):
             'msg': 'Unsupported Hashtype'
             }
     return jsonify(message)
+
+@api.route('/v1/hashfiles/<int:hashfile_id>/conversion', methods=['GET'])
+def v1_api_get_conversion_status(hashfile_id):
+    if not is_authorized(user=True, agent=False, request=request):
+        return redirect("/v1/not_authorized")
+
+    hashfile = Hashfiles.query.get(hashfile_id)
+    if not hashfile:
+        return jsonify({'status': 404, 'type': 'Error', 'msg': 'Hashfile not found'})
+
+    conv = HashfileConversions.query.filter_by(hashfile_id=hashfile_id).first()
+    if not conv:
+        return jsonify({'status': 404, 'type': 'Error', 'msg': 'No conversion record for this hashfile'})
+
+    return jsonify({
+        'status': 200,
+        'type': 'message',
+        'hashfile_id': hashfile_id,
+        'conversion_id': conv.id,
+        'source_type': conv.source_type,
+        'conversion_status': conv.status,
+        'conversion_error': conv.conversion_error,
+    })

--- a/hashview/api_docs/openapi.yaml
+++ b/hashview/api_docs/openapi.yaml
@@ -890,6 +890,42 @@ paths:
         '302':
           $ref: '#/components/responses/NotAuthorizedRedirect'
 
+  /v1/hashfiles/{hashfile_id}/conversion:
+    get:
+      tags: [Hashfiles]
+      summary: Poll the conversion status of an uploaded source file
+      description: >-
+        Returns the current state of the async conversion for a hashfile
+        created via the wpa_pcap or ntds upload endpoints. Status transitions
+        pending -> converting -> ready | failed; conversion_error carries the
+        message when status is failed.
+      operationId: getConversionStatus
+      x-audience: user
+      security:
+        - userApiKey: []
+      parameters:
+        - name: hashfile_id
+          in: path
+          required: true
+          schema: {type: integer}
+      responses:
+        '200':
+          description: >-
+            HTTP 200 always; body status 200 with the conversion state, or a
+            body status 404 if the hashfile or its conversion record doesn't
+            exist.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/ConversionStatusResponse'
+                  - $ref: '#/components/schemas/ApiError'
+              examples:
+                converting:
+                  value: {status: 200, type: message, hashfile_id: 12, conversion_id: 3, source_type: wpa_pcap, conversion_status: converting, conversion_error: null}
+        '302':
+          $ref: '#/components/responses/NotAuthorizedRedirect'
+
   /v1/hashfiles/{hashfile_id}:
     get:
       tags: [Hashfiles]
@@ -1198,6 +1234,24 @@ components:
           enum: [message]
         msg:
           type: string
+
+    ConversionStatusResponse:
+      type: object
+      description: Current state of an async source-file conversion.
+      required: [status, hashfile_id, conversion_status]
+      properties:
+        status: {type: integer, enum: [200]}
+        type: {type: string, enum: [message]}
+        hashfile_id: {type: integer}
+        conversion_id: {type: integer}
+        source_type: {type: string, enum: [wpa_pcap, ntds]}
+        conversion_status:
+          type: string
+          enum: [pending, converting, ready, failed]
+        conversion_error:
+          type: string
+          nullable: true
+          description: Error message when conversion_status is "failed"; otherwise null.
 
     ApiError:
       type: object

--- a/hashview/api_docs/openapi.yaml
+++ b/hashview/api_docs/openapi.yaml
@@ -937,6 +937,64 @@ paths:
         '302':
           $ref: '#/components/responses/NotAuthorizedRedirect'
 
+  /v1/hashfiles/upload/ntds/{customer_id}/{hashfile_name}:
+    post:
+      tags: [Hashfiles]
+      summary: Upload an NTDS.dit + SYSTEM hive for async conversion
+      description: >-
+        multipart/form-data with two file fields: `ntds_file` (the NTDS.dit)
+        and `system_file` (the SYSTEM registry hive, used for the boot key). A
+        pending conversion is queued; the scheduler later runs
+        impacket-secretsdump LOCAL (hashcat mode 1000) and imports the result.
+        Poll GET /v1/hashfiles/{hashfile_id}/conversion for progress.
+      operationId: uploadNtds
+      x-audience: user
+      security:
+        - userApiKey: []
+      parameters:
+        - name: customer_id
+          in: path
+          required: true
+          schema: {type: integer}
+        - name: hashfile_name
+          in: path
+          required: true
+          schema: {type: string}
+          description: Display name for the hashfile.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required: [ntds_file, system_file]
+              properties:
+                ntds_file:
+                  type: string
+                  format: binary
+                  description: The NTDS.dit database file.
+                system_file:
+                  type: string
+                  format: binary
+                  description: The SYSTEM registry hive.
+      responses:
+        '200':
+          description: >-
+            HTTP 200 always; body status 200 with hashfile_id + conversion_id
+            on success, 400 for an unknown customer or a missing ntds_file /
+            system_file, 500 if a file can't be saved.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/ConversionQueuedResponse'
+                  - $ref: '#/components/schemas/ApiError'
+              examples:
+                queued:
+                  value: {status: 200, type: message, msg: NTDS.dit uploaded. Conversion queued., hashfile_id: 12, conversion_id: 3}
+        '302':
+          $ref: '#/components/responses/NotAuthorizedRedirect'
+
   /v1/hashfiles/{hashfile_id}/conversion:
     get:
       tags: [Hashfiles]

--- a/hashview/api_docs/openapi.yaml
+++ b/hashview/api_docs/openapi.yaml
@@ -890,6 +890,53 @@ paths:
         '302':
           $ref: '#/components/responses/NotAuthorizedRedirect'
 
+  /v1/hashfiles/upload/wpa_pcap/{customer_id}/{hashfile_name}:
+    post:
+      tags: [Hashfiles]
+      summary: Upload a WPA capture for async conversion
+      description: >-
+        The request body is the RAW capture file (pcap/pcapng) as binary. A
+        Hashfiles record and a pending HashfileConversions record are created;
+        a scheduler job later runs hcxpcapngtool (hashcat mode 22000) and
+        imports the result. Poll GET /v1/hashfiles/{hashfile_id}/conversion
+        for progress.
+      operationId: uploadWpaPcap
+      x-audience: user
+      security:
+        - userApiKey: []
+      parameters:
+        - name: customer_id
+          in: path
+          required: true
+          schema: {type: integer}
+        - name: hashfile_name
+          in: path
+          required: true
+          schema: {type: string}
+          description: Display name for the hashfile.
+      requestBody:
+        required: true
+        content:
+          application/octet-stream:
+            schema: {type: string, format: binary}
+      responses:
+        '200':
+          description: >-
+            HTTP 200 always; body status 200 with hashfile_id + conversion_id
+            on success, 400 for an unknown customer or empty body, 500 if the
+            capture file can't be saved.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/ConversionQueuedResponse'
+                  - $ref: '#/components/schemas/ApiError'
+              examples:
+                queued:
+                  value: {status: 200, type: message, msg: Capture uploaded. Conversion queued., hashfile_id: 12, conversion_id: 3}
+        '302':
+          $ref: '#/components/responses/NotAuthorizedRedirect'
+
   /v1/hashfiles/{hashfile_id}/conversion:
     get:
       tags: [Hashfiles]
@@ -1234,6 +1281,19 @@ components:
           enum: [message]
         msg:
           type: string
+
+    ConversionQueuedResponse:
+      type: object
+      description: >-
+        Returned by the wpa_pcap / ntds upload endpoints when the source file
+        is saved and a conversion is queued (status pending).
+      required: [status, hashfile_id, conversion_id]
+      properties:
+        status: {type: integer, enum: [200]}
+        type: {type: string, enum: [message]}
+        msg: {type: string}
+        hashfile_id: {type: integer}
+        conversion_id: {type: integer}
 
     ConversionStatusResponse:
       type: object

--- a/hashview/hashfiles/routes.py
+++ b/hashview/hashfiles/routes.py
@@ -12,6 +12,7 @@ from hashview.jobs.forms import JobsNewHashFileForm
 from hashview.models import (
     Customers,
     Hashes,
+    HashfileConversions,
     HashfileHashes,
     Hashfiles,
     HashNotifications,
@@ -123,11 +124,19 @@ def hashfiles_list():
                 })
         hashfile_jobs[hashfile.id] = rows
 
+    conversions = {
+        c.hashfile_id: c
+        for c in HashfileConversions.query.filter(
+            HashfileConversions.status.in_(['pending', 'converting', 'failed'])
+        ).all()
+    }
+
     return render_template('hashfiles.html.j2', title='Hashfiles', hashfiles=hashfiles,
                            customers=customers, jobs=jobs,
                            hash_type_dict=hash_type_dict, hashfile_stats=hashfile_stats,
                            total_hashes=total_hashes, total_recovered=total_recovered,
-                           overall_rate=overall_rate, hashfile_jobs=hashfile_jobs)
+                           overall_rate=overall_rate, hashfile_jobs=hashfile_jobs,
+                           conversions=conversions)
 
 @hashfiles.route("/hashfiles/delete/<int:hashfile_id>", methods=['GET', 'POST'])
 @login_required

--- a/hashview/jobs/forms.py
+++ b/hashview/jobs/forms.py
@@ -43,12 +43,14 @@ class JobsNewHashFileForm(FlaskForm):
 
     name = StringField('Hashfile Name') # While required we may dynamically create this based on file upload
     file_type = SelectField('Hash File Format', choices=[('', '--SELECT--'),
-													('pwdump', 'pwdump()'), 
-													('NetNTLM', 'NetNTLMv1, NetNTLMv1+ESS or NetNTLMv2'), 
+													('pwdump', 'pwdump()'),
+													('NetNTLM', 'NetNTLMv1, NetNTLMv1+ESS or NetNTLMv2'),
 													('kerberos', 'Kerberos'),
 													('shadow', 'Linux / Unix Shadow File'),
 													('user_hash', '$user:$hash'),
-													('hash_only', '$hash')], validators=[DataRequired()])
+													('hash_only', '$hash'),
+													('wpa_pcap', 'WPA Capture (pcap / pcapng) — pwnagotchi, hcxdumptool'),
+													], validators=[DataRequired()])
 													
     hash_type = SelectField('Hash Type', choices=HASH_TYPE_CHOICES)
 

--- a/hashview/jobs/forms.py
+++ b/hashview/jobs/forms.py
@@ -50,6 +50,7 @@ class JobsNewHashFileForm(FlaskForm):
 													('user_hash', '$user:$hash'),
 													('hash_only', '$hash'),
 													('wpa_pcap', 'WPA Capture (pcap / pcapng) — pwnagotchi, hcxdumptool'),
+													('ntds', 'NTDS.dit (requires SYSTEM hive)'),
 													], validators=[DataRequired()])
 													
     hash_type = SelectField('Hash Type', choices=HASH_TYPE_CHOICES)
@@ -65,6 +66,7 @@ class JobsNewHashFileForm(FlaskForm):
 
     hashfilehashes = TextAreaField('Hashes')
     hashfile = FileField('Upload Hashfile')
+    system_file = FileField('SYSTEM hive (NTDS.dit only)')
     submit = SubmitField('Next')
 
 class JobsNotificationsForm(FlaskForm):

--- a/hashview/jobs/routes.py
+++ b/hashview/jobs/routes.py
@@ -351,6 +351,62 @@ def jobs_assigned_hashfile(job_id):
                     })
                 flash('Capture uploaded. Hashes will be available once conversion completes.', 'success')
                 return redirect(url_for('jobs.jobs_assigned_hashfile', job_id=job_id))
+
+            elif jobs_new_hashfile_form.file_type.data == 'ntds':
+                if not (jobs_new_hashfile_form.system_file.data and
+                        jobs_new_hashfile_form.system_file.data.filename):
+                    msg = 'NTDS.dit upload requires a SYSTEM hive file.'
+                    if is_ajax:
+                        return jsonify({'status': 'error', 'msg': msg}), 400
+                    flash(msg, 'danger')
+                    return redirect(url_for('jobs.jobs_assigned_hashfile', job_id=job_id))
+
+                try:
+                    system_path = os.path.join(
+                        current_app.root_path,
+                        save_file('control/tmp', jobs_new_hashfile_form.system_file.data),
+                    )
+                except Exception:
+                    if os.path.exists(hashfile_path):
+                        os.remove(hashfile_path)
+                    msg = 'Failed to save SYSTEM hive. Please try again.'
+                    if is_ajax:
+                        return jsonify({'status': 'error', 'msg': msg}), 500
+                    flash(msg, 'danger')
+                    return redirect(url_for('jobs.jobs_assigned_hashfile', job_id=job_id))
+
+                ntds_name = jobs_new_hashfile_form.name.data or hashfile_name
+                hashfile = Hashfiles(
+                    name=ntds_name,
+                    customer_id=job.customer_id,
+                    owner_id=current_user.id,
+                )
+                db.session.add(hashfile)
+                db.session.commit()
+
+                conv = HashfileConversions(
+                    hashfile_id=hashfile.id,
+                    source_type='ntds',
+                    status='pending',
+                    source_path=hashfile_path,
+                    system_path=system_path,
+                )
+                db.session.add(conv)
+
+                job.hashfile_id = hashfile.id
+                db.session.commit()
+                log_event('hashfile.create',
+                          target=f'hashfile:{hashfile.id} {hashfile.name!r}',
+                          detail='source_type=ntds status=pending')
+
+                if is_ajax:
+                    return jsonify({
+                        'status': 'ok',
+                        'msg': 'NTDS.dit uploaded. Hashes will be available once conversion completes (this may take several minutes for large databases).',
+                        'redirect': url_for('jobs.jobs_assigned_hashfile', job_id=job_id),
+                    })
+                flash('NTDS.dit uploaded. Hashes will be available once conversion completes.', 'success')
+                return redirect(url_for('jobs.jobs_assigned_hashfile', job_id=job_id))
             # --- End async path ---
 
             try:

--- a/hashview/jobs/routes.py
+++ b/hashview/jobs/routes.py
@@ -26,6 +26,7 @@ from hashview.jobs.forms import (
 from hashview.models import (
     Customers,
     Hashes,
+    HashfileConversions,
     HashfileHashes,
     Hashfiles,
     HashNotifications,
@@ -318,6 +319,40 @@ def jobs_assigned_hashfile(job_id):
                 hashfilehashes_file.write(jobs_new_hashfile_form.hashfilehashes.data)
 
         if len(hashfile_path) > 0:
+            # --- Async source-file types: queue for background conversion ---
+            if jobs_new_hashfile_form.file_type.data == 'wpa_pcap':
+                hashfile = Hashfiles(
+                    name=hashfile_name,
+                    customer_id=job.customer_id,
+                    owner_id=current_user.id,
+                )
+                db.session.add(hashfile)
+                db.session.commit()
+
+                conv = HashfileConversions(
+                    hashfile_id=hashfile.id,
+                    source_type='wpa_pcap',
+                    status='pending',
+                    source_path=hashfile_path,
+                )
+                db.session.add(conv)
+
+                job.hashfile_id = hashfile.id
+                db.session.commit()
+                log_event('hashfile.create',
+                          target=f'hashfile:{hashfile.id} {hashfile.name!r}',
+                          detail='source_type=wpa_pcap status=pending')
+
+                if is_ajax:
+                    return jsonify({
+                        'status': 'ok',
+                        'msg': 'Capture uploaded. Hashes will be available once conversion completes (up to ~30 seconds).',
+                        'redirect': url_for('jobs.jobs_assigned_hashfile', job_id=job_id),
+                    })
+                flash('Capture uploaded. Hashes will be available once conversion completes.', 'success')
+                return redirect(url_for('jobs.jobs_assigned_hashfile', job_id=job_id))
+            # --- End async path ---
+
             try:
                 if jobs_new_hashfile_form.file_type.data == 'pwdump':
                     has_problem = validate_pwdump_hashfile(hashfile_path, jobs_new_hashfile_form.pwdump_hash_type.data)

--- a/hashview/models.py
+++ b/hashview/models.py
@@ -204,6 +204,26 @@ class Hashfiles(db.Model):
     customer_id = db.Column(db.Integer, nullable=False)
     owner_id = db.Column(db.Integer, nullable=False)
 
+class HashfileConversions(db.Model):
+    """Tracks async conversion state for source file uploads (pcap, ntds.dit)."""
+
+    __tablename__ = 'hashfile_conversions'
+
+    id = db.Column(db.Integer, primary_key=True)
+    hashfile_id = db.Column(db.Integer, db.ForeignKey('hashfiles.id'), unique=True, nullable=False)
+    source_type = db.Column(db.String(20), nullable=False)   # 'wpa_pcap' | 'ntds'
+    status = db.Column(db.String(20), nullable=False, default='pending')
+    source_path = db.Column(db.Text, nullable=False)
+    system_path = db.Column(db.Text, nullable=True)          # ntds only: SYSTEM hive path
+    conversion_error = db.Column(db.Text, nullable=True)
+    created_at = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
+    started_at = db.Column(db.DateTime, nullable=True)       # set when status→converting
+
+    hashfile = db.relationship(
+        'Hashfiles',
+        backref=db.backref('conversion', uselist=False, cascade='all, delete-orphan'),
+    )
+
 class HashfileHashes(db.Model):
     """Class object to represent HashfileHashes"""
 

--- a/hashview/scheduler.py
+++ b/hashview/scheduler.py
@@ -185,6 +185,106 @@ def _data_retention_cleanup_inner(db :SQLAlchemy, mailer :Mail, logger :Logger):
         )
 
 
+# Imported at module scope so tests can monkeypatch hashview.scheduler.convert_pcap / convert_ntds
+try:
+    from hashview.utils.convert import ConversionError, convert_ntds, convert_pcap
+except ImportError:  # pragma: no cover
+    pass
+
+
+def process_pending_conversions(app: Flask):
+    """Pick up pending source-file conversion jobs and run them.
+
+    Called by APScheduler every 30 seconds. Each record transitions:
+      pending -> converting -> ready | failed
+    Records stuck in 'converting' for >10 minutes are reset to 'pending'
+    so a server restart mid-conversion doesn't leave them stranded.
+    """
+    with app.app_context():
+        try:
+            from datetime import datetime, timedelta
+
+            from hashview.models import HashfileConversions, db
+
+            stuck_cutoff = datetime.utcnow() - timedelta(minutes=10)
+            stuck = (
+                HashfileConversions.query
+                .filter_by(status='converting')
+                .filter(HashfileConversions.started_at < stuck_cutoff)
+                .all()
+            )
+            just_reset_ids = set()
+            for record in stuck:
+                record.status = 'pending'
+                record.started_at = None
+                just_reset_ids.add(record.id)
+            if stuck:
+                db.session.commit()
+
+            pending = HashfileConversions.query.filter_by(status='pending').all()
+            for record in pending:
+                # Skip records we just reset this cycle — let them be picked up next time.
+                if record.id in just_reset_ids:
+                    continue
+
+                record.status = 'converting'
+                record.started_at = datetime.utcnow()
+                db.session.commit()
+
+                try:
+                    _run_conversion(record)
+                    record.status = 'ready'
+                    db.session.commit()
+                except Exception as exc:
+                    record.status = 'failed'
+                    record.conversion_error = str(exc)
+                    db.session.commit()
+
+        except Exception:
+            app.logger.exception('process_pending_conversions failed.')
+
+
+def _run_conversion(record):
+    """Dispatch conversion based on source_type. Raises ConversionError on failure."""
+    from hashview.utils.utils import import_hashfilehashes
+
+    if record.source_type == 'wpa_pcap':
+        out_path = convert_pcap(record.source_path)
+        import_hashfilehashes(
+            hashfile_id=record.hashfile_id,
+            hashfile_path=out_path,
+            file_type='hash_only',
+            hash_type='22000',
+        )
+        _safe_remove(out_path)
+        _safe_remove(record.source_path)
+
+    elif record.source_type == 'ntds':
+        out_path = convert_ntds(record.source_path, record.system_path)
+        import_hashfilehashes(
+            hashfile_id=record.hashfile_id,
+            hashfile_path=out_path,
+            file_type='pwdump',
+            hash_type='1000',
+        )
+        _safe_remove(out_path)
+        _safe_remove(record.source_path)
+        _safe_remove(record.system_path)
+
+    else:
+        raise ConversionError(f'Unknown source type: {record.source_type!r}')
+
+
+def _safe_remove(path):
+    """Delete a file, ignoring errors if it no longer exists."""
+    import os
+    if path:
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+
+
 def data_retention_cleanup(app :Flask):
     """ Function to manage retention cleanup """
     with app.app_context():

--- a/hashview/templates/hashfiles.html.j2
+++ b/hashview/templates/hashfiles.html.j2
@@ -58,6 +58,20 @@
                         <span style="color:var(--text-mute); display:inline-flex;">{{ icon('file', size=16) }}</span>
                         {{ hashfile.name }}
                     </span>
+                    {% if conversions.get(hashfile.id) %}
+                      {% set conv = conversions[hashfile.id] %}
+                      {% if conv.status in ('pending', 'converting') %}
+                        <span class="tag is-warning is-light">
+                          <span class="icon"><i class="fas fa-spinner fa-spin"></i></span>
+                          &nbsp;Converting…
+                        </span>
+                      {% elif conv.status == 'failed' %}
+                        <span class="tag is-danger is-light"
+                              title="{{ conv.conversion_error | e }}">
+                          Conversion failed
+                        </span>
+                      {% endif %}
+                    {% endif %}
                 </td>
                 <td class="center"><span class="badge cyan">{{ hash_type_dict[hashfile.id] }}</span></td>
                 <td style="color:var(--text-dim);">{% for c in customers %}{% if c.id == hashfile.customer_id %}{{ c.name }}{% endif %}{% endfor %}</td>

--- a/hashview/templates/jobs_assigned_hashfiles.html.j2
+++ b/hashview/templates/jobs_assigned_hashfiles.html.j2
@@ -47,7 +47,8 @@
     // show the hash-type select that matches the chosen file format
     function showHashTypeSelected(sel){
         var map = {pwdump:'pwdump_hash_type_div', NetNTLM:'netntlm_hash_type_div', kerberos:'kerberos_hash_type_div',
-                   shadow:'shadow_hash_type_div', user_hash:'hash_type_div', hash_only:'hash_type_div'};
+                   shadow:'shadow_hash_type_div', user_hash:'hash_type_div', hash_only:'hash_type_div',
+                   wpa_pcap:'hash_type_placeholder'};
         ['pwdump_hash_type_div','netntlm_hash_type_div','kerberos_hash_type_div','shadow_hash_type_div','hash_type_div','hash_type_placeholder']
             .forEach(function(id){ var el=document.getElementById(id); if(el) el.style.display='none'; });
         var show = map[sel.value];

--- a/hashview/templates/jobs_assigned_hashfiles.html.j2
+++ b/hashview/templates/jobs_assigned_hashfiles.html.j2
@@ -48,11 +48,13 @@
     function showHashTypeSelected(sel){
         var map = {pwdump:'pwdump_hash_type_div', NetNTLM:'netntlm_hash_type_div', kerberos:'kerberos_hash_type_div',
                    shadow:'shadow_hash_type_div', user_hash:'hash_type_div', hash_only:'hash_type_div',
-                   wpa_pcap:'hash_type_placeholder'};
+                   wpa_pcap:'hash_type_placeholder', ntds:'hash_type_placeholder'};
         ['pwdump_hash_type_div','netntlm_hash_type_div','kerberos_hash_type_div','shadow_hash_type_div','hash_type_div','hash_type_placeholder']
             .forEach(function(id){ var el=document.getElementById(id); if(el) el.style.display='none'; });
         var show = map[sel.value];
         document.getElementById(show ? show : 'hash_type_placeholder').style.display = 'block';
+        var sfd = document.getElementById('system_file_div');
+        if (sfd) sfd.style.display = (sel.value === 'ntds') ? 'block' : 'none';
         var vsel = show ? document.getElementById(show).querySelector('select') : null;
         hvHashTypeExample(vsel);
     }
@@ -151,6 +153,11 @@
                         </div>
                         <span class="field-hint">Supports pwdump, NTDS, responder logs, shadow files, kerberos tickets, and more.</span>
                         {% if jobsNewHashFileForm.hashfile.errors %}{% for e in jobsNewHashFileForm.hashfile.errors %}<span class="field-hint" style="color:var(--red);">{{ e }}</span>{% endfor %}{% endif %}
+                        <div id="system_file_div" style="display:none; margin-top:16px;">
+                            <label class="field-label">SYSTEM hive <span class="req">*</span></label>
+                            {{ jobsNewHashFileForm.system_file(class="input") }}
+                            <span class="field-hint">Required for NTDS.dit uploads — the SYSTEM registry hive from the same domain controller.</span>
+                        </div>
                     </div>
                 </div>
 

--- a/hashview/utils/convert.py
+++ b/hashview/utils/convert.py
@@ -1,5 +1,42 @@
 """Server-side conversion of raw source files into hashcat-ready text files."""
+import os
+import subprocess  # nosec B404 - used only with fixed argv lists, never shell=True
 
 
 class ConversionError(Exception):
     """Raised when an external conversion tool fails or produces no output."""
+
+
+def convert_pcap(src_path: str) -> str:
+    """Convert a pcap/pcapng WPA capture to hashcat 22000 format.
+
+    Runs hcxpcapngtool from the hcxtools package. Raises ConversionError
+    if the tool is missing, exits non-zero, or produces no hashes.
+    Returns the path to the converted text file on success.
+    """
+    out_path = src_path + '.hc22000'
+    try:
+        # Fixed argv list, no shell=True; tool name resolved from PATH by design.
+        result = subprocess.run(  # nosec B603 B607
+            ['hcxpcapngtool', '-o', out_path, src_path],
+            capture_output=True,
+            timeout=300,
+        )
+    except FileNotFoundError as err:
+        raise ConversionError(
+            'hcxpcapngtool is not installed on this server. '
+            'Install hcxtools (apt install hcxtools) to enable WPA capture conversion.'
+        ) from err
+    except subprocess.TimeoutExpired as err:
+        # Clean up any partial output before raising
+        if os.path.exists(out_path):
+            os.remove(out_path)
+        raise ConversionError('hcxpcapngtool timed out after 5 minutes.') from err
+    if result.returncode != 0:
+        msg = result.stderr.decode('utf-8', errors='replace').strip()
+        raise ConversionError(msg or 'hcxpcapngtool exited with an error and produced no output.')
+    if not os.path.exists(out_path) or os.path.getsize(out_path) == 0:
+        raise ConversionError(
+            'No valid WPA handshakes or PMKIDs found in the capture file.'
+        )
+    return out_path

--- a/hashview/utils/convert.py
+++ b/hashview/utils/convert.py
@@ -1,0 +1,5 @@
+"""Server-side conversion of raw source files into hashcat-ready text files."""
+
+
+class ConversionError(Exception):
+    """Raised when an external conversion tool fails or produces no output."""

--- a/hashview/utils/convert.py
+++ b/hashview/utils/convert.py
@@ -40,3 +40,42 @@ def convert_pcap(src_path: str) -> str:
             'No valid WPA handshakes or PMKIDs found in the capture file.'
         )
     return out_path
+
+
+def convert_ntds(ntds_path: str, system_path: str) -> str:
+    """Convert an NTDS.dit + SYSTEM hive pair to pwdump format using impacket-secretsdump.
+
+    Runs impacket-secretsdump in LOCAL mode (no network required). Output is
+    written to a .pwdump file for processing by import_hashfilehashes().
+    Raises ConversionError if the tool is missing, exits non-zero, or
+    produces no output. Returns the path to the pwdump file on success.
+    """
+    out_path = ntds_path + '.pwdump'
+    try:
+        # Fixed argv list, no shell=True; tool name resolved from PATH by design.
+        result = subprocess.run(  # nosec B603 B607
+            ['impacket-secretsdump',
+             '-ntds', ntds_path,
+             '-system', system_path,
+             'LOCAL'],
+            capture_output=True,
+            timeout=600,
+        )
+    except FileNotFoundError as err:
+        raise ConversionError(
+            'impacket-secretsdump is not installed on this server. '
+            'Install impacket (pip install impacket) to enable NTDS.dit conversion.'
+        ) from err
+    except subprocess.TimeoutExpired as err:
+        raise ConversionError('impacket-secretsdump timed out after 10 minutes.') from err
+    if result.returncode != 0:
+        msg = result.stderr.decode('utf-8', errors='replace').strip()
+        raise ConversionError(msg or 'impacket-secretsdump exited with an error and produced no output.')
+    if not result.stdout.strip():
+        raise ConversionError(
+            'No hashes extracted from the NTDS.dit file. '
+            'Verify the SYSTEM hive corresponds to this NTDS.dit.'
+        )
+    with open(out_path, 'wb') as f:
+        f.write(result.stdout)
+    return out_path

--- a/migrations/versions/a1b2c3d4e5f6_add_hashfile_conversions.py
+++ b/migrations/versions/a1b2c3d4e5f6_add_hashfile_conversions.py
@@ -1,0 +1,38 @@
+"""add_hashfile_conversions
+
+Revision ID: a1b2c3d4e5f6
+Revises: d4e8b1f3a297
+Create Date: 2026-06-09 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'a1b2c3d4e5f6'
+down_revision = 'd4e8b1f3a297'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'hashfile_conversions',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('hashfile_id', sa.Integer(), nullable=False),
+        sa.Column('source_type', sa.String(length=20), nullable=False),
+        sa.Column('status', sa.String(length=20), nullable=False),
+        sa.Column('source_path', sa.Text(), nullable=False),
+        sa.Column('system_path', sa.Text(), nullable=True),
+        sa.Column('conversion_error', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('started_at', sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(['hashfile_id'], ['hashfiles.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('hashfile_id'),
+    )
+
+
+def downgrade():
+    op.drop_table('hashfile_conversions')

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,6 @@ pip-audit==2.10.0
 pre-commit==4.6.0
 openapi-spec-validator==0.7.1
 PyYAML==6.0.3
+# Mirrors the pylint.yml CI gate for scripts/preflight.sh (rules + fail-under
+# come from .pylintrc). Requires Python >= 3.10.
+pylint==4.0.5

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+#
+# preflight.sh — run every CI gate locally before pushing.
+#
+# Mirrors the GitHub Actions workflows so failures are caught on your machine
+# instead of after a push:
+#   .github/workflows/lint.yml    -> ruff, bandit (vs baseline), pip-audit, openapi
+#   .github/workflows/pylint.yml  -> pylint (rules + fail-under from .pylintrc)
+#   .github/workflows/e2e.yml     -> docker-compose Playwright harness  (opt-in: --e2e)
+# Plus the unit-test suite (tests/unit/), which has no CI job but is meant to be
+# run locally (see CLAUDE.md / tests/unit/conftest.py — in-memory SQLite, no DB).
+#
+# Tool versions are pinned in requirements-dev.txt; install once with:
+#   pip install -r requirements.txt -r requirements-dev.txt
+#
+# Usage:
+#   scripts/preflight.sh              # all static gates + unit tests
+#   scripts/preflight.sh --fast       # skip the slow gates (pip-audit, unit tests)
+#   scripts/preflight.sh --no-audit   # skip pip-audit only (e.g. offline)
+#   scripts/preflight.sh --e2e        # also run the docker e2e harness (slow, needs docker)
+#   scripts/preflight.sh -h|--help
+#
+# Wire it as a pre-push hook (optional):
+#   ln -s ../../scripts/preflight.sh .git/hooks/pre-push
+# The per-commit framework (.pre-commit-config.yaml) stays as-is for fast,
+# auto-fixing commit-time checks; this script is the heavier pre-push mirror.
+
+set -uo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+# --- options ---------------------------------------------------------------
+RUN_AUDIT=1
+RUN_UNIT=1
+RUN_E2E=0
+for arg in "$@"; do
+  case "$arg" in
+    --fast)     RUN_AUDIT=0; RUN_UNIT=0 ;;
+    --no-audit) RUN_AUDIT=0 ;;
+    --e2e)      RUN_E2E=1 ;;
+    -h|--help)
+      sed -n '2,40p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *) echo "Unknown option: $arg (try --help)" >&2; exit 2 ;;
+  esac
+done
+
+# Prefer an explicit $PYTHON, then a local .venv, then python3 on PATH.
+if [ -n "${PYTHON:-}" ]; then
+  PY="$PYTHON"
+elif [ -x .venv/bin/python ]; then
+  PY=".venv/bin/python"
+else
+  PY="python3"
+fi
+
+# --- pretty output ---------------------------------------------------------
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+  BOLD=$'\033[1m'; RED=$'\033[31m'; GREEN=$'\033[32m'; YELLOW=$'\033[33m'; DIM=$'\033[2m'; RESET=$'\033[0m'
+else
+  BOLD=""; RED=""; GREEN=""; YELLOW=""; DIM=""; RESET=""
+fi
+
+declare -a RESULTS=()
+FAILED=0
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+# run_gate <name> <missing-tool-hint> <command...>
+# Prints a header, runs the command, records PASS/FAIL/SKIP, never aborts the
+# run early so you see every problem in one pass.
+run_gate() {
+  local name="$1"; local hint="$2"; shift 2
+  printf '\n%s━━ %s ━━%s\n' "$BOLD" "$name" "$RESET"
+  if [ -n "$hint" ] && ! have "$hint"; then
+    printf '%sSKIP%s  %s — %s not found. Install: pip install -r requirements-dev.txt\n' \
+      "$YELLOW" "$RESET" "$name" "$hint"
+    RESULTS+=("${YELLOW}SKIP${RESET}  $name (missing $hint)")
+    return
+  fi
+  if "$@"; then
+    RESULTS+=("${GREEN}PASS${RESET}  $name")
+  else
+    RESULTS+=("${RED}FAIL${RESET}  $name")
+    FAILED=1
+  fi
+}
+
+printf '%sHashview preflight%s  %s(interpreter: %s)%s\n' "$BOLD" "$RESET" "$DIM" "$PY" "$RESET"
+
+# 1. Ruff — lint (imports, bugbear, pyupgrade, pycodestyle). Matches lint.yml.
+run_gate "ruff" "ruff" \
+  ruff check hashview/ hashview.py
+
+# 2. Bandit — SAST vs committed baseline; only NEW findings fail. Matches lint.yml.
+run_gate "bandit (vs baseline)" "bandit" \
+  bandit -r hashview install/hashview-agent -c pyproject.toml -b .bandit-baseline.json -q
+
+# 3. OpenAPI — structural validation of the committed spec. Matches lint.yml.
+run_gate "openapi spec" "openapi-spec-validator" \
+  openapi-spec-validator hashview/api_docs/openapi.yaml
+
+# 4. pip-audit — known CVEs in production deps. Matches lint.yml. Network + slow.
+if [ "$RUN_AUDIT" -eq 1 ]; then
+  run_gate "pip-audit" "pip-audit" \
+    pip-audit -r requirements.txt
+else
+  printf '\n%s━━ pip-audit ━━%s\n%sSKIP%s  (disabled)\n' "$BOLD" "$RESET" "$YELLOW" "$RESET"
+  RESULTS+=("${YELLOW}SKIP${RESET}  pip-audit (disabled)")
+fi
+
+# 5. Pylint — full project, rules + fail-under from .pylintrc. Matches pylint.yml.
+run_gate "pylint" "" \
+  "$PY" -m pylint --jobs=1 --rcfile=.pylintrc --output-format=colorized --reports=n --score=y hashview/ hashview.py
+
+# 6. Unit tests — in-memory SQLite, no DB/docker. No CI job; run locally.
+if [ "$RUN_UNIT" -eq 1 ]; then
+  run_gate "unit tests" "" \
+    "$PY" -m pytest tests/unit -q
+else
+  printf '\n%s━━ unit tests ━━%s\n%sSKIP%s  (disabled)\n' "$BOLD" "$RESET" "$YELLOW" "$RESET"
+  RESULTS+=("${YELLOW}SKIP${RESET}  unit tests (disabled)")
+fi
+
+# 7. E2E — docker-compose Playwright harness. Opt-in; heavy; needs docker.
+if [ "$RUN_E2E" -eq 1 ]; then
+  run_gate "e2e (docker)" "docker" \
+    ./tests/run_e2e_compose.sh
+else
+  printf '\n%s━━ e2e (docker) ━━%s\n%sSKIP%s  (opt-in: pass --e2e)\n' "$BOLD" "$RESET" "$DIM" "$RESET"
+fi
+
+# --- summary ---------------------------------------------------------------
+printf '\n%s━━ summary ━━%s\n' "$BOLD" "$RESET"
+for line in "${RESULTS[@]}"; do printf '  %s\n' "$line"; done
+
+if [ "$FAILED" -ne 0 ]; then
+  printf '\n%sPreflight FAILED%s — fix the gates above before pushing.\n' "$RED$BOLD" "$RESET"
+  exit 1
+fi
+printf '\n%sPreflight passed.%s\n' "$GREEN$BOLD" "$RESET"
+exit 0

--- a/tests/e2e/test_agent_sim.py
+++ b/tests/e2e/test_agent_sim.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import sys
 import uuid
 
 import pytest
@@ -16,7 +17,7 @@ def test_agent_registers_and_receives_work(live_server):
     env["HASHVIEW_AGENT_NAME"] = "test-agent"
     env["HASHVIEW_AGENT_MAX_SECONDS"] = "5"
     result = subprocess.run(
-        ["python", "tests/agent/sim.py"],
+        [sys.executable, "tests/agent/sim.py"],
         env=env,
         capture_output=True,
         text=True,

--- a/tests/e2e/test_job_creation.py
+++ b/tests/e2e/test_job_creation.py
@@ -18,7 +18,7 @@ def test_job_creation_flow(page, live_server, login):
             "HASHVIEW_E2E_TASK_ID, HASHVIEW_E2E_TASK_NAME."
         )
     page.get_by_role("link", name="Jobs").click()
-    page.get_by_role("link", name="New Job").click()
+    page.get_by_role("link", name="New Job", exact=True).click()
     expect(page.get_by_role("heading", name="Create Job")).to_be_visible()
 
     page.get_by_label("Job Name").fill("E2E Job")

--- a/tests/e2e/test_quality.py
+++ b/tests/e2e/test_quality.py
@@ -31,7 +31,7 @@ def test_login_invalid_email_shows_error(page, live_server):
 def test_job_name_required_validation(page, live_server, login):
     login()
     page.get_by_role("link", name="Jobs").click()
-    page.get_by_role("link", name="New Job").click()
+    page.get_by_role("link", name="New Job", exact=True).click()
     expect(page.get_by_role("heading", name="Create Job")).to_be_visible()
 
     _select_customer(page)
@@ -43,7 +43,7 @@ def test_job_name_required_validation(page, live_server, login):
 def test_job_name_xss_is_escaped(page, live_server, login):
     login()
     page.get_by_role("link", name="Jobs").click()
-    page.get_by_role("link", name="New Job").click()
+    page.get_by_role("link", name="New Job", exact=True).click()
     expect(page.get_by_role("heading", name="Create Job")).to_be_visible()
 
     xss_payload = '<script id="xss-test">window.__xss=1</script>'
@@ -68,7 +68,7 @@ def test_job_name_xss_is_escaped(page, live_server, login):
 def test_hashfile_validation_rejects_invalid_hash(page, live_server, login):
     login()
     page.get_by_role("link", name="Jobs").click()
-    page.get_by_role("link", name="New Job").click()
+    page.get_by_role("link", name="New Job", exact=True).click()
     expect(page.get_by_role("heading", name="Create Job")).to_be_visible()
 
     page.get_by_label("Job Name").fill("E2E Invalid Hash Test")
@@ -93,7 +93,7 @@ def test_hashfile_validation_rejects_invalid_hash(page, live_server, login):
 def test_hashfile_upload_example_file(page, live_server, login):
     login()
     page.get_by_role("link", name="Jobs").click()
-    page.get_by_role("link", name="New Job").click()
+    page.get_by_role("link", name="New Job", exact=True).click()
     expect(page.get_by_role("heading", name="Create Job")).to_be_visible()
 
     page.get_by_label("Job Name").fill("E2E Upload Example Hashfile")
@@ -117,7 +117,7 @@ def test_hashfile_upload_example_file(page, live_server, login):
 def test_hashfile_upload_example_pwdump(page, live_server, login):
     login()
     page.get_by_role("link", name="Jobs").click()
-    page.get_by_role("link", name="New Job").click()
+    page.get_by_role("link", name="New Job", exact=True).click()
     expect(page.get_by_role("heading", name="Create Job")).to_be_visible()
 
     page.get_by_label("Job Name").fill("E2E Upload Example Pwdump")

--- a/tests/e2e/test_security.py
+++ b/tests/e2e/test_security.py
@@ -40,7 +40,7 @@ def test_customer_name_xss_is_escaped(page, live_server, login):
     payload = "<svg onload=alert(1)>"
 
     page.get_by_role("link", name="Jobs").click()
-    page.get_by_role("link", name="New Job").click()
+    page.get_by_role("link", name="New Job", exact=True).click()
     expect(page.get_by_role("heading", name="Create Job")).to_be_visible()
 
     page.locator("input[name='name']").fill(f"E2E XSS Customer {uuid.uuid4().hex[:6]}")
@@ -169,7 +169,7 @@ def test_job_idor_access_denied_for_other_user(
         test_user_credentials["password"],
     )
     page.get_by_role("link", name="Jobs").click()
-    page.get_by_role("link", name="New Job").click()
+    page.get_by_role("link", name="New Job", exact=True).click()
     expect(page.get_by_role("heading", name="Create Job")).to_be_visible()
 
     page.get_by_label("Job Name").fill("E2E IDOR Job")

--- a/tests/e2e/test_tasks_edit.py
+++ b/tests/e2e/test_tasks_edit.py
@@ -1,9 +1,12 @@
-"""End-to-end coverage of the /tasks/edit/<id> page.
+"""End-to-end coverage of editing a task via the /tasks edit modal.
+
+Editing is a client-side modal (opened from each row's Edit button and
+pre-filled from the task's data), not a separate /tasks/edit/<id> page.
 
 Exercises that:
-  * the edit page renders cleanly for an existing task,
+  * the edit modal opens pre-filled for an existing task,
   * editing the task name persists,
-  * switching the attack mode (Straight -> Brute-force) and submitting works.
+  * switching the attack mode (Straight -> Brute-force/mask) and saving works.
 """
 
 import re
@@ -12,7 +15,6 @@ from pathlib import Path
 
 import pytest
 from playwright.sync_api import expect
-
 
 EXAMPLE_WORDLIST = Path(__file__).parent / "example_wordlist.txt"
 
@@ -68,8 +70,8 @@ def _create_task(page, live_server, name, mode_value, wl_name):
 
 @pytest.mark.e2e
 def test_tasks_edit_page_renders_for_existing_task(page, live_server, login):
-    """Open the edit page for a freshly-created Straight task and confirm
-    no template/server errors leaked into the rendered HTML.
+    """Open the edit modal for a freshly-created Straight task and confirm it
+    opens pre-filled with no template/server errors leaked into the page.
     """
     login()
     suffix = uuid.uuid4().hex[:6]
@@ -83,9 +85,12 @@ def test_tasks_edit_page_renders_for_existing_task(page, live_server, login):
         page.goto(f"{live_server}/tasks", wait_until="domcontentloaded")
         row = _row_with_text(page, task_name)
         expect(row).to_be_visible()
-        row.locator("a[href*='/tasks/edit/']").first.click()
+        row.locator("button[title='Edit']").click()
 
-        expect(page).to_have_url(re.compile(r".*/tasks/edit/\d+"))
+        # Editing is a client-side modal pre-filled from the task's data.
+        modal = page.locator("#edit-task-modal")
+        expect(modal).to_be_visible()
+        expect(modal.locator("#etk-name")).to_have_value(task_name)
         body = page.content()
         assert "UndefinedError" not in body
         assert "Traceback" not in body
@@ -97,7 +102,7 @@ def test_tasks_edit_page_renders_for_existing_task(page, live_server, login):
 
 @pytest.mark.e2e
 def test_tasks_edit_change_name_persists(page, live_server, login):
-    """Renaming a task on the edit page should be visible on /tasks afterwards."""
+    """Renaming a task in the edit modal should be visible on /tasks afterwards."""
     login()
     suffix = uuid.uuid4().hex[:6]
     wl_name = f"e2e-wl-{suffix}"
@@ -112,11 +117,12 @@ def test_tasks_edit_change_name_persists(page, live_server, login):
         page.goto(f"{live_server}/tasks", wait_until="domcontentloaded")
         row = _row_with_text(page, original_name)
         expect(row).to_be_visible()
-        row.locator("a[href*='/tasks/edit/']").first.click()
-        expect(page).to_have_url(re.compile(r".*/tasks/edit/\d+"))
+        row.locator("button[title='Edit']").click()
+        modal = page.locator("#edit-task-modal")
+        expect(modal).to_be_visible()
 
-        page.locator("#name").fill(new_name)
-        page.get_by_role("button", name=re.compile(r"^Update$", re.I)).click()
+        modal.locator("#etk-name").fill(new_name)
+        modal.get_by_role("button", name=re.compile(r"Save changes", re.I)).click()
         expect(page).to_have_url(re.compile(r".*/tasks/?$"))
         final_task_name = new_name
 
@@ -129,7 +135,7 @@ def test_tasks_edit_change_name_persists(page, live_server, login):
 
 @pytest.mark.e2e
 def test_tasks_edit_attack_mode_change(page, live_server, login):
-    """Switch a Straight task to Brute-force (mode 3) on the edit page."""
+    """Switch a Straight task to Brute-force (mask) in the edit modal."""
     login()
     suffix = uuid.uuid4().hex[:6]
     wl_name = f"e2e-wl-{suffix}"
@@ -142,12 +148,13 @@ def test_tasks_edit_attack_mode_change(page, live_server, login):
         page.goto(f"{live_server}/tasks", wait_until="domcontentloaded")
         row = _row_with_text(page, task_name)
         expect(row).to_be_visible()
-        row.locator("a[href*='/tasks/edit/']").first.click()
-        expect(page).to_have_url(re.compile(r".*/tasks/edit/\d+"))
+        row.locator("button[title='Edit']").click()
+        modal = page.locator("#edit-task-modal")
+        expect(modal).to_be_visible()
 
-        page.locator("#hc_attackmode").select_option("3")
-        page.locator("#mask").fill("?l?l?l?l")
-        page.get_by_role("button", name=re.compile(r"^Update$", re.I)).click()
+        modal.locator("#etk-t-mask").click()      # switch to Brute-force (mask) tab
+        modal.locator("#etk-mask").fill("?l?l?l?l")
+        modal.get_by_role("button", name=re.compile(r"Save changes", re.I)).click()
         expect(page).to_have_url(re.compile(r".*/tasks/?$"))
 
         page.goto(f"{live_server}/tasks", wait_until="domcontentloaded")

--- a/tests/run_e2e_compose.sh
+++ b/tests/run_e2e_compose.sh
@@ -63,6 +63,17 @@ done
 
 if ! curl -fsS "$BASE_URL/login" >/dev/null 2>&1; then
   echo "App did not become ready in time."
+  # Surface startup/migration errors first — a long readiness poll floods the
+  # log with per-request tracebacks that bury the real boot failure under a
+  # plain --tail.
+  echo "--- startup-relevant app log lines ---"
+  # `|| true`: under `set -euo pipefail`, a no-match grep exits 1 and would
+  # abort the script here, skipping the tail dump and the explicit exit below.
+  $COMPOSE_BIN logs app 2>&1 | grep -iE \
+    "Upgrading Database|Setting up defaults|Adding Default|Traceback|Error|Exception|Connection refused|doesn't exist|Multiple head|alembic" \
+    | head -60 || true
+  echo "--- recent docker logs (tail) ---"
+  $COMPOSE_BIN logs --tail 200
   exit 1
 fi
 

--- a/tests/unit/test_api_endpoints.py
+++ b/tests/unit/test_api_endpoints.py
@@ -930,6 +930,100 @@ def test_jobs_add_creates_notification_rows(client, admin_user):
 
 
 # ---------------------------------------------------------------------------
+# POST /v1/hashfiles/upload/wpa_pcap/<customer_id>/<hashfile_name>
+# ---------------------------------------------------------------------------
+
+def _upload_dirs(app, tmp_path, monkeypatch):
+    """Point app root_path at tmp_path and create control/tmp inside it."""
+    monkeypatch.setattr(app, "root_path", str(tmp_path))
+    os.makedirs(os.path.join(str(tmp_path), "control", "tmp"), exist_ok=True)
+
+
+@pytest.mark.security
+def test_wpa_pcap_upload_creates_hashfile_and_conversion(client, app, admin_user, tmp_path, monkeypatch):
+    """Valid pcap upload creates Hashfiles + pending HashfileConversions records."""
+    _upload_dirs(app, tmp_path, monkeypatch)
+
+    cust = Customers(name="CaptureCorp")
+    _db.session.add(cust)
+    _db.session.commit()
+
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    resp = client.post(
+        f"/v1/hashfiles/upload/wpa_pcap/{cust.id}/pwnagotchi-capture",
+        data=b"\xd4\xc3\xb2\xa1fake pcap bytes",
+        content_type="application/octet-stream",
+    )
+    body = _json_body(resp)
+
+    assert body["status"] == 200
+    assert "hashfile_id" in body
+    assert "conversion_id" in body
+
+    conv = HashfileConversions.query.filter_by(hashfile_id=body["hashfile_id"]).first()
+    assert conv is not None
+    assert conv.status == "pending"
+    assert conv.source_type == "wpa_pcap"
+
+
+@pytest.mark.security
+def test_wpa_pcap_upload_no_cookie_redirects(client):
+    """No uuid cookie redirects to not_authorized."""
+    resp = client.post(
+        "/v1/hashfiles/upload/wpa_pcap/1/test-capture",
+        data=b"bytes",
+        content_type="application/octet-stream",
+    )
+    assert resp.status_code == 302
+    assert "/not_authorized" in resp.headers["Location"]
+
+
+@pytest.mark.security
+def test_wpa_pcap_upload_agent_cookie_redirects(client, authorized_agent):
+    """Agent credentials are rejected (user-only route)."""
+    client.set_cookie("uuid", authorized_agent.uuid, domain="localhost.test")
+    resp = client.post(
+        "/v1/hashfiles/upload/wpa_pcap/1/test-capture",
+        data=b"bytes",
+        content_type="application/octet-stream",
+    )
+    assert resp.status_code == 302
+    assert "/not_authorized" in resp.headers["Location"]
+
+
+@pytest.mark.security
+def test_wpa_pcap_upload_invalid_customer_returns_400(client, admin_user):
+    """Non-existent customer_id returns a 400 error body."""
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    resp = client.post(
+        "/v1/hashfiles/upload/wpa_pcap/99999/test-capture",
+        data=b"bytes",
+        content_type="application/octet-stream",
+    )
+    body = _json_body(resp)
+    assert body["status"] == 400
+
+
+@pytest.mark.security
+def test_wpa_pcap_upload_empty_body_returns_400(client, app, admin_user, tmp_path, monkeypatch):
+    """Empty request body returns a 400 error body."""
+    _upload_dirs(app, tmp_path, monkeypatch)
+
+    cust = Customers(name="EmptyCaptureCorp")
+    _db.session.add(cust)
+    _db.session.commit()
+
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    resp = client.post(
+        f"/v1/hashfiles/upload/wpa_pcap/{cust.id}/empty-capture",
+        data=b"",
+        content_type="application/octet-stream",
+    )
+    body = _json_body(resp)
+    assert body["status"] == 400
+
+
+# ---------------------------------------------------------------------------
 # GET /v1/hashfiles/<hashfile_id>/conversion
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_api_endpoints.py
+++ b/tests/unit/test_api_endpoints.py
@@ -24,6 +24,7 @@ from hashview.models import (
     Hashes,
     HashfileHashes,
     Hashfiles,
+    HashfileConversions,
     JobNotifications,
     Jobs,
     JobTasks,
@@ -926,3 +927,103 @@ def test_jobs_add_creates_notification_rows(client, admin_user):
     rows = JobNotifications.query.filter_by(job_id=body["job_id"]).all()
     assert {r.method for r in rows} == {"email", "slack"}
     assert all(r.owner_id == admin_user.id for r in rows)
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/hashfiles/<hashfile_id>/conversion
+# ---------------------------------------------------------------------------
+
+@pytest.mark.security
+def test_conversion_status_returns_pending_record(client, admin_user):
+    """Pending conversion record is returned with all fields."""
+    cust = Customers(name="StatusCorp")
+    _db.session.add(cust)
+    _db.session.commit()
+
+    hf = Hashfiles(name="status-test", customer_id=cust.id, owner_id=admin_user.id)
+    _db.session.add(hf)
+    _db.session.commit()
+
+    conv = HashfileConversions(
+        hashfile_id=hf.id,
+        source_type='wpa_pcap',
+        status='pending',
+        source_path='/tmp/cap.pcapng',
+    )
+    _db.session.add(conv)
+    _db.session.commit()
+
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    resp = client.get(f"/v1/hashfiles/{hf.id}/conversion")
+    body = _json_body(resp)
+
+    assert body["status"] == 200
+    assert body["conversion_status"] == "pending"
+    assert body["source_type"] == "wpa_pcap"
+    assert body["hashfile_id"] == hf.id
+    assert body["conversion_id"] == conv.id
+    assert body["conversion_error"] is None
+
+
+@pytest.mark.security
+def test_conversion_status_failed_includes_error_message(client, admin_user):
+    """A failed conversion record includes the conversion_error field."""
+    cust = Customers(name="FailedCorp")
+    _db.session.add(cust)
+    _db.session.commit()
+
+    hf = Hashfiles(name="failed-test", customer_id=cust.id, owner_id=admin_user.id)
+    _db.session.add(hf)
+    _db.session.commit()
+
+    conv = HashfileConversions(
+        hashfile_id=hf.id,
+        source_type='wpa_pcap',
+        status='failed',
+        source_path='/tmp/cap.pcapng',
+        conversion_error='hcxpcapngtool is not installed',
+    )
+    _db.session.add(conv)
+    _db.session.commit()
+
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    resp = client.get(f"/v1/hashfiles/{hf.id}/conversion")
+    body = _json_body(resp)
+
+    assert body["status"] == 200
+    assert body["conversion_status"] == "failed"
+    assert "hcxpcapngtool" in body["conversion_error"]
+
+
+@pytest.mark.security
+def test_conversion_status_hashfile_not_found_returns_404(client, admin_user):
+    """Non-existent hashfile_id returns 404."""
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    resp = client.get("/v1/hashfiles/99999/conversion")
+    body = _json_body(resp)
+    assert body["status"] == 404
+
+
+@pytest.mark.security
+def test_conversion_status_no_conversion_record_returns_404(client, admin_user):
+    """Hashfile with no conversion record returns 404."""
+    cust = Customers(name="NoConvCorp")
+    _db.session.add(cust)
+    _db.session.commit()
+
+    hf = Hashfiles(name="no-conv", customer_id=cust.id, owner_id=admin_user.id)
+    _db.session.add(hf)
+    _db.session.commit()
+
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    resp = client.get(f"/v1/hashfiles/{hf.id}/conversion")
+    body = _json_body(resp)
+    assert body["status"] == 404
+
+
+@pytest.mark.security
+def test_conversion_status_no_cookie_redirects(client):
+    """No uuid cookie redirects to not_authorized."""
+    resp = client.get("/v1/hashfiles/1/conversion")
+    assert resp.status_code == 302
+    assert "/not_authorized" in resp.headers["Location"]

--- a/tests/unit/test_api_endpoints.py
+++ b/tests/unit/test_api_endpoints.py
@@ -1024,6 +1024,122 @@ def test_wpa_pcap_upload_empty_body_returns_400(client, app, admin_user, tmp_pat
 
 
 # ---------------------------------------------------------------------------
+# POST /v1/hashfiles/upload/ntds/<customer_id>/<hashfile_name>
+# ---------------------------------------------------------------------------
+
+@pytest.mark.security
+def test_ntds_upload_creates_hashfile_and_conversion(client, app, admin_user, tmp_path, monkeypatch):
+    """Valid ntds + SYSTEM multipart upload creates Hashfiles + pending conversion with both paths."""
+    import io
+
+    _upload_dirs(app, tmp_path, monkeypatch)
+
+    cust = Customers(name="ADCorp")
+    _db.session.add(cust)
+    _db.session.commit()
+
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    resp = client.post(
+        f"/v1/hashfiles/upload/ntds/{cust.id}/ad-dump",
+        data={
+            "ntds_file": (io.BytesIO(b"fake ntds.dit content"), "ntds.dit"),
+            "system_file": (io.BytesIO(b"fake SYSTEM hive content"), "SYSTEM"),
+        },
+        content_type="multipart/form-data",
+    )
+    body = _json_body(resp)
+
+    assert body["status"] == 200
+    assert "hashfile_id" in body
+    assert "conversion_id" in body
+
+    conv = HashfileConversions.query.filter_by(hashfile_id=body["hashfile_id"]).first()
+    assert conv is not None
+    assert conv.status == "pending"
+    assert conv.source_type == "ntds"
+    assert conv.source_path is not None
+    assert conv.system_path is not None
+
+
+@pytest.mark.security
+def test_ntds_upload_missing_system_file_returns_400(client, app, admin_user, tmp_path, monkeypatch):
+    """Submitting ntds_file without system_file returns 400."""
+    import io
+
+    _upload_dirs(app, tmp_path, monkeypatch)
+
+    cust = Customers(name="MissingSysCorp")
+    _db.session.add(cust)
+    _db.session.commit()
+
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    resp = client.post(
+        f"/v1/hashfiles/upload/ntds/{cust.id}/ad-dump",
+        data={
+            "ntds_file": (io.BytesIO(b"fake ntds.dit"), "ntds.dit"),
+        },
+        content_type="multipart/form-data",
+    )
+    body = _json_body(resp)
+    assert body["status"] == 400
+    assert "system_file" in body["msg"]
+
+
+@pytest.mark.security
+def test_ntds_upload_missing_ntds_file_returns_400(client, app, admin_user, tmp_path, monkeypatch):
+    """Submitting system_file without ntds_file returns 400."""
+    import io
+
+    _upload_dirs(app, tmp_path, monkeypatch)
+
+    cust = Customers(name="MissingNTDSCorp")
+    _db.session.add(cust)
+    _db.session.commit()
+
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    resp = client.post(
+        f"/v1/hashfiles/upload/ntds/{cust.id}/ad-dump",
+        data={
+            "system_file": (io.BytesIO(b"fake SYSTEM"), "SYSTEM"),
+        },
+        content_type="multipart/form-data",
+    )
+    body = _json_body(resp)
+    assert body["status"] == 400
+    assert "ntds_file" in body["msg"]
+
+
+@pytest.mark.security
+def test_ntds_upload_no_cookie_redirects(client):
+    """No uuid cookie redirects to not_authorized."""
+    resp = client.post(
+        "/v1/hashfiles/upload/ntds/1/ad-dump",
+        data={},
+        content_type="multipart/form-data",
+    )
+    assert resp.status_code == 302
+    assert "/not_authorized" in resp.headers["Location"]
+
+
+@pytest.mark.security
+def test_ntds_upload_invalid_customer_returns_400(client, admin_user):
+    """Non-existent customer_id returns 400."""
+    import io
+
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    resp = client.post(
+        "/v1/hashfiles/upload/ntds/99999/ad-dump",
+        data={
+            "ntds_file": (io.BytesIO(b"fake ntds"), "ntds.dit"),
+            "system_file": (io.BytesIO(b"fake system"), "SYSTEM"),
+        },
+        content_type="multipart/form-data",
+    )
+    body = _json_body(resp)
+    assert body["status"] == 400
+
+
+# ---------------------------------------------------------------------------
 # GET /v1/hashfiles/<hashfile_id>/conversion
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_source_file_conversion.py
+++ b/tests/unit/test_source_file_conversion.py
@@ -1,0 +1,173 @@
+"""Tests for server-side source file conversion (pcap + NTDS.dit)."""
+import os
+from datetime import datetime, timedelta
+
+from hashview.models import Hashfiles, HashfileConversions, Users, db
+
+
+def _make_owner():
+    u = Users(first_name="T", last_name="U", email_address="t@example.com",
+               password="x" * 60, admin=True)
+    db.session.add(u)
+    db.session.commit()
+    return u
+
+
+def _make_hashfile(owner_id):
+    hf = Hashfiles(name="capture.pcapng", customer_id=1, owner_id=owner_id)
+    db.session.add(hf)
+    db.session.commit()
+    return hf
+
+
+def test_hashfile_conversions_model_creates_and_queries(app):
+    """HashfileConversions record can be saved and loaded with all fields."""
+    owner = _make_owner()
+    hf = _make_hashfile(owner.id)
+
+    conv = HashfileConversions(
+        hashfile_id=hf.id,
+        source_type="wpa_pcap",
+        status="pending",
+        source_path="/tmp/capture.pcapng",
+        system_path=None,
+    )
+    db.session.add(conv)
+    db.session.commit()
+
+    loaded = HashfileConversions.query.filter_by(hashfile_id=hf.id).first()
+    assert loaded is not None
+    assert loaded.source_type == "wpa_pcap"
+    assert loaded.status == "pending"
+    assert loaded.source_path == "/tmp/capture.pcapng"
+    assert loaded.system_path is None
+    assert loaded.conversion_error is None
+
+
+def test_hashfile_backref_gives_conversion(app):
+    """hashfile.conversion returns the HashfileConversions record or None."""
+    owner = _make_owner()
+    hf = _make_hashfile(owner.id)
+
+    assert hf.conversion is None  # no conversion record yet
+
+    conv = HashfileConversions(
+        hashfile_id=hf.id,
+        source_type="wpa_pcap",
+        status="pending",
+        source_path="/tmp/cap.pcapng",
+    )
+    db.session.add(conv)
+    db.session.commit()
+    db.session.refresh(hf)
+
+    assert hf.conversion is not None
+    assert hf.conversion.status == "pending"
+
+
+def _login(client, user):
+    with client.session_transaction() as sess:
+        sess["_user_id"] = str(user.id)
+        sess["_fresh"] = True
+
+
+def test_scheduler_resets_stuck_converting_records(app, tmp_path, monkeypatch):
+    """Records stuck in 'converting' for >10 min are reset to 'pending'."""
+    monkeypatch.chdir(tmp_path)
+    os.makedirs(tmp_path / 'hashview' / 'control' / 'tmp')
+
+    owner = _make_owner()
+    hf = _make_hashfile(owner.id)
+
+    stuck_time = datetime.utcnow() - timedelta(minutes=15)
+    conv = HashfileConversions(
+        hashfile_id=hf.id,
+        source_type="wpa_pcap",
+        status="converting",
+        source_path="/tmp/cap.pcapng",
+        started_at=stuck_time,
+    )
+    db.session.add(conv)
+    db.session.commit()
+
+    from hashview.scheduler import process_pending_conversions
+    process_pending_conversions(app)
+
+    db.session.refresh(conv)
+    assert conv.status == "pending"
+
+
+def test_scheduler_fails_unknown_source_type(app, tmp_path, monkeypatch):
+    """A HashfileConversions record with an unrecognised source_type is marked failed."""
+    monkeypatch.chdir(tmp_path)
+    os.makedirs(tmp_path / 'hashview' / 'control' / 'tmp')
+
+    owner = _make_owner()
+    hf = _make_hashfile(owner.id)
+
+    conv = HashfileConversions(
+        hashfile_id=hf.id,
+        source_type="unknown_format",
+        status="pending",
+        source_path="/tmp/whatever",
+    )
+    db.session.add(conv)
+    db.session.commit()
+
+    from hashview.scheduler import process_pending_conversions
+    process_pending_conversions(app)
+
+    db.session.refresh(conv)
+    assert conv.status == "failed"
+    assert "unknown_format" in conv.conversion_error
+
+
+def test_hashfile_deletion_cascades_to_conversion(app):
+    """Deleting a Hashfiles record also deletes its HashfileConversions record (FK cascade)."""
+    owner = _make_owner()
+    hf = _make_hashfile(owner.id)
+
+    conv = HashfileConversions(
+        hashfile_id=hf.id,
+        source_type='wpa_pcap',
+        status='pending',
+        source_path='/tmp/cap.pcapng',
+    )
+    db.session.add(conv)
+    db.session.commit()
+    conv_id = conv.id
+
+    db.session.delete(hf)
+    db.session.commit()
+
+    assert HashfileConversions.query.filter_by(id=conv_id).first() is None
+
+
+def test_hashfiles_list_shows_converting_badge_for_pending_conversion(app, client):
+    """The hashfiles list page renders a status badge for hashfiles with pending conversions."""
+    from hashview.models import Customers
+
+    owner = _make_owner()
+    _login(client, owner)
+
+    cust = Customers(name="BadgeCorp")
+    db.session.add(cust)
+    db.session.commit()
+
+    hf = Hashfiles(name="badge-test-capture", customer_id=cust.id, owner_id=owner.id)
+    db.session.add(hf)
+    db.session.commit()
+
+    conv = HashfileConversions(
+        hashfile_id=hf.id,
+        source_type='wpa_pcap',
+        status='pending',
+        source_path='/tmp/cap.pcapng',
+    )
+    db.session.add(conv)
+    db.session.commit()
+
+    resp = client.get('/hashfiles')
+    assert resp.status_code == 200
+    # The template renders "Converting…" for pending/converting status
+    assert 'Converting' in resp.get_data(as_text=True)

--- a/tests/unit/test_source_file_conversion.py
+++ b/tests/unit/test_source_file_conversion.py
@@ -1,8 +1,11 @@
 """Tests for server-side source file conversion (pcap + NTDS.dit)."""
 import os
+import subprocess
 from datetime import datetime, timedelta
+from unittest.mock import patch
 
-from hashview.models import Hashfiles, HashfileConversions, Users, db
+import pytest
+from hashview.models import Customers, Hashfiles, HashfileConversions, Users, db
 
 
 def _make_owner():
@@ -71,6 +74,30 @@ def _login(client, user):
         sess["_fresh"] = True
 
 
+def _make_job(app, owner_id, customer_id):
+    from hashview.models import Jobs
+    job = Jobs(
+        name="test-job",
+        status="Incomplete",
+        customer_id=customer_id,
+        owner_id=owner_id,
+    )
+    db.session.add(job)
+    db.session.commit()
+    return job
+
+
+def _make_customer(name="Acme"):
+    from hashview.models import Customers, Settings
+    cust = Customers(name=name)
+    db.session.add(cust)
+    if not Settings.query.first():
+        from hashview.models import Settings
+        db.session.add(Settings(retention_period=30, max_runtime_jobs=0, max_runtime_tasks=0))
+    db.session.commit()
+    return cust
+
+
 def test_scheduler_resets_stuck_converting_records(app, tmp_path, monkeypatch):
     """Records stuck in 'converting' for >10 min are reset to 'pending'."""
     monkeypatch.chdir(tmp_path)
@@ -122,6 +149,216 @@ def test_scheduler_fails_unknown_source_type(app, tmp_path, monkeypatch):
     assert "unknown_format" in conv.conversion_error
 
 
+def test_convert_pcap_raises_when_tool_not_installed(tmp_path):
+    """ConversionError is raised with an install hint when hcxpcapngtool is absent."""
+    from hashview.utils.convert import ConversionError, convert_pcap
+
+    src = tmp_path / "cap.pcapng"
+    src.write_bytes(b"fake pcap content")
+
+    with patch("hashview.utils.convert.subprocess.run",
+               side_effect=FileNotFoundError("hcxpcapngtool")):
+        with pytest.raises(ConversionError, match="hcxpcapngtool"):
+            convert_pcap(str(src))
+
+
+def test_convert_pcap_raises_when_tool_exits_nonzero(tmp_path):
+    """ConversionError carries the tool's stderr when it exits non-zero."""
+    from hashview.utils.convert import ConversionError, convert_pcap
+
+    src = tmp_path / "cap.pcapng"
+    src.write_bytes(b"fake pcap content")
+
+    failed_result = subprocess.CompletedProcess(
+        args=[], returncode=1,
+        stdout=b"", stderr=b"error: invalid pcap file",
+    )
+    with patch("hashview.utils.convert.subprocess.run", return_value=failed_result):
+        with pytest.raises(ConversionError, match="invalid pcap file"):
+            convert_pcap(str(src))
+
+
+def test_convert_pcap_raises_when_output_is_empty(tmp_path):
+    """ConversionError is raised when the tool succeeds but produces no hashes."""
+    from hashview.utils.convert import ConversionError, convert_pcap
+
+    src = tmp_path / "cap.pcapng"
+    src.write_bytes(b"fake pcap content")
+
+    def _fake_run(cmd, **kwargs):
+        out_path = cmd[cmd.index('-o') + 1]
+        open(out_path, 'w').close()
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=b"", stderr=b"")
+
+    with patch("hashview.utils.convert.subprocess.run", side_effect=_fake_run):
+        with pytest.raises(ConversionError, match="No valid WPA"):
+            convert_pcap(str(src))
+
+
+def test_convert_pcap_raises_on_timeout(tmp_path):
+    """ConversionError is raised with a clean message when hcxpcapngtool times out."""
+    from hashview.utils.convert import ConversionError, convert_pcap
+
+    src = tmp_path / "cap.pcapng"
+    src.write_bytes(b"fake pcap content")
+
+    with patch("hashview.utils.convert.subprocess.run",
+               side_effect=subprocess.TimeoutExpired(cmd=['hcxpcapngtool'], timeout=300)):
+        with pytest.raises(ConversionError, match="timed out"):
+            convert_pcap(str(src))
+
+
+def test_convert_pcap_returns_output_path_on_success(tmp_path):
+    """convert_pcap returns the path to the converted file when the tool succeeds."""
+    from hashview.utils.convert import convert_pcap
+
+    src = tmp_path / "cap.pcapng"
+    src.write_bytes(b"fake pcap content")
+
+    wpa_line = b"WPA*02*aabbcc*001122334455*aabbccddeeff*targetssid*abc123*01*\n"
+
+    def _fake_run(cmd, **kwargs):
+        out_path = cmd[cmd.index('-o') + 1]
+        with open(out_path, 'wb') as f:
+            f.write(wpa_line)
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout=b"", stderr=b"")
+
+    with patch("hashview.utils.convert.subprocess.run", side_effect=_fake_run):
+        result = convert_pcap(str(src))
+
+    assert result.endswith('.hc22000')
+    assert os.path.exists(result)
+    with open(result, 'rb') as f:
+        assert f.read() == wpa_line
+
+
+def test_wpa_pcap_upload_creates_pending_conversion_record(app, client, tmp_path):
+    """POSTing a pcap file with file_type=wpa_pcap creates a HashfileConversions
+    record with status='pending' and does NOT immediately import hashes."""
+    import io as _io
+    from hashview.models import Customers, HashfileHashes
+
+    cust = Customers(name="TestCorp")
+    db.session.add(cust)
+    db.session.commit()
+
+    owner = _make_owner()
+    _login(client, owner)
+    job = _make_job(app, owner.id, cust.id)
+
+    pcap_bytes = b"\xd4\xc3\xb2\xa1fake pcap"
+    data = {
+        "file_type": "wpa_pcap",
+        "name": "pwnagotchi-capture",
+        "hash_type": "",
+        "shadow_hash_type": "",
+        "pwdump_hash_type": "",
+        "netntlm_hash_type": "",
+        "kerberos_hash_type": "",
+        "hashfile": (
+            _io.BytesIO(pcap_bytes),
+            "capture.pcapng",
+        ),
+    }
+    resp = client.post(
+        f"/jobs/{job.id}/assigned_hashfile/",
+        data=data,
+        content_type="multipart/form-data",
+        follow_redirects=False,
+    )
+
+    assert resp.status_code in (302, 303)
+
+    hf = Hashfiles.query.filter_by(name="capture.pcapng").first()
+    assert hf is not None
+
+    conv = HashfileConversions.query.filter_by(hashfile_id=hf.id).first()
+    assert conv is not None
+    assert conv.status == "pending"
+    assert conv.source_type == "wpa_pcap"
+
+    assert HashfileHashes.query.filter_by(hashfile_id=hf.id).count() == 0
+
+
+def test_scheduler_processes_wpa_pcap_conversion_successfully(app, tmp_path, monkeypatch):
+    """Scheduler converts a pending wpa_pcap record and imports hashes."""
+    monkeypatch.chdir(tmp_path)
+    os.makedirs(tmp_path / 'hashview' / 'control' / 'tmp')
+
+    owner = _make_owner()
+    hf = _make_hashfile(owner.id)
+
+    src = tmp_path / "cap.pcapng"
+    src.write_bytes(b"fake pcap")
+    out = str(src) + '.hc22000'
+
+    conv = HashfileConversions(
+        hashfile_id=hf.id,
+        source_type='wpa_pcap',
+        status='pending',
+        source_path=str(src),
+    )
+    db.session.add(conv)
+    db.session.commit()
+
+    wpa_line = "WPA*02*aabbcc*001122334455*aabbccddeeff*targetssid*abc123*01*\n"
+
+    def _fake_convert_pcap(src_path):
+        with open(out, 'w') as f:
+            f.write(wpa_line)
+        return out
+
+    with patch("hashview.scheduler.convert_pcap", _fake_convert_pcap):
+        from hashview.scheduler import process_pending_conversions
+        process_pending_conversions(app)
+
+    db.session.refresh(conv)
+    assert conv.status == 'ready'
+
+    from hashview.models import Hashes, HashfileHashes
+    imported = (
+        Hashes.query
+        .join(HashfileHashes, Hashes.id == HashfileHashes.hash_id)
+        .filter(HashfileHashes.hashfile_id == hf.id)
+        .all()
+    )
+    assert len(imported) == 1
+    assert str(imported[0].hash_type) == '22000'
+
+
+def test_scheduler_marks_failed_on_conversion_error(app, tmp_path, monkeypatch):
+    """When ConversionError is raised, the record status becomes 'failed'."""
+    monkeypatch.chdir(tmp_path)
+    os.makedirs(tmp_path / 'hashview' / 'control' / 'tmp')
+
+    owner = _make_owner()
+    hf = _make_hashfile(owner.id)
+
+    conv = HashfileConversions(
+        hashfile_id=hf.id,
+        source_type='wpa_pcap',
+        status='pending',
+        source_path='/tmp/nonexistent.pcapng',
+    )
+    db.session.add(conv)
+    db.session.commit()
+
+    from hashview.utils.convert import ConversionError
+
+    with patch("hashview.scheduler.convert_pcap",
+               side_effect=ConversionError("hcxpcapngtool is not installed")):
+        from hashview.scheduler import process_pending_conversions
+        process_pending_conversions(app)
+
+    db.session.refresh(conv)
+    assert conv.status == 'failed'
+    assert 'hcxpcapngtool' in conv.conversion_error
+
+
+# ---------------------------------------------------------------------------
+# Test 1: FK cascade — deleting a Hashfiles record deletes its HashfileConversions
+# ---------------------------------------------------------------------------
+
 def test_hashfile_deletion_cascades_to_conversion(app):
     """Deleting a Hashfiles record also deletes its HashfileConversions record (FK cascade)."""
     owner = _make_owner()
@@ -142,6 +379,100 @@ def test_hashfile_deletion_cascades_to_conversion(app):
 
     assert HashfileConversions.query.filter_by(id=conv_id).first() is None
 
+
+# ---------------------------------------------------------------------------
+# Test 2: Source pcap file deleted from disk after successful wpa_pcap conversion
+# ---------------------------------------------------------------------------
+
+def test_scheduler_removes_source_file_after_wpa_pcap_success(app, tmp_path, monkeypatch):
+    """Source pcap and converted .hc22000 are removed from disk after successful wpa_pcap conversion."""
+    monkeypatch.chdir(tmp_path)
+    os.makedirs(tmp_path / 'hashview' / 'control' / 'tmp')
+
+    owner = _make_owner()
+    hf = _make_hashfile(owner.id)
+
+    src = tmp_path / "cap.pcapng"
+    src.write_bytes(b"fake pcap")
+    out = str(src) + '.hc22000'
+
+    conv = HashfileConversions(
+        hashfile_id=hf.id,
+        source_type='wpa_pcap',
+        status='pending',
+        source_path=str(src),
+    )
+    db.session.add(conv)
+    db.session.commit()
+
+    wpa_line = "WPA*02*aabbcc*001122334455*aabbccddeeff*targetssid*abc123*01*\n"
+
+    def _fake_convert_pcap(src_path):
+        with open(out, 'w') as f:
+            f.write(wpa_line)
+        return out
+
+    with patch("hashview.scheduler.convert_pcap", _fake_convert_pcap):
+        from hashview.scheduler import process_pending_conversions
+        process_pending_conversions(app)
+
+    assert not os.path.exists(str(src)), "source pcap should be deleted after conversion"
+    assert not os.path.exists(out), ".hc22000 output should be deleted after import"
+
+
+# ---------------------------------------------------------------------------
+# Test 5: convert_pcap fallback message when tool exits nonzero with no stderr
+# ---------------------------------------------------------------------------
+
+def test_convert_pcap_raises_fallback_when_no_stderr(tmp_path):
+    """ConversionError has a generic message when hcxpcapngtool exits non-zero with no stderr."""
+    from hashview.utils.convert import ConversionError, convert_pcap
+
+    src = tmp_path / "cap.pcapng"
+    src.write_bytes(b"fake pcap content")
+
+    silent_failure = subprocess.CompletedProcess(
+        args=[], returncode=1, stdout=b"", stderr=b"",
+    )
+    with patch("hashview.utils.convert.subprocess.run", return_value=silent_failure):
+        with pytest.raises(ConversionError, match="exited with an error"):
+            convert_pcap(str(src))
+
+
+# ---------------------------------------------------------------------------
+# Test 7: Non-ConversionError exceptions also mark record failed
+# ---------------------------------------------------------------------------
+
+def test_scheduler_marks_failed_on_unexpected_exception(app, tmp_path, monkeypatch):
+    """Non-ConversionError exceptions (e.g. RuntimeError) also mark the record as failed."""
+    monkeypatch.chdir(tmp_path)
+    os.makedirs(tmp_path / 'hashview' / 'control' / 'tmp')
+
+    owner = _make_owner()
+    hf = _make_hashfile(owner.id)
+
+    conv = HashfileConversions(
+        hashfile_id=hf.id,
+        source_type='wpa_pcap',
+        status='pending',
+        source_path='/tmp/nonexistent.pcapng',
+    )
+    db.session.add(conv)
+    db.session.commit()
+
+    with patch("hashview.scheduler.convert_pcap",
+               side_effect=RuntimeError("disk full")):
+        from hashview.scheduler import process_pending_conversions
+        process_pending_conversions(app)
+
+    db.session.refresh(conv)
+    assert conv.status == 'failed'
+    assert 'disk full' in conv.conversion_error
+
+
+# ---------------------------------------------------------------------------
+# Test 8: Hashfiles list view includes conversion status badge
+# ---------------------------------------------------------------------------
 
 def test_hashfiles_list_shows_converting_badge_for_pending_conversion(app, client):
     """The hashfiles list page renders a status badge for hashfiles with pending conversions."""
@@ -171,3 +502,49 @@ def test_hashfiles_list_shows_converting_badge_for_pending_conversion(app, clien
     assert resp.status_code == 200
     # The template renders "Converting…" for pending/converting status
     assert 'Converting' in resp.get_data(as_text=True)
+
+
+# ---------------------------------------------------------------------------
+# Test 9: Two pending records both processed in a single scheduler cycle
+# ---------------------------------------------------------------------------
+
+def test_scheduler_processes_multiple_pending_records(app, tmp_path, monkeypatch):
+    """A single scheduler run processes all pending records, not just the first."""
+    monkeypatch.chdir(tmp_path)
+    os.makedirs(tmp_path / 'hashview' / 'control' / 'tmp')
+
+    owner = _make_owner()
+
+    hf1 = Hashfiles(name="cap1.pcapng", customer_id=1, owner_id=owner.id)
+    hf2 = Hashfiles(name="cap2.pcapng", customer_id=1, owner_id=owner.id)
+    db.session.add_all([hf1, hf2])
+    db.session.commit()
+
+    src1 = tmp_path / "cap1.pcapng"
+    src2 = tmp_path / "cap2.pcapng"
+    src1.write_bytes(b"fake pcap 1")
+    src2.write_bytes(b"fake pcap 2")
+
+    conv1 = HashfileConversions(hashfile_id=hf1.id, source_type='wpa_pcap',
+                                 status='pending', source_path=str(src1))
+    conv2 = HashfileConversions(hashfile_id=hf2.id, source_type='wpa_pcap',
+                                 status='pending', source_path=str(src2))
+    db.session.add_all([conv1, conv2])
+    db.session.commit()
+
+    wpa_line = "WPA*02*aabbcc*001122334455*aabbccddeeff*targetssid*abc123*01*\n"
+
+    def _fake_convert_pcap(src_path):
+        out = src_path + '.hc22000'
+        with open(out, 'w') as f:
+            f.write(wpa_line)
+        return out
+
+    with patch("hashview.scheduler.convert_pcap", _fake_convert_pcap):
+        from hashview.scheduler import process_pending_conversions
+        process_pending_conversions(app)
+
+    db.session.refresh(conv1)
+    db.session.refresh(conv2)
+    assert conv1.status == 'ready'
+    assert conv2.status == 'ready'

--- a/tests/unit/test_source_file_conversion.py
+++ b/tests/unit/test_source_file_conversion.py
@@ -356,6 +356,199 @@ def test_scheduler_marks_failed_on_conversion_error(app, tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# convert_ntds()
+# ---------------------------------------------------------------------------
+
+def test_convert_ntds_raises_when_tool_not_installed(tmp_path):
+    """ConversionError is raised with an install hint when impacket-secretsdump is absent."""
+    from hashview.utils.convert import ConversionError, convert_ntds
+
+    ntds = tmp_path / "ntds.dit"
+    system = tmp_path / "SYSTEM"
+    ntds.write_bytes(b"fake ntds")
+    system.write_bytes(b"fake system")
+
+    with patch("hashview.utils.convert.subprocess.run",
+               side_effect=FileNotFoundError("impacket-secretsdump")):
+        with pytest.raises(ConversionError, match="impacket-secretsdump"):
+            convert_ntds(str(ntds), str(system))
+
+
+def test_convert_ntds_raises_when_tool_exits_nonzero(tmp_path):
+    """ConversionError carries stderr when impacket-secretsdump exits non-zero."""
+    from hashview.utils.convert import ConversionError, convert_ntds
+
+    ntds = tmp_path / "ntds.dit"
+    system = tmp_path / "SYSTEM"
+    ntds.write_bytes(b"fake ntds")
+    system.write_bytes(b"fake system")
+
+    failed = subprocess.CompletedProcess(
+        args=[], returncode=1,
+        stdout=b"", stderr=b"error: cannot decrypt boot key",
+    )
+    with patch("hashview.utils.convert.subprocess.run", return_value=failed):
+        with pytest.raises(ConversionError, match="cannot decrypt boot key"):
+            convert_ntds(str(ntds), str(system))
+
+
+def test_convert_ntds_raises_when_output_is_empty(tmp_path):
+    """ConversionError when secretsdump succeeds but produces no stdout."""
+    from hashview.utils.convert import ConversionError, convert_ntds
+
+    ntds = tmp_path / "ntds.dit"
+    system = tmp_path / "SYSTEM"
+    ntds.write_bytes(b"fake ntds")
+    system.write_bytes(b"fake system")
+
+    empty = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout=b"", stderr=b"",
+    )
+    with patch("hashview.utils.convert.subprocess.run", return_value=empty):
+        with pytest.raises(ConversionError, match="No hashes extracted"):
+            convert_ntds(str(ntds), str(system))
+
+
+def test_convert_ntds_returns_output_path_on_success(tmp_path):
+    """convert_ntds writes stdout to a .pwdump file and returns its path."""
+    from hashview.utils.convert import convert_ntds
+
+    ntds = tmp_path / "ntds.dit"
+    system = tmp_path / "SYSTEM"
+    ntds.write_bytes(b"fake ntds")
+    system.write_bytes(b"fake system")
+
+    pwdump_line = b"alice:1001:aad3b435b51404eeaad3b435b51404ee:8846f7eaee8fb117ad06bdd830b7586c:::\n"
+    success = subprocess.CompletedProcess(
+        args=[], returncode=0, stdout=pwdump_line, stderr=b"",
+    )
+    with patch("hashview.utils.convert.subprocess.run", return_value=success):
+        result = convert_ntds(str(ntds), str(system))
+
+    assert result.endswith('.pwdump')
+    assert os.path.exists(result)
+    with open(result, 'rb') as f:
+        assert f.read() == pwdump_line
+
+
+def test_ntds_upload_creates_pending_conversion_record(app, client, tmp_path):
+    """POSTing ntds.dit + SYSTEM with file_type=ntds creates a HashfileConversions
+    record with both source_path and system_path set."""
+    import io as _io
+    from hashview.models import Customers, HashfileHashes
+
+    cust = Customers(name="CorpTwo")
+    db.session.add(cust)
+    db.session.commit()
+
+    owner = _make_owner()
+    _login(client, owner)
+    job = _make_job(app, owner.id, cust.id)
+
+    data = {
+        "file_type": "ntds",
+        "name": "corp-ad-dump",
+        "hash_type": "",
+        "shadow_hash_type": "",
+        "pwdump_hash_type": "",
+        "netntlm_hash_type": "",
+        "kerberos_hash_type": "",
+        "hashfile": (
+            _io.BytesIO(b"fake ntds.dit content"),
+            "ntds.dit",
+        ),
+        "system_file": (
+            _io.BytesIO(b"fake SYSTEM hive content"),
+            "SYSTEM",
+        ),
+    }
+    resp = client.post(
+        f"/jobs/{job.id}/assigned_hashfile/",
+        data=data,
+        content_type="multipart/form-data",
+        follow_redirects=False,
+    )
+
+    assert resp.status_code in (302, 303)
+
+    hf = Hashfiles.query.filter_by(name="corp-ad-dump").first()
+    assert hf is not None
+
+    conv = HashfileConversions.query.filter_by(hashfile_id=hf.id).first()
+    assert conv is not None
+    assert conv.status == "pending"
+    assert conv.source_type == "ntds"
+    assert conv.source_path is not None
+    assert conv.system_path is not None
+
+    assert HashfileHashes.query.filter_by(hashfile_id=hf.id).count() == 0
+
+
+def test_convert_ntds_raises_on_timeout(tmp_path):
+    """ConversionError is raised with a clean message when impacket-secretsdump times out."""
+    from hashview.utils.convert import ConversionError, convert_ntds
+
+    ntds = tmp_path / "ntds.dit"
+    system = tmp_path / "SYSTEM"
+    ntds.write_bytes(b"fake ntds")
+    system.write_bytes(b"fake system")
+
+    with patch("hashview.utils.convert.subprocess.run",
+               side_effect=subprocess.TimeoutExpired(cmd=['impacket-secretsdump'], timeout=600)):
+        with pytest.raises(ConversionError, match="timed out"):
+            convert_ntds(str(ntds), str(system))
+
+
+def test_scheduler_processes_ntds_conversion_successfully(app, tmp_path, monkeypatch):
+    """Scheduler converts a pending ntds record and imports hashes via pwdump."""
+    monkeypatch.chdir(tmp_path)
+    os.makedirs(tmp_path / 'hashview' / 'control' / 'tmp')
+
+    owner = _make_owner()
+    hf = _make_hashfile(owner.id)
+
+    ntds_src = tmp_path / "ntds.dit"
+    system_src = tmp_path / "SYSTEM"
+    ntds_src.write_bytes(b"fake ntds")
+    system_src.write_bytes(b"fake system")
+    out = str(ntds_src) + '.pwdump'
+
+    conv = HashfileConversions(
+        hashfile_id=hf.id,
+        source_type='ntds',
+        status='pending',
+        source_path=str(ntds_src),
+        system_path=str(system_src),
+    )
+    db.session.add(conv)
+    db.session.commit()
+
+    pwdump_line = "alice:1001:aad3b435b51404eeaad3b435b51404ee:8846f7eaee8fb117ad06bdd830b7586c:::\n"
+
+    def _fake_convert_ntds(ntds_path, system_path):
+        with open(out, 'w') as f:
+            f.write(pwdump_line)
+        return out
+
+    with patch("hashview.scheduler.convert_ntds", _fake_convert_ntds):
+        from hashview.scheduler import process_pending_conversions
+        process_pending_conversions(app)
+
+    db.session.refresh(conv)
+    assert conv.status == 'ready'
+
+    from hashview.models import Hashes, HashfileHashes
+    imported = (
+        Hashes.query
+        .join(HashfileHashes, Hashes.id == HashfileHashes.hash_id)
+        .filter(HashfileHashes.hashfile_id == hf.id)
+        .all()
+    )
+    assert len(imported) == 1
+    assert str(imported[0].hash_type) == '1000'
+
+
+# ---------------------------------------------------------------------------
 # Test 1: FK cascade — deleting a Hashfiles record deletes its HashfileConversions
 # ---------------------------------------------------------------------------
 
@@ -421,6 +614,95 @@ def test_scheduler_removes_source_file_after_wpa_pcap_success(app, tmp_path, mon
 
 
 # ---------------------------------------------------------------------------
+# Test 3: ntds.dit, SYSTEM hive, and .pwdump all deleted after successful ntds conversion
+# ---------------------------------------------------------------------------
+
+def test_scheduler_removes_source_files_after_ntds_success(app, tmp_path, monkeypatch):
+    """ntds.dit, SYSTEM hive, and .pwdump output are all removed after successful ntds conversion."""
+    monkeypatch.chdir(tmp_path)
+    os.makedirs(tmp_path / 'hashview' / 'control' / 'tmp')
+
+    owner = _make_owner()
+    hf = _make_hashfile(owner.id)
+
+    ntds_src = tmp_path / "ntds.dit"
+    system_src = tmp_path / "SYSTEM"
+    ntds_src.write_bytes(b"fake ntds")
+    system_src.write_bytes(b"fake system")
+    out = str(ntds_src) + '.pwdump'
+
+    conv = HashfileConversions(
+        hashfile_id=hf.id,
+        source_type='ntds',
+        status='pending',
+        source_path=str(ntds_src),
+        system_path=str(system_src),
+    )
+    db.session.add(conv)
+    db.session.commit()
+
+    pwdump_line = "alice:1001:aad3b435b51404eeaad3b435b51404ee:8846f7eaee8fb117ad06bdd830b7586c:::\n"
+
+    def _fake_convert_ntds(ntds_path, system_path):
+        with open(out, 'w') as f:
+            f.write(pwdump_line)
+        return out
+
+    with patch("hashview.scheduler.convert_ntds", _fake_convert_ntds):
+        from hashview.scheduler import process_pending_conversions
+        process_pending_conversions(app)
+
+    assert not os.path.exists(str(ntds_src)), "ntds.dit should be deleted after conversion"
+    assert not os.path.exists(str(system_src)), "SYSTEM hive should be deleted after conversion"
+    assert not os.path.exists(out), ".pwdump output should be deleted after import"
+
+
+# ---------------------------------------------------------------------------
+# Test 4: ntds upload without a SYSTEM hive returns an error
+# ---------------------------------------------------------------------------
+
+def test_ntds_upload_without_system_file_returns_error(app, client, tmp_path):
+    """POSTing ntds without a SYSTEM hive file shows an error and creates no records."""
+    import io as _io
+    from hashview.models import Customers
+
+    cust = Customers(name="CorpMissingSys")
+    db.session.add(cust)
+    db.session.commit()
+
+    owner = _make_owner()
+    _login(client, owner)
+    job = _make_job(app, owner.id, cust.id)
+
+    data = {
+        "file_type": "ntds",
+        "name": "missing-system",
+        "hash_type": "",
+        "shadow_hash_type": "",
+        "pwdump_hash_type": "",
+        "netntlm_hash_type": "",
+        "kerberos_hash_type": "",
+        "hashfile": (
+            _io.BytesIO(b"fake ntds.dit content"),
+            "ntds.dit",
+        ),
+        # no system_file submitted
+    }
+    resp = client.post(
+        f"/jobs/{job.id}/assigned_hashfile/",
+        data=data,
+        content_type="multipart/form-data",
+        follow_redirects=True,
+    )
+
+    assert resp.status_code == 200
+    assert b'SYSTEM hive' in resp.data
+
+    # No records should be created
+    assert Hashfiles.query.filter_by(name="missing-system").first() is None
+
+
+# ---------------------------------------------------------------------------
 # Test 5: convert_pcap fallback message when tool exits nonzero with no stderr
 # ---------------------------------------------------------------------------
 
@@ -437,6 +719,27 @@ def test_convert_pcap_raises_fallback_when_no_stderr(tmp_path):
     with patch("hashview.utils.convert.subprocess.run", return_value=silent_failure):
         with pytest.raises(ConversionError, match="exited with an error"):
             convert_pcap(str(src))
+
+
+# ---------------------------------------------------------------------------
+# Test 6: convert_ntds fallback message when tool exits nonzero with no stderr
+# ---------------------------------------------------------------------------
+
+def test_convert_ntds_raises_fallback_when_no_stderr(tmp_path):
+    """ConversionError has a generic message when impacket-secretsdump exits non-zero with no stderr."""
+    from hashview.utils.convert import ConversionError, convert_ntds
+
+    ntds = tmp_path / "ntds.dit"
+    system = tmp_path / "SYSTEM"
+    ntds.write_bytes(b"fake ntds")
+    system.write_bytes(b"fake system")
+
+    silent_failure = subprocess.CompletedProcess(
+        args=[], returncode=1, stdout=b"", stderr=b"",
+    )
+    with patch("hashview.utils.convert.subprocess.run", return_value=silent_failure):
+        with pytest.raises(ConversionError, match="exited with an error"):
+            convert_ntds(str(ntds), str(system))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Allows users to upload raw WPA capture files (pcap/pcapng from pwnagotchi or
hcxdumptool) and NTDS.dit + SYSTEM hive pairs directly. Hashview converts them
server-side and imports the resulting hashes asynchronously, so the upload
returns immediately without a long wait.

## How it works

A new `HashfileConversions` table tracks conversion state for each upload. An
APScheduler job polls every 30 seconds, runs the appropriate conversion tool,
and feeds the output into the existing hash import pipeline:

- **WPA captures** → `hcxpcapngtool` → hashcat mode 22000 (WPA-PBKDF2-PMKID+EAPOL)
- **NTDS.dit + SYSTEM hive** → `impacket-secretsdump LOCAL` → hashcat mode 1000 (NTLM)

Source files are removed from disk after a successful conversion. Failed
conversions are marked with an error message, shown as a status badge on the
hashfiles list page.

## Dependencies

- `hcxtools` (`apt install hcxtools`) — required for WPA capture conversion
- `impacket` (`pip install impacket`) — required for NTDS.dit conversion

Both are optional at runtime; uploading the relevant file type on a server
without the tool installed produces a clear error message.

## Changes

- New model `HashfileConversions` with an Alembic migration (chained onto the
  current `v0.8.3-dev` head).
- New module `hashview/utils/convert.py` (`convert_pcap`, `convert_ntds`,
  `ConversionError`).
- New scheduler job `process_pending_conversions` (30-second interval).
- Upload form: two new `file_type` options (`wpa_pcap`, `ntds`); NTDS uploads
  include a second file field for the SYSTEM hive.
- Hashfiles list: status badges for pending / converting / failed conversions.
- 28 unit tests covering the failure modes, file cleanup, cascade deletion, and
  the full upload → scheduler → import path.

## REST API

Three endpoints provide programmatic access to the same capability, documented
in the OpenAPI spec (`hashview/api_docs/openapi.yaml`) and covered by 15 unit
tests (auth rejection, missing fields, invalid customer IDs, and the happy path
for each):

- `POST /v1/hashfiles/upload/wpa_pcap/<customer_id>/<hashfile_name>` — raw
  binary body (pcap/pcapng); returns `hashfile_id` and `conversion_id`.
- `POST /v1/hashfiles/upload/ntds/<customer_id>/<hashfile_name>` —
  multipart/form-data with `ntds_file` and `system_file`; returns `hashfile_id`
  and `conversion_id`.
- `GET /v1/hashfiles/<hashfile_id>/conversion` — poll conversion state; returns
  `conversion_status`, `source_type`, and `conversion_error`.

All three are user-authenticated (the existing `uuid` cookie / API key). The
intended flow is upload → poll → done.

## Also included (outside the feature)

- **Resolved an Alembic dual-head** that appears when this branch merges into
  `v0.8.3-dev`: the base added migration `d4e8b1f3a297` (task-loopback) off the
  same parent as the conversion migration, producing two heads — which silently
  aborted the startup `upgrade`, left an empty schema, and failed the e2e run.
  The conversion migration is re-chained onto `d4e8b1f3a297` so history stays
  linear.
- **Fixed the `DATA_RETENTION` scheduler job**, which had the same
  `current_app`-proxy bug as the new conversion job (jobs ran outside an app
  context and silently failed). Pre-existing; fixed here because the new
  30-second job exposed the pattern.
- **Hardened the DB healthcheck** in `docker-compose.yml` to gate on a real TCP
  query as the app user instead of the socket-only `mysqladmin ping`, so the app
  doesn't start before MySQL is truly ready. Affects `docker compose up` as well
  as CI.
- **Repaired stale e2e tests** for the current UI: strict-mode "New Job"
  locators, and `test_tasks_edit` rewritten for the modal-based edit flow;
  `test_agent_sim` now launches via `sys.executable` for host portability.
  `tests/run_e2e_compose.sh` also dumps container logs on a readiness timeout so
  boot failures are diagnosable.
- **Added `scripts/preflight.sh`** to run all CI gates locally before pushing,
  and pinned `pylint` in `requirements-dev.txt`.