### PR TITLE
Fix open redirect on login via ?next= (#192)

### DIFF
--- a/hashview/users/routes.py
+++ b/hashview/users/routes.py
@@ -134,9 +134,10 @@ def login_post():
     db.session.commit()
     current_app.logger.info('Login is Complete with Success(User:%s).', user.email_address)
     log_event('user.login', actor=(user.email_address, user.id))
-    return redirect(
-        request.args.get("next", url_for('main.home'))
-    )
+    # Route the post-login redirect through the same-site guard so a crafted
+    # ?next=https://evil.example can't turn login into an open redirect; an
+    # off-site or protocol-relative target falls back to the home page.
+    return redirect(_safe_next(default_endpoint='main.home'))
 
 @users.route("/logout")
 def logout():

--- a/tests/e2e/test_security.py
+++ b/tests/e2e/test_security.py
@@ -139,14 +139,12 @@ def test_login_next_param_not_open_redirect(page, live_server, test_user_credent
     page.get_by_label("Email").fill(test_user_credentials["email"])
     page.get_by_label("Password").fill(test_user_credentials["password"])
     page.get_by_role("button", name="Crack the planet!").click()
-    if os.getenv("HASHVIEW_E2E_ENFORCE_OPEN_REDIRECT", "0") in {"1", "true", "yes"}:
-        assert page.url.startswith(live_server)
-    else:
-        if page.url.startswith("https://example.com"):
-            pytest.xfail("Open redirect: login next allows external URL.")
-        assert page.url.startswith(live_server) or page.url.startswith(
-            "https://example.com"
-        )
+    # The crafted off-site ?next= must be ignored: login redirects through the
+    # same-site guard, so the user always lands back on the app, never on
+    # example.com. (Previously xfail — fixed in login_post via _safe_next.)
+    assert page.url.startswith(live_server), (
+        f"login honored an off-site next= (open redirect): {page.url}"
+    )
 
 
 @pytest.mark.e2e

--- a/tests/unit/test_login_redirect.py
+++ b/tests/unit/test_login_redirect.py
@@ -1,0 +1,53 @@
+"""Regression tests for the login post-auth redirect (open-redirect guard).
+
+See issue #192: login honored an attacker-controlled ?next= without
+validation, allowing an open redirect. login_post now routes through
+_safe_next(), which only accepts a relative, same-site path.
+"""
+
+import pytest
+
+from hashview.models import Users, db
+from hashview.users.routes import bcrypt
+
+PASSWORD = "correct horse battery staple"
+
+
+@pytest.fixture()
+def login_user_row(app):
+    user = Users(
+        first_name="Test",
+        last_name="User",
+        email_address="login@example.com",
+        password=bcrypt.generate_password_hash(PASSWORD).decode("latin-1"),
+        admin=True,
+    )
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+def _login(client, next_value):
+    return client.post(
+        f"/login?next={next_value}",
+        data={"email": "login@example.com", "password": PASSWORD},
+        follow_redirects=False,
+    )
+
+
+def test_login_rejects_offsite_next(app, client, login_user_row):
+    resp = _login(client, "https://evil.example")
+    assert resp.status_code in (301, 302)
+    assert "evil.example" not in resp.headers["Location"]
+
+
+def test_login_rejects_protocol_relative_next(app, client, login_user_row):
+    resp = _login(client, "//evil.example")
+    assert resp.status_code in (301, 302)
+    assert "evil.example" not in resp.headers["Location"]
+
+
+def test_login_preserves_same_site_next(app, client, login_user_row):
+    resp = _login(client, "/jobs")
+    assert resp.status_code in (301, 302)
+    assert resp.headers["Location"].endswith("/jobs")


### PR DESCRIPTION
## Summary
Closes #192. `login_post` passed the attacker-controlled `?next=` straight to `redirect()`, so `/login?next=https://evil.example` redirected an authenticated user off-site (open redirect). This routes the post-login redirect through the existing `_safe_next()` guard — the same one the profile flow already uses — which only accepts a relative, same-site path and otherwise falls back to the home page.

## Change
`hashview/users/routes.py`:

```python
-    return redirect(
-        request.args.get("next", url_for('main.home'))
-    )
+    return redirect(_safe_next(default_endpoint='main.home'))
```

## Test Plan
- [x] `tests/unit/test_login_redirect.py` (new, runs in CI without e2e creds):
  - off-site `next=https://evil.example` → ignored
  - protocol-relative `next=//evil.example` → ignored
  - relative `next=/jobs` → preserved
- [x] `tests/e2e/test_security.py::test_login_next_param_not_open_redirect` flipped from `xfail` to a hard same-site assertion; passes against a live stack.
- [x] `tests/unit/test_azure_sso.py` still green (login redirect behavior on success unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)