### PR TITLE
Function-level regression test coverage + e2e DB seeding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+coverage.json
 *.cover
 *.py,cover
 .hypothesis/

--- a/TESTING.md
+++ b/TESTING.md
@@ -83,6 +83,22 @@ This script:
     that skips the directory if Flask isn't importable, so a stray
     `pytest tests/` against an e2e-only venv won't error at collection.
 
+## Function coverage gate
+
+Every function in `hashview/` must have a unit test that executes it. Verify
+locally:
+
+```
+./.venv/bin/python -m pytest tests/unit -q --cov=hashview --cov-report=json:coverage.json
+./.venv/bin/python tests/check_function_coverage.py
+```
+
+The checker parses `coverage.json`, walks every `hashview/*.py` with `ast`, and
+exits non-zero listing any function with zero executed body lines (migrations
+excluded). Waivers (discouraged) go one-per-line in
+`tests/function_coverage_allowlist.txt` as `hashview/path/file.py::function_name`.
+`pytest-cov` is required (`./.venv/bin/pip install pytest-cov`).
+
 ## CI / CD (dev Docker containers)
 
 Recommended CI flow:

--- a/hashview/utils/backup.py
+++ b/hashview/utils/backup.py
@@ -38,8 +38,9 @@ _MIN_BACKUP_BYTES = 64          # an empty openssl stream is ~48 bytes
 _CHUNK = 1024 * 1024
 
 
-def _require_tools():
-    missing = [t for t in ('mysqldump', 'gzip', 'openssl') if shutil.which(t) is None]
+def _require_tools(need_mysqldump=True):
+    tools = (('mysqldump',) if need_mysqldump else ()) + ('gzip', 'openssl')
+    missing = [t for t in tools if shutil.which(t) is None]
     if missing:
         raise BackupError('Missing required tool(s): ' + ', '.join(missing))
 
@@ -146,10 +147,13 @@ def create_encrypted_db_backup(db_uri, tmp_dir, dump_cmd=None):
     shows the password + sha256 once. ``dump_cmd`` overrides the dump stage
     (used by tests to avoid requiring a live MySQL).
     """
-    _require_tools()
+    # Backend check first: a non-MySQL deployment must hear "unsupported", not
+    # "mysqldump missing". mysqldump is only required when we build the dump
+    # command ourselves (dump_cmd is the test seam that replaces that stage).
     url = make_url(db_uri)
     if not url.get_backend_name().startswith('mysql'):
         raise BackupError('Database backup is only supported for MySQL deployments.')
+    _require_tools(need_mysqldump=dump_cmd is None)
 
     password = secrets.token_urlsafe(24)        # ~143 bits, URL-safe (shell/quoting-safe)
     enc_path = os.path.join(tmp_dir, secrets.token_hex(8) + '.sql.gz.enc')

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 pytest==9.0.3
-pytest-cov==7.0.0
+pytest-cov==7.1.0
 pytest-playwright==0.7.2
 pytest-base-url==2.1.0
 playwright==1.58.0

--- a/tests/check_function_coverage.py
+++ b/tests/check_function_coverage.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+"""Fail when any function in hashview/ has zero executed body lines.
+
+Usage:
+    ./.venv/bin/python -m pytest tests/unit -q --cov=hashview --cov-report=json:coverage.json
+    ./.venv/bin/python tests/check_function_coverage.py [coverage.json]
+
+Exit codes: 0 = every function covered (or allowlisted), 1 = gaps found,
+2 = coverage.json missing/unreadable.
+
+Waivers go in tests/function_coverage_allowlist.txt, one per line, as
+``hashview/path/file.py::function_name``. Lines starting with ``#`` are
+comments. The allowlist is expected to stay empty.
+"""
+
+import ast
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ALLOWLIST = REPO_ROOT / "tests" / "function_coverage_allowlist.txt"
+
+
+def load_allowlist():
+    if not ALLOWLIST.exists():
+        return set()
+    entries = set()
+    for line in ALLOWLIST.read_text().splitlines():
+        line = line.strip()
+        if line and not line.startswith("#"):
+            entries.add(line)
+    return entries
+
+
+def body_lines(node):
+    """Line numbers of a function body, excluding a leading docstring."""
+    body = node.body
+    if body and isinstance(body[0], ast.Expr) and isinstance(body[0].value, ast.Constant):
+        body = body[1:]
+    lines = set()
+    for stmt in body:
+        lines.update(range(stmt.lineno, (stmt.end_lineno or stmt.lineno) + 1))
+    return lines
+
+
+def normalize(path):
+    """Coverage paths relative to the repo root, or None if outside it."""
+    p = Path(path)
+    if p.is_absolute():
+        try:
+            return str(p.resolve().relative_to(REPO_ROOT))
+        except ValueError:
+            return None
+    return str(p)
+
+
+def main():
+    cov_path = Path(sys.argv[1]) if len(sys.argv) > 1 else REPO_ROOT / "coverage.json"
+    try:
+        cov = json.loads(cov_path.read_text())
+    except OSError as exc:
+        print(f"cannot read coverage data: {exc}", file=sys.stderr)
+        print("run: pytest tests/unit --cov=hashview --cov-report=json:coverage.json", file=sys.stderr)
+        return 2
+
+    allow = load_allowlist()
+    missing = []
+    total = 0
+    for path, data in sorted(cov["files"].items()):
+        rel = normalize(path)
+        if rel is None or not rel.startswith("hashview/") or rel.startswith("hashview/migrations"):
+            continue
+        executed = set(data["executed_lines"])
+        try:
+            tree = ast.parse((REPO_ROOT / rel).read_text())
+        except OSError:
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                total += 1
+                key = f"{rel}::{node.name}"
+                if not (body_lines(node) & executed) and key not in allow:
+                    missing.append((rel, node.lineno, node.name))
+
+    print(f"functions scanned: {total}; zero-coverage: {len(missing)}")
+    for rel, lineno, name in missing:
+        print(f"  {rel}:{lineno}  {name}")
+    return 1 if missing else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/function_coverage_allowlist.txt
+++ b/tests/function_coverage_allowlist.txt
@@ -1,0 +1,2 @@
+# Waived functions, one per line: hashview/path/file.py::function_name
+# Keep empty unless a waiver survives code review.

--- a/tests/run_e2e_compose.sh
+++ b/tests/run_e2e_compose.sh
@@ -4,6 +4,16 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+# Load .env.test so the seed step below sees the same HASHVIEW_E2E_* vars the
+# pytest conftest reads (set -a exports each assignment).
+if [ -f .env.test ]; then
+  echo "Loading e2e environment from .env.test..."
+  set -a
+  # shellcheck disable=SC1091
+  . ./.env.test
+  set +a
+fi
+
 export DOCKER_PLATFORM="linux/amd64"
 
 COMPOSE_BIN="${COMPOSE_BIN:-docker compose}"
@@ -78,6 +88,39 @@ if ! curl -fsS "$BASE_URL/login" >/dev/null 2>&1; then
 fi
 
 export HASHVIEW_E2E_BASE_URL="$BASE_URL"
+
+# Seed the database to the state the suite pins via env vars: the admin user
+# (id=1) gets the e2e email/password/api_key, a Settings row exists, and the
+# Customer/Hashfile/Job rows are created at the expected IDs. Idempotent. Runs
+# INSIDE the app container (PYTHONPATH=/ — the package lives at /hashview in the
+# image). SETUP_EMAIL/SETUP_PASSWORD default to the login email/password.
+#
+# Only seed when the e2e env is actually configured (e.g. a local .env.test).
+# CI has no .env.test, so these are unset — skip seeding (the seeder exits
+# non-zero on missing required vars, which under `set -e` would abort the whole
+# harness) and let the individual tests skip on missing data, exactly as they
+# did before seeding existed.
+if [ -n "${HASHVIEW_E2E_API_KEY:-}" ] && [ -n "${HASHVIEW_E2E_CUSTOMER_ID:-}" ] \
+   && [ -n "${HASHVIEW_E2E_HASHFILE_ID:-}" ] && [ -n "${HASHVIEW_E2E_JOB_ID:-}" ] \
+   && [ -n "${HASHVIEW_E2E_TASK_ID:-}" ] \
+   && { [ -n "${HASHVIEW_E2E_SETUP_EMAIL:-}" ] || [ -n "${HASHVIEW_E2E_EMAIL:-}" ]; }; then
+  echo "Seeding e2e database (customer/hashfile/job + admin)..."
+  $COMPOSE_BIN cp tests/seed_e2e_db.py app:/tmp/seed_e2e_db.py
+  $COMPOSE_BIN exec -T \
+    -e PYTHONPATH=/ \
+    -e HASHVIEW_E2E_SETUP_EMAIL="${HASHVIEW_E2E_SETUP_EMAIL:-${HASHVIEW_E2E_EMAIL:-}}" \
+    -e HASHVIEW_E2E_SETUP_PASSWORD="${HASHVIEW_E2E_SETUP_PASSWORD:-${HASHVIEW_E2E_PASSWORD:-}}" \
+    -e HASHVIEW_E2E_API_KEY="${HASHVIEW_E2E_API_KEY:-}" \
+    -e HASHVIEW_E2E_SECOND_EMAIL="${HASHVIEW_E2E_SECOND_EMAIL:-}" \
+    -e HASHVIEW_E2E_SECOND_PASSWORD="${HASHVIEW_E2E_SECOND_PASSWORD:-}" \
+    -e HASHVIEW_E2E_CUSTOMER_ID="${HASHVIEW_E2E_CUSTOMER_ID:-}" \
+    -e HASHVIEW_E2E_HASHFILE_ID="${HASHVIEW_E2E_HASHFILE_ID:-}" \
+    -e HASHVIEW_E2E_JOB_ID="${HASHVIEW_E2E_JOB_ID:-}" \
+    -e HASHVIEW_E2E_TASK_ID="${HASHVIEW_E2E_TASK_ID:-}" \
+    -w / app python /tmp/seed_e2e_db.py
+else
+  echo "Skipping DB seed: e2e env vars not set (no .env.test?). Data-dependent tests will skip."
+fi
 
 echo "Running pytest against $BASE_URL"
 set +e

--- a/tests/seed_e2e_db.py
+++ b/tests/seed_e2e_db.py
@@ -1,0 +1,179 @@
+"""E2E database seeder. Run inside the app container after the app is up.
+
+Idempotent. Brings the database to the state the e2e suite expects:
+- admin user (id=1) has the e2e email/password/api_key from the env vars
+- Settings row exists (so the /setup/settings wizard doesn't trigger)
+- Customer / Hashfile / Job rows exist at the IDs the suite pins via env vars
+- a second, non-admin user (for the job-IDOR test) when the optional
+  HASHVIEW_E2E_SECOND_EMAIL / HASHVIEW_E2E_SECOND_PASSWORD vars are provided
+
+Required env vars: HASHVIEW_E2E_SETUP_EMAIL, HASHVIEW_E2E_SETUP_PASSWORD,
+HASHVIEW_E2E_API_KEY, HASHVIEW_E2E_CUSTOMER_ID, HASHVIEW_E2E_HASHFILE_ID,
+HASHVIEW_E2E_JOB_ID, HASHVIEW_E2E_TASK_ID.
+Optional: HASHVIEW_E2E_SECOND_EMAIL, HASHVIEW_E2E_SECOND_PASSWORD (provision a
+non-admin user so tests/e2e/test_security.py's IDOR check runs, not skips).
+"""
+import os
+import sys
+
+from flask import Flask
+from flask_bcrypt import Bcrypt
+
+from hashview.config import Config
+from hashview.models import (
+    Customers,
+    HashfileHashes,
+    Hashes,
+    Hashfiles,
+    JobTasks,
+    Jobs,
+    Settings,
+    Tasks,
+    Users,
+    db,
+)
+
+REQUIRED_ENV = (
+    "HASHVIEW_E2E_SETUP_EMAIL",
+    "HASHVIEW_E2E_SETUP_PASSWORD",
+    "HASHVIEW_E2E_API_KEY",
+    "HASHVIEW_E2E_CUSTOMER_ID",
+    "HASHVIEW_E2E_HASHFILE_ID",
+    "HASHVIEW_E2E_JOB_ID",
+    "HASHVIEW_E2E_TASK_ID",
+)
+OPTIONAL_SECOND_USER_ENV = (
+    "HASHVIEW_E2E_SECOND_EMAIL",
+    "HASHVIEW_E2E_SECOND_PASSWORD",
+)
+
+
+def build_app() -> Flask:
+    app = Flask(__name__)
+    app.config.from_object(Config)
+    db.init_app(app)
+    Bcrypt(app)
+    return app
+
+
+def seed(app: Flask) -> None:
+    email = os.environ["HASHVIEW_E2E_SETUP_EMAIL"]
+    password = os.environ["HASHVIEW_E2E_SETUP_PASSWORD"]
+    api_key = os.environ["HASHVIEW_E2E_API_KEY"]
+    customer_id = int(os.environ["HASHVIEW_E2E_CUSTOMER_ID"])
+    hashfile_id = int(os.environ["HASHVIEW_E2E_HASHFILE_ID"])
+    job_id = int(os.environ["HASHVIEW_E2E_JOB_ID"])
+    task_id = int(os.environ["HASHVIEW_E2E_TASK_ID"])
+
+    bcrypt = Bcrypt(app)
+
+    with app.app_context():
+        admin = db.session.get(Users, 1)
+        if admin is None:
+            raise RuntimeError(
+                "Admin user (id=1) not found. App must finish booting before seeding."
+            )
+        admin.first_name = admin.first_name or "Admin"
+        admin.last_name = admin.last_name or "User"
+        admin.email_address = email
+        admin.password = bcrypt.generate_password_hash(password).decode("utf-8")
+        admin.admin = True
+        admin.api_key = api_key
+
+        second_email = os.getenv("HASHVIEW_E2E_SECOND_EMAIL")
+        second_password = os.getenv("HASHVIEW_E2E_SECOND_PASSWORD")
+        if second_email and second_password:
+            second_user = Users.query.filter_by(email_address=second_email).first()
+            second_pw_hash = bcrypt.generate_password_hash(second_password).decode("utf-8")
+            if second_user is None:
+                db.session.add(
+                    Users(
+                        first_name="E2E",
+                        last_name="Second",
+                        email_address=second_email,
+                        password=second_pw_hash,
+                        admin=False,
+                    )
+                )
+            else:
+                second_user.password = second_pw_hash
+                second_user.admin = False
+
+        if db.session.query(Settings).first() is None:
+            db.session.add(
+                Settings(
+                    retention_period=30,
+                    max_runtime_jobs=0,
+                    max_runtime_tasks=0,
+                )
+            )
+
+        if db.session.get(Customers, customer_id) is None:
+            db.session.add(Customers(id=customer_id, name="E2E Customer"))
+
+        if db.session.get(Tasks, task_id) is None:
+            raise RuntimeError(
+                f"Task id={task_id} not found. Default tasks should be created on app boot."
+            )
+
+        if db.session.get(Hashfiles, hashfile_id) is None:
+            db.session.add(
+                Hashfiles(
+                    id=hashfile_id,
+                    name="e2e-hashfile",
+                    customer_id=customer_id,
+                    owner_id=admin.id,
+                )
+            )
+            db.session.flush()
+            hash_row = Hashes(
+                sub_ciphertext="d41d8cd98f00b204e9800998ecf8427e",
+                ciphertext="d41d8cd98f00b204e9800998ecf8427e",
+                hash_type=0,
+                cracked=False,
+            )
+            db.session.add(hash_row)
+            db.session.flush()
+            db.session.add(
+                HashfileHashes(
+                    hash_id=hash_row.id,
+                    username="e2e-user",
+                    hashfile_id=hashfile_id,
+                )
+            )
+
+        if db.session.get(Jobs, job_id) is None:
+            db.session.add(
+                Jobs(
+                    id=job_id,
+                    name="E2E Job",
+                    status="Ready",
+                    customer_id=customer_id,
+                    hashfile_id=hashfile_id,
+                    owner_id=admin.id,
+                )
+            )
+            db.session.flush()
+            db.session.add(
+                JobTasks(
+                    job_id=job_id,
+                    task_id=task_id,
+                    status="Not Started",
+                )
+            )
+
+        db.session.commit()
+
+
+def main() -> int:
+    missing = [k for k in REQUIRED_ENV if not os.getenv(k)]
+    if missing:
+        print(f"seed_e2e_db: missing env vars: {missing}", file=sys.stderr)
+        return 2
+    seed(build_app())
+    print("seed_e2e_db: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -32,6 +32,21 @@ if importlib.util.find_spec("flask") is None:
     collect_ignore_glob = ["test_*.py"]
 
 
+@pytest.fixture(autouse=True, scope="session")
+def control_dirs():
+    """Create the runtime control dirs that setup.py / the Dockerfile guarantee.
+
+    They're gitignored, so a fresh clone lacks them; several units write real
+    files there (wordlist storage, backup tmp files, hashfile uploads).
+    """
+    import os
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[2] / "hashview" / "control"
+    for sub in ("rules", "wordlists", "tmp", "hashes"):
+        os.makedirs(root / sub, exist_ok=True)
+
+
 @pytest.fixture(autouse=True)
 def ensure_setup():
     """Override parent autouse so live_server isn't requested for unit tests."""

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -1,0 +1,37 @@
+"""Shared seeding/login helpers for unit route tests.
+
+The login pattern mirrors tests/unit/test_delete_idempotency.py: create a row,
+then set Flask-Login's session keys directly so no password/CSRF dance is
+needed. Constructors match hashview/models.py (non-nullable columns supplied).
+"""
+
+from hashview.models import Customers, Users, db
+
+
+def make_admin(email="admin@example.com"):
+    u = Users(first_name="Ad", last_name="Min", email_address=email,
+              password="x" * 60, admin=True)
+    db.session.add(u)
+    db.session.commit()
+    return u
+
+
+def make_user(email="user@example.com"):
+    u = Users(first_name="Plain", last_name="User", email_address=email,
+              password="x" * 60, admin=False)
+    db.session.add(u)
+    db.session.commit()
+    return u
+
+
+def login(client, user):
+    with client.session_transaction() as sess:
+        sess["_user_id"] = str(user.id)
+        sess["_fresh"] = True
+
+
+def make_customer(name="Test Customer"):
+    c = Customers(name=name)
+    db.session.add(c)
+    db.session.commit()
+    return c

--- a/tests/unit/test_agents_routes.py
+++ b/tests/unit/test_agents_routes.py
@@ -1,0 +1,62 @@
+"""Regression tests for agents routes/helpers (function-coverage batch)."""
+
+from hashview.models import Agents, db
+from tests.unit.helpers import login, make_admin, make_user
+
+
+def _agent(name="ag", status="Pending", uuid="u1"):
+    a = Agents(name=name, src_ip="127.0.0.1", uuid=uuid, status=status)
+    db.session.add(a)
+    db.session.commit()
+    return a
+
+
+def test_fmt_age_buckets():
+    from hashview.agents.routes import _fmt_age
+    assert _fmt_age(0) == "now"
+    assert _fmt_age(30) == "30s ago"
+    assert _fmt_age(120) == "2m ago"
+    assert _fmt_age(3600) == "1h ago"
+    assert _fmt_age(3660) == "1h 1m ago"
+    assert _fmt_age(86400) == "1d ago"
+
+
+def test_agent_ages_returns_mapping(app):
+    from hashview.agents.routes import _agent_ages
+    a = _agent()
+    ages = _agent_ages([a])
+    assert a.id in ages  # value may be None (no last_checkin), key must exist
+
+
+def test_agents_list_renders_for_admin(app, client):
+    admin = make_admin()
+    login(client, admin)
+    _agent(name="VisibleAgent")
+    resp = client.get("/agents")
+    assert resp.status_code == 200
+    assert b"VisibleAgent" in resp.data
+
+
+def test_agents_list_forbidden_for_non_admin(app, client):
+    user = make_user()
+    login(client, user)
+    resp = client.get("/agents")
+    assert resp.status_code == 403
+
+
+def test_agents_authorize_sets_status(app, client):
+    admin = make_admin()
+    login(client, admin)
+    a = _agent(status="Pending")
+    resp = client.get(f"/agents/{a.id}/authorize", follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert Agents.query.get(a.id).status == "Authorized"
+
+
+def test_agents_deauthorize_sets_pending(app, client):
+    admin = make_admin()
+    login(client, admin)
+    a = _agent(status="Authorized")
+    resp = client.get(f"/agents/{a.id}/deauthorize", follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert Agents.query.get(a.id).status == "Pending"

--- a/tests/unit/test_analytics_view.py
+++ b/tests/unit/test_analytics_view.py
@@ -244,3 +244,21 @@ def test_shared_password_zip_download(app, client):
     assert len(names) >= 1                            # at least the Password1 group
     content = "\n".join(archive.read(n).decode("utf-8") for n in names)
     assert "Password1" in content and "alice" in content and "bob" in content
+
+
+def test_download_fig9_shared_password_accounts(app, client):
+    """fig9 download serves the shared-password usernames as a .txt attachment."""
+    user = _admin(); _login(client, user)
+    customer_id, hashfile_id = _seed()
+    resp = client.get(f"/analytics/download/fig9?customer_id={customer_id}&hashfile_id={hashfile_id}")
+    assert resp.status_code == 200
+    assert resp.headers["Content-Disposition"].startswith("attachment")
+
+
+def test_download_fig8_same_user_pass(app, client):
+    """fig8 download serves a .txt attachment (empty result is still valid)."""
+    user = _admin(); _login(client, user)
+    customer_id, hashfile_id = _seed()
+    resp = client.get(f"/analytics/download/fig8?customer_id={customer_id}&hashfile_id={hashfile_id}")
+    assert resp.status_code == 200
+    assert resp.headers["Content-Disposition"].startswith("attachment")

--- a/tests/unit/test_api_agent_protocol.py
+++ b/tests/unit/test_api_agent_protocol.py
@@ -1,0 +1,262 @@
+"""Regression tests for agent-facing v1 API protocol endpoints
+(function-coverage batch: api).
+
+Auth recap (see hashview/api/routes.py is_authorized): the 'uuid' cookie maps
+to Users.api_key (user routes) or Agents.uuid with an active status (agent
+routes). Cookie domain must equal the test SERVER_NAME (localhost.test).
+"""
+
+import json
+
+import hashview
+from hashview.models import (
+    Agents,
+    Customers,
+    Hashes,
+    HashfileHashes,
+    Hashfiles,
+    JobTasks,
+    Jobs,
+    Settings,
+    Tasks,
+    Users,
+    db,
+)
+
+DOMAIN = "localhost.test"
+
+
+def _agent(uuid="agent-uuid", status="Idle"):
+    a = Agents(name="a1", src_ip="127.0.0.1", uuid=uuid, status=status)
+    db.session.add(a)
+    db.session.commit()
+    return a
+
+
+def _user(api_key="user-key"):
+    u = Users(first_name="U", last_name="Sr", email_address="u@e.com",
+              password="x" * 60, admin=True, api_key=api_key)
+    db.session.add(u)
+    db.session.commit()
+    return u
+
+
+def _body(resp):
+    return json.loads(resp.get_data(as_text=True))
+
+
+# --- pure / static responses ------------------------------------------------
+
+def test_version_check():
+    from hashview.api.routes import versionCheck
+    assert versionCheck(None) is False
+    assert versionCheck("0.0.1") is False           # older than current
+    assert versionCheck(hashview.__version__) is True
+
+
+def test_unauthorized_envelope(app, client):
+    body = _body(client.get("/v1/not_authorized"))
+    assert body["status"] == 200
+    assert body["type"] == "Error"
+    assert "not authorized" in body["msg"].lower()
+
+
+def test_upgrade_required_envelope(app, client):
+    body = _body(client.get("/v1/upgrade_required"))
+    assert body["status"] == 426
+    assert "update your agent" in body["msg"].lower()
+
+
+# --- heartbeat --------------------------------------------------------------
+
+def _set_agent_cookies(client, uuid):
+    client.set_cookie("uuid", uuid, domain=DOMAIN)
+    client.set_cookie("agent_version", hashview.__version__, domain=DOMAIN)
+
+
+def test_heartbeat_old_version_redirects_to_upgrade(app, client):
+    client.set_cookie("uuid", "x", domain=DOMAIN)
+    client.set_cookie("agent_version", "0.0.1", domain=DOMAIN)
+    resp = client.post("/v1/agents/heartbeat", json={"agent_status": "Idle", "hc_status": ""})
+    assert 300 <= resp.status_code < 400
+    assert "upgrade_required" in resp.headers.get("Location", "")
+
+
+def test_heartbeat_new_agent_is_registered_pending(app, client):
+    db.session.add(Settings(max_runtime_tasks=0, max_runtime_jobs=0))
+    db.session.commit()
+    _set_agent_cookies(client, "brand-new-uuid")
+    client.set_cookie("name", "fresh-agent", domain=DOMAIN)
+    resp = client.post("/v1/agents/heartbeat", json={"agent_status": "Idle", "hc_status": ""})
+    body = _body(resp)
+    assert body["msg"] == "Go Away"
+    agent = Agents.query.filter_by(uuid="brand-new-uuid").first()
+    assert agent is not None and agent.status == "Pending"
+
+
+def test_heartbeat_idle_agent_gets_queued_task(app, client):
+    db.session.add(Settings(max_runtime_tasks=0, max_runtime_jobs=0))
+    db.session.commit()
+    agent = _agent(uuid="idle-agent", status="Idle")
+    jt = JobTasks(job_id=1, task_id=1, status="Queued", priority=3)
+    db.session.add(jt)
+    db.session.commit()
+    _set_agent_cookies(client, "idle-agent")
+    resp = client.post("/v1/agents/heartbeat", json={"agent_status": "Idle", "hc_status": ""})
+    body = _body(resp)
+    assert body["msg"] == "START"
+    assert body["job_task_id"] == jt.id
+    assert JobTasks.query.get(jt.id).agent_id == agent.id
+
+
+# --- read endpoints ---------------------------------------------------------
+
+def test_get_update_wordlist_returns_ok(app, client, monkeypatch):
+    _user()
+    # patch the heavy regeneration helper at its use site in the route module
+    monkeypatch.setattr("hashview.api.routes.update_dynamic_wordlist",
+                        lambda wid, jid: None)
+    client.set_cookie("uuid", "user-key", domain=DOMAIN)
+    resp = client.get("/v1/updateWordlist/1")
+    assert _body(resp)["status"] == 200
+
+
+def test_get_queue_assignment_returns_assigned_task(app, client):
+    agent = _agent(uuid="qa-agent", status="Working")
+    jt = JobTasks(job_id=1, task_id=2, status="Running", priority=3, agent_id=agent.id)
+    db.session.add(jt)
+    db.session.commit()
+    client.set_cookie("uuid", "qa-agent", domain=DOMAIN)
+    resp = client.get(f"/v1/jobTasks/{jt.id}")
+    body = _body(resp)
+    assert body["status"] == 200
+    assert json.loads(body["job_task"])["task_id"] == 2
+
+
+def test_get_job_returns_job_json(app, client):
+    _user()
+    cust = Customers(name="C")
+    db.session.add(cust)
+    db.session.commit()
+    job = Jobs(name="apijob", status="Ready", customer_id=cust.id, owner_id=1)
+    db.session.add(job)
+    db.session.commit()
+    client.set_cookie("uuid", "user-key", domain=DOMAIN)
+    resp = client.get(f"/v1/jobs/{job.id}")
+    body = _body(resp)
+    assert body["status"] == 200
+    assert json.loads(body["job"])["name"] == "apijob"
+
+
+def test_get_task_returns_task_json(app, client):
+    user = _user()
+    task = Tasks(name="apitask", owner_id=user.id, hc_attackmode=0)
+    db.session.add(task)
+    db.session.commit()
+    client.set_cookie("uuid", "user-key", domain=DOMAIN)
+    resp = client.get(f"/v1/tasks/{task.id}")
+    body = _body(resp)
+    assert body["status"] == 200
+    assert json.loads(body["task"])["name"] == "apitask"
+
+
+def test_get_hashtype_returns_mode(app, client):
+    _user()
+    hf = Hashfiles(name="hf", customer_id=1, owner_id=1)
+    db.session.add(hf)
+    db.session.commit()
+    h = Hashes(sub_ciphertext="0" * 8, ciphertext="abc", hash_type=1000, cracked=False)
+    db.session.add(h)
+    db.session.commit()
+    db.session.add(HashfileHashes(hash_id=h.id, hashfile_id=hf.id))
+    db.session.commit()
+    client.set_cookie("uuid", "user-key", domain=DOMAIN)
+    resp = client.get(f"/v1/getHashType/{hf.id}")
+    body = _body(resp)
+    assert body["status"] == 200
+    assert body["hash_type"] == 1000
+
+
+def test_get_hashfile_serves_uncracked_ciphertext(app, client):
+    _user()
+    hf = Hashfiles(name="hf", customer_id=1, owner_id=1)
+    db.session.add(hf)
+    db.session.commit()
+    h = Hashes(sub_ciphertext="0" * 8, ciphertext="UNCRACKEDHASH", hash_type=0, cracked=False)
+    db.session.add(h)
+    db.session.commit()
+    db.session.add(HashfileHashes(hash_id=h.id, hashfile_id=hf.id))
+    db.session.commit()
+    client.set_cookie("uuid", "user-key", domain=DOMAIN)
+    resp = client.get(f"/v1/hashfiles/{hf.id}")
+    assert resp.status_code == 200
+    assert b"UNCRACKEDHASH" in resp.data
+
+
+# --- upload endpoints -------------------------------------------------------
+
+def test_post_hashfile_upload_invalid_customer(app, client):
+    _user()
+    client.set_cookie("uuid", "user-key", domain=DOMAIN)
+    resp = client.post("/v1/hashfiles/upload/99999/5/0/myfile",
+                       data="deadbeef", content_type="text/plain")
+    body = _body(resp)
+    assert body["status"] == 400
+    assert "customer" in body["msg"].lower()
+
+
+def test_post_hashfile_upload_creates_hashfile(app, client):
+    user = _user()
+    cust = Customers(name="UpCo")
+    db.session.add(cust)
+    db.session.commit()
+    client.set_cookie("uuid", "user-key", domain=DOMAIN)
+    # file_format 5 = hash_only, hash_type 0 (raw MD5-style accepted by validator)
+    resp = client.post(f"/v1/hashfiles/upload/{cust.id}/5/0/myfile",
+                       data="5f4dcc3b5aa765d61d8327deb882cf99",
+                       content_type="text/plain")
+    body = _body(resp)
+    assert body["status"] == 200
+    assert body["msg"] == "Hashfile added"
+    assert Hashfiles.query.get(body["hashfile_id"]) is not None
+
+
+def test_put_jobtask_crackfile_marks_hash_cracked(app, client, monkeypatch):
+    monkeypatch.setattr("hashview.api.routes.process_recovered_hash_notifications",
+                        lambda: None)
+    agent = _agent(uuid="crack-agent", status="Working")
+    # NTLM('password') sub_ciphertext keyed by get_md5_hash(ciphertext)
+    from hashview.utils.utils import get_md5_hash
+    ntlm = "8846F7EAEE8FB117AD06BDD830B7586C"
+    h = Hashes(sub_ciphertext=get_md5_hash(ntlm), ciphertext=ntlm,
+               hash_type=1000, cracked=False)
+    db.session.add(h)
+    db.session.commit()
+    client.set_cookie("uuid", "crack-agent", domain=DOMAIN)
+    # encoded_plaintext is hex; hexplain_to_text decodes it -> "password"
+    hexpw = "password".encode().hex()
+    resp = client.post("/v1/uploadCrackFile/1/1000",
+                       json={"file": f"{ntlm}:{hexpw}"})
+    body = _body(resp)
+    assert body["status"] == 200
+    refreshed = Hashes.query.get(h.id)
+    assert refreshed.cracked
+    assert refreshed.plaintext == "password"
+
+
+# --- privilege boundaries ---------------------------------------------------
+
+def test_user_only_route_rejects_agent(app, client):
+    _agent(uuid="agentx", status="Idle")
+    client.set_cookie("uuid", "agentx", domain=DOMAIN)
+    resp = client.post("/v1/hashfiles/upload/1/5/0/f", data="x", content_type="text/plain")
+    assert 300 <= resp.status_code < 400
+    assert "not_authorized" in resp.headers.get("Location", "")
+
+
+def test_agent_only_route_rejects_user(app, client):
+    _user()
+    client.set_cookie("uuid", "user-key", domain=DOMAIN)
+    resp = client.post("/v1/uploadCrackFile/1/1000", json={"file": ""})
+    assert 300 <= resp.status_code < 400
+    assert "not_authorized" in resp.headers.get("Location", "")

--- a/tests/unit/test_app_factory.py
+++ b/tests/unit/test_app_factory.py
@@ -1,0 +1,44 @@
+"""Regression tests for app-factory hooks + jinja helpers
+(function-coverage batch: __init__)."""
+
+import hashview
+from hashview.models import Agents, db
+from tests.unit.helpers import login, make_admin
+
+
+def test_jinja_hex_decode_is_passthrough():
+    # Stored values are now plain UTF-8 text; the filter just returns them.
+    assert hashview.jinja_hex_decode("alice") == "alice"
+    assert hashview.jinja_hex_decode("$HEX[6869]") == "$HEX[6869]"
+
+
+def test_jinja_hex_decode_registered_as_filter(app):
+    assert "jinja_hex_decode" in app.jinja_env.filters
+
+
+def test_do_gui_setup_allows_static(app):
+    # A request for a static asset must short-circuit (return None) without a
+    # setup redirect.
+    with app.test_request_context("/static/css/x.css"):
+        assert hashview.do_gui_setup_if_needed() is None
+
+
+def test_setup_defaults_if_needed_runs_without_raising(app):
+    # Each step is wrapped in try/except and logged; calling it must complete
+    # (returns None) on the in-memory app.
+    with app.app_context():
+        assert hashview.setup_defaults_if_needed() is None
+
+
+def test_nav_count_helpers_run_when_rendering_with_agents(app, client):
+    # The _connected/_state/_hps helpers live inside the inject_nav_counts
+    # context processor and execute per agent when any template renders. Seed an
+    # agent with a benchmark + recent check-in and render an authenticated page.
+    admin = make_admin()
+    login(client, admin)
+    db.session.add(Agents(name="navagent", src_ip="127.0.0.1", uuid="nav-uuid",
+                          status="Working", benchmark="284.6 GH/s",
+                          last_checkin=__import__("datetime").datetime.utcnow()))
+    db.session.commit()
+    resp = client.get("/jobs")
+    assert resp.status_code == 200

--- a/tests/unit/test_azure_sso.py
+++ b/tests/unit/test_azure_sso.py
@@ -260,3 +260,57 @@ def test_admin_settings_api_does_not_leak_secret(client):
     body = client.get('/v1/admin/settings').get_data(as_text=True)
     assert 'SUPER-SECRET' not in body
     assert 'xoxb-leak' not in body
+
+
+# ---------------------------------------------------------------------------
+# hashview/auth/oauth.py — config gate, signature cache, lazy client build
+# ---------------------------------------------------------------------------
+
+
+def test_azure_is_configured_gate(app):
+    from hashview.auth.oauth import azure_is_configured
+    assert azure_is_configured(None) is False
+    assert azure_is_configured(_settings(auth_method='local')) is False
+    assert azure_is_configured(_settings(auth_method='azure')) is True
+    assert azure_is_configured(_settings(auth_method='azure', complete=False)) is False
+
+
+def test_signature_changes_with_secret(app):
+    from hashview.auth.oauth import _signature
+    s1 = _settings(auth_method='azure', secret='one')
+    sig1 = _signature(s1)
+    s1.azure_client_secret = 'two'
+    _db.session.commit()
+    assert _signature(s1) != sig1
+    # The plaintext secret never appears in the signature.
+    assert 'two' not in _signature(s1)
+
+
+def test_get_entra_client_none_when_unconfigured(app):
+    from hashview.auth.oauth import get_entra_client
+    assert get_entra_client(_settings(auth_method='local')) is None
+
+
+def test_get_entra_client_builds_when_configured(app, monkeypatch):
+    import hashview.auth.oauth as oauth_mod
+    from hashview.auth.oauth import get_entra_client
+    # Reset the module cache so this test is deterministic.
+    oauth_mod._cache.update(sig=None, client=None)
+
+    built = []
+
+    class _FakeOAuth:
+        def __init__(self, app=None):
+            pass
+
+        def register(self, **kw):
+            built.append(kw)
+
+        def create_client(self, name):
+            return f"client:{name}"
+
+    monkeypatch.setattr(oauth_mod, "OAuth", _FakeOAuth)
+    s = _settings(auth_method='azure', secret='sek')
+    client = get_entra_client(s)
+    assert client == "client:entra"
+    assert built and built[0]["client_id"] == "cid"

--- a/tests/unit/test_customers_routes.py
+++ b/tests/unit/test_customers_routes.py
@@ -1,0 +1,51 @@
+"""Regression tests for customers routes/helpers (function-coverage batch)."""
+
+from hashview.models import (
+    Customers,
+    Hashes,
+    HashfileHashes,
+    Hashfiles,
+    db,
+)
+from tests.unit.helpers import login, make_admin, make_customer
+
+
+def test_hash_type_names_maps_modes(app):
+    from hashview.customers.routes import _hash_type_names
+    names = _hash_type_names()
+    assert isinstance(names, dict)
+    # 1000 is NTLM in the form choices
+    assert "1000" in names
+
+
+def test_customers_list_renders(app, client):
+    admin = make_admin()
+    login(client, admin)
+    make_customer(name="AcmeCorp")
+    resp = client.get("/customers")
+    assert resp.status_code == 200
+    assert b"AcmeCorp" in resp.data
+
+
+def test_customers_info_renders_with_stats(app, client):
+    admin = make_admin()
+    login(client, admin)
+    cust = make_customer()
+    hf = Hashfiles(name="hf", customer_id=cust.id, owner_id=admin.id)
+    db.session.add(hf)
+    db.session.commit()
+    h = Hashes(sub_ciphertext="0" * 8, ciphertext="abc", hash_type=1000, cracked=True,
+               plaintext="pw")
+    db.session.add(h)
+    db.session.commit()
+    db.session.add(HashfileHashes(hash_id=h.id, hashfile_id=hf.id))
+    db.session.commit()
+    resp = client.get(f"/customers/{cust.id}/info")
+    assert resp.status_code == 200
+
+
+def test_customers_info_missing_returns_404(app, client):
+    admin = make_admin()
+    login(client, admin)
+    resp = client.get("/customers/999999/info")
+    assert resp.status_code == 404

--- a/tests/unit/test_jobs_routes.py
+++ b/tests/unit/test_jobs_routes.py
@@ -1,0 +1,326 @@
+"""Regression tests for jobs routes (function-coverage batch: jobs).
+
+Covers the 13 previously-uncovered jobs route handlers plus the JobsForm
+``validate_job`` validator. Behavior is asserted via status codes, redirects,
+and DB side effects against the in-memory app.
+"""
+
+import io
+
+from hashview.jobs.forms import JobsForm
+from hashview.models import (
+    Hashes,
+    HashfileHashes,
+    Hashfiles,
+    JobNotifications,
+    Jobs,
+    JobTasks,
+    Settings,
+    TaskGroups,
+    Tasks,
+    Wordlists,
+    db,
+)
+from hashview.utils.utils import ingest_static_wordlist_file
+from tests.unit.helpers import login, make_admin, make_customer
+
+
+def _job(owner, customer, status="Ready", name="j1", hashfile_id=None):
+    job = Jobs(name=name, status=status, owner_id=owner.id,
+               customer_id=customer.id, hashfile_id=hashfile_id)
+    db.session.add(job)
+    db.session.commit()
+    return job
+
+
+def _task(owner, name="t1", wl_id=None, attackmode=0):
+    t = Tasks(name=name, hc_attackmode=attackmode, owner_id=owner.id, wl_id=wl_id)
+    db.session.add(t)
+    db.session.commit()
+    return t
+
+
+def _assign(job, task, status="Not Started", priority=3):
+    jt = JobTasks(job_id=job.id, task_id=task.id, status=status, priority=priority)
+    db.session.add(jt)
+    db.session.commit()
+    return jt
+
+
+def _hashfile_with_hash(customer, owner, cracked=False):
+    hf = Hashfiles(name="hf", customer_id=customer.id, owner_id=owner.id)
+    db.session.add(hf)
+    db.session.commit()
+    h = Hashes(sub_ciphertext="0" * 8, ciphertext="abcd", hash_type=0,
+               cracked=cracked, plaintext="pw" if cracked else None)
+    db.session.add(h)
+    db.session.commit()
+    db.session.add(HashfileHashes(hash_id=h.id, hashfile_id=hf.id))
+    db.session.commit()
+    return hf, h
+
+
+def _static_wl(owner, tmp_path, content=b"a\nb\n", name="WL"):
+    src = tmp_path / (name + ".txt")
+    src.write_bytes(content)
+    wl = ingest_static_wordlist_file(str(src), owner.id, name)
+    db.session.add(wl)
+    db.session.commit()
+    return wl
+
+
+# --- list / add ------------------------------------------------------------
+
+def test_jobs_list_shows_job(app, client):
+    admin = make_admin()
+    login(client, admin)
+    cust = make_customer()
+    _job(admin, cust, name="VisibleJob")
+    resp = client.get("/jobs")
+    assert resp.status_code == 200
+    assert b"VisibleJob" in resp.data
+
+
+def test_jobs_add_get_renders(app, client):
+    admin = make_admin()
+    login(client, admin)
+    make_customer()
+    resp = client.get("/jobs/add")
+    assert resp.status_code == 200
+
+
+def test_jobs_add_post_creates_job(app, client):
+    admin = make_admin()
+    login(client, admin)
+    cust = make_customer()
+    Settings(retention_period=0, enabled_job_weights=False)  # ensure a Settings row exists
+    db.session.add(Settings(enabled_job_weights=False))
+    db.session.commit()
+    resp = client.post("/jobs/add", data={
+        "name": "BrandNewJob", "priority": "3",
+        "customer_id": str(cust.id), "submit": "Next",
+    }, follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert Jobs.query.filter_by(name="BrandNewJob").first() is not None
+
+
+# --- hashfile assignment ---------------------------------------------------
+
+def test_jobs_assigned_hashfile_get_renders(app, client):
+    admin = make_admin()
+    login(client, admin)
+    cust = make_customer()
+    _hashfile_with_hash(cust, admin)
+    job = _job(admin, cust)
+    resp = client.get(f"/jobs/{job.id}/assigned_hashfile/")
+    assert resp.status_code == 200
+
+
+def test_jobs_assigned_hashfile_select_existing(app, client):
+    admin = make_admin()
+    login(client, admin)
+    cust = make_customer()
+    hf, _ = _hashfile_with_hash(cust, admin)
+    job = _job(admin, cust)
+    resp = client.post(f"/jobs/{job.id}/assigned_hashfile/",
+                       data={"hashfile_id": str(hf.id)}, follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert Jobs.query.get(job.id).hashfile_id == hf.id
+
+
+def test_jobs_assigned_hashfile_cracked_flashes_count(app, client):
+    admin = make_admin()
+    login(client, admin)
+    cust = make_customer()
+    hf, _ = _hashfile_with_hash(cust, admin, cracked=True)
+    job = _job(admin, cust, hashfile_id=hf.id)
+    resp = client.get(f"/jobs/{job.id}/assigned_hashfile/{hf.id}",
+                      follow_redirects=True)
+    assert resp.status_code == 200
+    assert b"instacracked" in resp.data
+
+
+# --- task listing / assignment ---------------------------------------------
+
+def test_jobs_list_tasks_renders(app, client):
+    admin = make_admin()
+    login(client, admin)
+    cust = make_customer()
+    job = _job(admin, cust)
+    _task(admin, name="AvailableTask")
+    resp = client.get(f"/jobs/{job.id}/tasks")
+    assert resp.status_code == 200
+    assert b"AvailableTask" in resp.data
+
+
+def test_jobs_assign_task_creates_jobtask(app, client):
+    admin = make_admin()
+    login(client, admin)
+    cust = make_customer()
+    job = _job(admin, cust)
+    task = _task(admin)
+    resp = client.get(f"/jobs/{job.id}/assign_task/{task.id}", follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert JobTasks.query.filter_by(job_id=job.id, task_id=task.id).count() == 1
+
+
+def test_jobs_assign_task_group_creates_one_per_task(app, client):
+    import json
+    admin = make_admin()
+    login(client, admin)
+    cust = make_customer()
+    job = _job(admin, cust)
+    t1, t2 = _task(admin, name="g1"), _task(admin, name="g2")
+    tg = TaskGroups(name="grp", owner_id=admin.id,
+                    tasks=json.dumps([t1.id, t2.id]))
+    db.session.add(tg)
+    db.session.commit()
+    resp = client.get(f"/jobs/{job.id}/assign_task_group/{tg.id}", follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert JobTasks.query.filter_by(job_id=job.id).count() == 2
+
+
+# --- task reordering -------------------------------------------------------
+
+def _ordered_task_ids(job):
+    return [jt.task_id for jt in
+            JobTasks.query.filter_by(job_id=job.id).order_by(JobTasks.id).all()]
+
+
+def test_jobs_move_task_up_swaps_order(app, client):
+    admin = make_admin()
+    login(client, admin)
+    cust = make_customer()
+    job = _job(admin, cust)
+    t1, t2 = _task(admin, name="first"), _task(admin, name="second")
+    _assign(job, t1)
+    _assign(job, t2)
+    assert _ordered_task_ids(job) == [t1.id, t2.id]
+    resp = client.get(f"/jobs/{job.id}/move_task_up/{t2.id}", follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert _ordered_task_ids(job) == [t2.id, t1.id]
+
+
+def test_jobs_move_task_up_top_is_noop(app, client):
+    admin = make_admin()
+    login(client, admin)
+    cust = make_customer()
+    job = _job(admin, cust)
+    t1, t2 = _task(admin, name="first"), _task(admin, name="second")
+    _assign(job, t1)
+    _assign(job, t2)
+    client.get(f"/jobs/{job.id}/move_task_up/{t1.id}", follow_redirects=False)
+    assert _ordered_task_ids(job) == [t1.id, t2.id]
+
+
+def test_jobs_move_task_down_swaps_order(app, client):
+    admin = make_admin()
+    login(client, admin)
+    cust = make_customer()
+    job = _job(admin, cust)
+    t1, t2 = _task(admin, name="first"), _task(admin, name="second")
+    _assign(job, t1)
+    _assign(job, t2)
+    resp = client.get(f"/jobs/{job.id}/move_task_down/{t1.id}", follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert _ordered_task_ids(job) == [t2.id, t1.id]
+
+
+def test_jobs_remove_all_tasks_clears(app, client):
+    admin = make_admin()
+    login(client, admin)
+    cust = make_customer()
+    job = _job(admin, cust)
+    _assign(job, _task(admin, name="a"))
+    _assign(job, _task(admin, name="b"))
+    resp = client.get(f"/jobs/{job.id}/remove_all_tasks", follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert JobTasks.query.filter_by(job_id=job.id).count() == 0
+
+
+# --- summary / start / stop ------------------------------------------------
+
+def test_jobs_summary_renders_for_seeded_job(app, client, tmp_path):
+    admin = make_admin()
+    login(client, admin)
+    cust = make_customer()
+    hf, _ = _hashfile_with_hash(cust, admin)
+    job = _job(admin, cust, hashfile_id=hf.id)
+    wl = _static_wl(admin, tmp_path)
+    _assign(job, _task(admin, wl_id=wl.id))
+    db.session.add(Settings(enabled_job_weights=False))
+    db.session.commit()
+    resp = client.get(f"/jobs/{job.id}/summary")
+    assert resp.status_code == 200
+
+
+def test_jobs_summary_without_tasks_redirects(app, client):
+    admin = make_admin()
+    login(client, admin)
+    cust = make_customer()
+    job = _job(admin, cust)
+    resp = client.get(f"/jobs/{job.id}/summary", follow_redirects=False)
+    assert resp.status_code in (301, 302)
+
+
+def test_jobs_start_queues_job(app, client, tmp_path):
+    admin = make_admin()
+    login(client, admin)
+    cust = make_customer()
+    hf, _ = _hashfile_with_hash(cust, admin)
+    job = _job(admin, cust, status="Ready", hashfile_id=hf.id)
+    wl = _static_wl(admin, tmp_path)
+    _assign(job, _task(admin, wl_id=wl.id))
+    resp = client.get(f"/jobs/start/{job.id}", follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert Jobs.query.get(job.id).status == "Queued"
+    assert JobTasks.query.filter_by(job_id=job.id).first().status == "Queued"
+
+
+def test_jobs_stop_cancels_running_job(app, client):
+    admin = make_admin()
+    login(client, admin)
+    cust = make_customer()
+    job = _job(admin, cust, status="Running")
+    jt = _assign(job, _task(admin), status="Running")
+    resp = client.get(f"/jobs/stop/{job.id}", follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert Jobs.query.get(job.id).status == "Canceled"
+    assert JobTasks.query.get(jt.id).status == "Canceled"
+
+
+def test_jobs_stop_non_running_flashes(app, client):
+    admin = make_admin()
+    login(client, admin)
+    cust = make_customer()
+    job = _job(admin, cust, status="Ready")
+    resp = client.get(f"/jobs/stop/{job.id}", follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert Jobs.query.get(job.id).status == "Ready"
+
+
+# --- form validator --------------------------------------------------------
+
+def test_validate_job_rejects_duplicate_name(app):
+    admin = make_admin()
+    cust = make_customer()
+    _job(admin, cust, name="DupName")
+    import pytest
+    from wtforms.validators import ValidationError
+
+    class _Field:
+        data = "DupName"
+
+    form = JobsForm()
+    with pytest.raises(ValidationError):
+        form.validate_job(_Field())
+
+
+def test_validate_job_allows_unique_name(app):
+    form = JobsForm()
+
+    class _Field:
+        data = "TotallyUniqueName"
+
+    # No exception -> passes
+    assert form.validate_job(_Field()) is None

--- a/tests/unit/test_main_routes.py
+++ b/tests/unit/test_main_routes.py
@@ -1,0 +1,54 @@
+"""Regression tests for main routes (function-coverage batch: main)."""
+
+from datetime import datetime
+
+from hashview.models import (
+    Customers,
+    Hashes,
+    HashfileHashes,
+    Jobs,
+    JobTasks,
+    Tasks,
+    db,
+)
+from tests.unit.helpers import login, make_admin, make_customer
+
+
+def test_home_renders_with_recovery_feed(app, client):
+    # Seeding a cracked hash with a username drives the recovery-feed loop,
+    # which exercises the nested _hexdec helper.
+    admin = make_admin()
+    login(client, admin)
+    h = Hashes(sub_ciphertext="0" * 8, ciphertext="abc", hash_type=1000,
+               cracked=True, plaintext="Summer2024",
+               recovered_at=datetime(2024, 1, 2), recovered_by=admin.id)
+    db.session.add(h)
+    db.session.commit()
+    db.session.add(HashfileHashes(hash_id=h.id, hashfile_id=1, username="alice"))
+    db.session.commit()
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert b"Summer2024" in resp.data
+
+
+def test_stop_job_task_cancels(app, client):
+    from hashview.models import Hashfiles
+    admin = make_admin()
+    login(client, admin)
+    cust = make_customer()
+    hf = Hashfiles(name="hf", customer_id=cust.id, owner_id=admin.id, runtime=0)
+    db.session.add(hf)
+    db.session.commit()
+    job = Jobs(name="j", status="Running", customer_id=cust.id, owner_id=admin.id,
+               hashfile_id=hf.id)
+    db.session.add(job)
+    db.session.commit()
+    # update_job_task_status accrues runtime from started_at -> now, so a
+    # running task needs a started_at.
+    jt = JobTasks(job_id=job.id, task_id=1, status="Running", priority=3,
+                  started_at=datetime.utcnow())
+    db.session.add(jt)
+    db.session.commit()
+    resp = client.get(f"/job_task/stop/{jt.id}", follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert JobTasks.query.get(jt.id).status == "Canceled"

--- a/tests/unit/test_notifications_routes.py
+++ b/tests/unit/test_notifications_routes.py
@@ -1,0 +1,31 @@
+"""Regression tests for notifications routes/helpers (function-coverage batch)."""
+
+from hashview.models import (
+    Hashes,
+    HashfileHashes,
+    HashNotifications,
+    Settings,
+    db,
+)
+from tests.unit.helpers import login, make_admin
+
+
+def test_hash_type_names_maps_modes(app):
+    from hashview.notifications.routes import _hash_type_names
+    names = _hash_type_names()
+    assert isinstance(names, dict)
+    assert "1000" in names
+
+
+def test_notifications_list_renders_with_seeded_notification(app, client):
+    admin = make_admin()
+    login(client, admin)
+    db.session.add(Settings(email_enabled=True, pushover_enabled=True, slack_enabled=False))
+    h = Hashes(sub_ciphertext="0" * 8, ciphertext="abc", hash_type=1000, cracked=False)
+    db.session.add(h)
+    db.session.commit()
+    db.session.add(HashfileHashes(hash_id=h.id, hashfile_id=1, username="alice"))
+    db.session.add(HashNotifications(owner_id=admin.id, hash_id=h.id, method="email"))
+    db.session.commit()
+    resp = client.get("/notifications")
+    assert resp.status_code == 200

--- a/tests/unit/test_searches_routes.py
+++ b/tests/unit/test_searches_routes.py
@@ -1,0 +1,64 @@
+"""Regression tests for searches routes + export helpers
+(function-coverage batch: searches)."""
+
+import io
+
+from hashview.models import Customers, Hashes, HashfileHashes, Hashfiles, db
+from hashview.searches.routes import export_results, get_rows
+from tests.unit.helpers import login, make_admin
+
+
+def _seed_cracked(username="bob", plaintext="Hunter2", ciphertext="deadbeef"):
+    cust = Customers(name="SearchCo")
+    db.session.add(cust)
+    db.session.commit()
+    hf = Hashfiles(name="hf", customer_id=cust.id, owner_id=1)
+    db.session.add(hf)
+    db.session.commit()
+    h = Hashes(sub_ciphertext="0" * 8, ciphertext=ciphertext, hash_type=1000,
+               cracked=True, plaintext=plaintext)
+    db.session.add(h)
+    db.session.commit()
+    hfh = HashfileHashes(hash_id=h.id, hashfile_id=hf.id, username=username)
+    db.session.add(hfh)
+    db.session.commit()
+    return cust, hf, h, hfh
+
+
+def test_searches_list_get_renders(app, client):
+    admin = make_admin()
+    login(client, admin)
+    resp = client.get("/search")
+    assert resp.status_code == 200
+
+
+def test_searches_list_password_search_finds_match(app, client):
+    admin = make_admin()
+    login(client, admin)
+    _seed_cracked(plaintext="UniquePass1")
+    resp = client.post("/search", data={
+        "search_type": "password", "query": "UniquePass1",
+        "export_type": "Comma", "submit": "Search",
+    })
+    assert resp.status_code == 200
+    assert b"UniquePass1" in resp.data
+
+
+def test_get_rows_writes_csv(app):
+    cust, hf, h, hfh = _seed_cracked(username="carol", plaintext="pw1", ciphertext="abc123")
+    str_io = io.StringIO()
+    get_rows(str_io, [cust], [(h, hfh)], [hf], ",")
+    out = str_io.getvalue()
+    assert "SearchCo" in out
+    assert "carol" in out
+    assert "abc123" in out
+    assert "pw1" in out
+
+
+def test_export_results_returns_attachment(app):
+    cust, hf, h, hfh = _seed_cracked(ciphertext="ffee00")
+    # send_file needs a request context.
+    with app.test_request_context("/search"):
+        resp = export_results([cust], [(h, hfh)], [hf], "Colon")
+    assert resp.status_code == 200
+    assert resp.headers["Content-Disposition"].startswith("attachment")

--- a/tests/unit/test_setup_defaults.py
+++ b/tests/unit/test_setup_defaults.py
@@ -1,0 +1,135 @@
+"""Regression tests for setup defaults + first-run routes
+(function-coverage batch: setup)."""
+
+from hashview import setup as setup_mod
+from hashview.models import Rules, Settings, Tasks, Users, Wordlists, db
+from hashview.setup import (
+    add_admin_user,
+    add_default_rules,
+    add_default_static_wordlist,
+    add_default_tasks,
+    admin_pass_needs_changed,
+    admin_user_needs_added,
+    default_rules_need_added,
+    default_static_wordlist_need_added,
+    default_tasks_need_added,
+    settings_needs_added,
+)
+from hashview.users.routes import bcrypt
+
+
+# --- predicate / adder pairs -----------------------------------------------
+
+def test_default_tasks_added_once(app):
+    assert default_tasks_need_added(db) is True
+    add_default_tasks(db)
+    assert default_tasks_need_added(db) is False
+    assert Tasks.query.count() == 3
+
+
+def test_default_rules_added_once(app, monkeypatch):
+    # The real adder shells out to gzip + os.replace; stub the file work and
+    # the hash/size helpers so we exercise the DB-insert logic only.
+    monkeypatch.setattr(setup_mod.os, "system", lambda cmd: 0)
+    monkeypatch.setattr(setup_mod.os, "replace", lambda a, b: None)
+    monkeypatch.setattr(setup_mod, "get_filehash", lambda p: "0" * 64)
+    monkeypatch.setattr(setup_mod, "get_linecount", lambda p: 64)
+    assert default_rules_need_added(db) is True
+    add_default_rules(db)
+    assert default_rules_need_added(db) is False
+    assert Rules.query.filter_by(name="Best64 Rule").first() is not None
+
+
+def test_default_static_wordlist_added_once(app, monkeypatch):
+    monkeypatch.setattr(setup_mod.os, "system", lambda cmd: 0)
+    monkeypatch.setattr(setup_mod.os, "replace", lambda a, b: None)
+    monkeypatch.setattr(setup_mod, "get_filehash", lambda p: "0" * 64)
+    monkeypatch.setattr(setup_mod, "get_linecount", lambda p: 100)
+    assert default_static_wordlist_need_added(db) is True
+    add_default_static_wordlist(db)
+    assert default_static_wordlist_need_added(db) is False
+    wl = Wordlists.query.filter_by(name="Rockyou.txt").first()
+    assert wl is not None and wl.type == "static"
+
+
+def test_admin_user_added_once(app):
+    assert admin_user_needs_added(db) is True
+    add_admin_user(db, bcrypt)
+    assert admin_user_needs_added(db) is False
+    assert Users.query.filter_by(admin=True).count() == 1
+
+
+def test_admin_pass_needs_changed_detects_default(app):
+    # No user id=1 -> needs changing.
+    assert admin_pass_needs_changed(db, bcrypt) is True
+    # Seed user id=1 still on the default password -> still True.
+    add_admin_user(db, bcrypt)  # creates the default-password admin (id=1)
+    assert admin_pass_needs_changed(db, bcrypt) is True
+    # Change the password -> False.
+    user = Users.query.get(1)
+    user.password = bcrypt.generate_password_hash("a-much-better-password")
+    db.session.commit()
+    assert admin_pass_needs_changed(db, bcrypt) is False
+
+
+def test_settings_needs_added_toggles(app):
+    assert settings_needs_added(db) is True
+    db.session.add(Settings(retention_period=1, max_runtime_tasks=0, max_runtime_jobs=0))
+    db.session.commit()
+    assert settings_needs_added(db) is False
+
+
+# --- first-run routes ------------------------------------------------------
+
+def _seed_default_admin():
+    user = Users(first_name="admin", last_name="user", email_address="",
+                 password=bcrypt.generate_password_hash("hashview").decode("utf-8"),
+                 admin=True)
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+def test_admin_pass_get_renders_when_default(app, client):
+    _seed_default_admin()
+    resp = client.get("/setup/admin-pass")
+    assert resp.status_code == 200
+
+
+def test_admin_pass_post_sets_password(app, client):
+    _seed_default_admin()
+    resp = client.post("/setup/admin-pass", data={
+        "first_name": "Real", "last_name": "Admin",
+        "email_address": "real@example.com",
+        "password": "supersecurepassword", "confirm_password": "supersecurepassword",
+        "submit": "Update",
+    }, follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    user = Users.query.get(1)
+    assert user.first_name == "Real"
+    assert not bcrypt.check_password_hash(user.password, "hashview")
+
+
+def test_settings_get_renders_when_missing(app, client):
+    _seed_default_admin()
+    resp = client.get("/setup/settings")
+    assert resp.status_code == 200
+
+
+def test_settings_post_creates_settings(app, client):
+    _seed_default_admin()
+    resp = client.post("/setup/settings", data={
+        "retention_period": "30", "max_runtime_tasks": "0",
+        "max_runtime_jobs": "0", "submit": "Save",
+    }, follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    s = Settings.query.first()
+    assert s is not None and s.retention_period == 30
+
+
+def test_settings_get_redirects_when_present(app, client):
+    _seed_default_admin()
+    db.session.add(Settings(retention_period=1, max_runtime_tasks=0, max_runtime_jobs=0))
+    db.session.commit()
+    resp = client.get("/setup/settings", follow_redirects=False)
+    assert resp.status_code in (301, 302)

--- a/tests/unit/test_small_module_helpers.py
+++ b/tests/unit/test_small_module_helpers.py
@@ -1,0 +1,144 @@
+"""Regression tests for small-module helpers + routes (function-coverage batch).
+
+Covers rules._rule_ttype/rules_add, wordlists._wl_ttype/dynamicwordlist_update,
+settings._human_size + the two SettingsForm validators, and the hashfiles
+_runtime nested helper (exercised by rendering /hashfiles).
+"""
+
+import io
+
+import pytest
+from wtforms.validators import ValidationError
+
+from hashview.models import Hashfiles, Jobs, Rules, Tasks, Wordlists, db
+from tests.unit.helpers import login, make_admin, make_customer
+
+
+class _FakeTask:
+    def __init__(self, hc_attackmode, rule_id=None):
+        self.hc_attackmode = hc_attackmode
+        self.rule_id = rule_id
+
+
+# --- rules._rule_ttype / wordlists._wl_ttype --------------------------------
+
+def test_rule_ttype_labels():
+    from hashview.rules.routes import _rule_ttype
+    assert _rule_ttype(_FakeTask(0, rule_id=5)) == "DICT + RULE"
+    assert _rule_ttype(_FakeTask(0)) == "DICTIONARY"
+    assert _rule_ttype(_FakeTask(1)) == "COMBINATOR"
+    assert _rule_ttype(_FakeTask(3)) == "MASK"
+    assert _rule_ttype(_FakeTask(6)) == "HYBRID"
+    assert _rule_ttype(_FakeTask(99)) == "?"
+
+
+def test_wl_ttype_labels():
+    from hashview.wordlists.routes import _wl_ttype
+    assert _wl_ttype(_FakeTask(0, rule_id=5)) == "DICT + RULE"
+    assert _wl_ttype(_FakeTask(0)) == "DICTIONARY"
+    assert _wl_ttype(_FakeTask(7)) == "HYBRID"
+    assert _wl_ttype(_FakeTask(42)) == "?"
+
+
+# --- settings._human_size ---------------------------------------------------
+
+def test_settings_human_size():
+    from hashview.settings.routes import _human_size
+    assert _human_size(0) == "0 B"
+    assert _human_size(512) == "512 B"
+    assert _human_size(1024) == "1 KB"
+    assert _human_size(1536) == "1.5 KB"
+    assert _human_size(1024 * 1024) == "1 MB"
+
+
+# --- SettingsForm validators ------------------------------------------------
+
+def test_validate_rention_period_range(app):
+    from hashview.settings.forms import HashviewSettingsForm
+    form = HashviewSettingsForm()
+
+    class _F:
+        def __init__(self, v):
+            self.data = v
+
+    with pytest.raises(ValidationError):
+        form.validate_rention_period(_F(0))
+    with pytest.raises(ValidationError):
+        form.validate_rention_period(_F(70000))
+    assert form.validate_rention_period(_F(30)) is None
+
+
+def test_validate_max_runtime_range(app):
+    from hashview.settings.forms import HashviewSettingsForm
+    form = HashviewSettingsForm()
+    with pytest.raises(ValidationError):
+        form.validate_max_runtime(-1, 0)
+    with pytest.raises(ValidationError):
+        form.validate_max_runtime(0, 70000)
+    assert form.validate_max_runtime(5, 5) is None
+
+
+# --- rules_add (upload) -----------------------------------------------------
+
+def test_rules_add_creates_rule(app, client):
+    admin = make_admin()
+    login(client, admin)
+    resp = client.post("/rules/add", data={
+        "name": "MyRule",
+        "rules": (io.BytesIO(b":\n$1\n"), "my.rule"),
+        "submit": "upload",
+    }, content_type="multipart/form-data", follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    rule = Rules.query.filter_by(name="MyRule").first()
+    assert rule is not None
+
+
+# --- dynamicwordlist_update -------------------------------------------------
+
+def test_dynamicwordlist_update_triggers_regen(app, client, monkeypatch):
+    admin = make_admin()
+    login(client, admin)
+    wl = Wordlists(name="(DYNAMIC) All Usernames", owner_id=admin.id, type="dynamic",
+                   path="/nonexistent/dyn.txt", size=0, checksum="0" * 64)
+    db.session.add(wl)
+    db.session.commit()
+    calls = []
+    monkeypatch.setattr("hashview.wordlists.routes.update_dynamic_wordlist",
+                        lambda wid: calls.append(wid))
+    resp = client.get(f"/wordlists/update/{wl.id}", follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert calls == [wl.id]
+
+
+def test_dynamicwordlist_update_rejects_static(app, client, monkeypatch):
+    admin = make_admin()
+    login(client, admin)
+    wl = Wordlists(name="static-wl", owner_id=admin.id, type="static",
+                   path="/nonexistent/s.gz", size=1, checksum="0" * 64)
+    db.session.add(wl)
+    db.session.commit()
+    calls = []
+    monkeypatch.setattr("hashview.wordlists.routes.update_dynamic_wordlist",
+                        lambda wid: calls.append(wid))
+    resp = client.get(f"/wordlists/update/{wl.id}", follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert calls == []  # static wordlists are not regenerated
+
+
+# --- hashfiles._runtime (nested helper) -------------------------------------
+
+def test_hashfiles_list_runs_runtime_helper(app, client):
+    from datetime import datetime
+    admin = make_admin()
+    login(client, admin)
+    cust = make_customer()
+    hf = Hashfiles(name="rf", customer_id=cust.id, owner_id=admin.id)
+    db.session.add(hf)
+    db.session.commit()
+    # A job referencing this hashfile with a start time drives _runtime(j).
+    job = Jobs(name="rj", status="Running", customer_id=cust.id, owner_id=admin.id,
+               hashfile_id=hf.id, started_at=datetime(2024, 1, 1, 10, 0, 0))
+    db.session.add(job)
+    db.session.commit()
+    resp = client.get("/hashfiles")
+    assert resp.status_code == 200

--- a/tests/unit/test_task_groups_routes.py
+++ b/tests/unit/test_task_groups_routes.py
@@ -1,0 +1,111 @@
+"""Regression tests for task_groups routes + form (function-coverage batch)."""
+
+import json
+
+import pytest
+from wtforms.validators import ValidationError
+
+from hashview.models import TaskGroups, Tasks, db
+from hashview.task_groups.forms import TaskGroupsForm
+from tests.unit.helpers import login, make_admin
+
+
+def _task(owner, name="t"):
+    t = Tasks(name=name, hc_attackmode=0, owner_id=owner.id)
+    db.session.add(t)
+    db.session.commit()
+    return t
+
+
+def _group(owner, task_ids, name="grp"):
+    tg = TaskGroups(name=name, owner_id=owner.id, tasks=str(list(task_ids)))
+    db.session.add(tg)
+    db.session.commit()
+    return tg
+
+
+def test_task_groups_list_renders(app, client):
+    admin = make_admin()
+    login(client, admin)
+    t = _task(admin, "memberA")
+    _group(admin, [t.id], name="GroupShown")
+    resp = client.get("/task_groups")
+    assert resp.status_code == 200
+    assert b"GroupShown" in resp.data
+
+
+def test_task_groups_add_with_task_ids_creates_group(app, client):
+    admin = make_admin()
+    login(client, admin)
+    t1, t2 = _task(admin, "a"), _task(admin, "b")
+    resp = client.post("/task_groups/add", data={
+        "name": "NewGroup", "task_ids": f"{t1.id},{t2.id}", "submit": "Create",
+    }, follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    tg = TaskGroups.query.filter_by(name="NewGroup").first()
+    assert tg is not None
+    assert json.loads(tg.tasks) == [t1.id, t2.id]
+
+
+def test_assigned_tasks_renders(app, client):
+    admin = make_admin()
+    login(client, admin)
+    t = _task(admin, "m")
+    tg = _group(admin, [t.id])
+    resp = client.get(f"/task_groups/assigned_tasks/{tg.id}")
+    assert resp.status_code == 200
+
+
+def test_assigned_tasks_add_task_appends(app, client):
+    admin = make_admin()
+    login(client, admin)
+    t1, t2 = _task(admin, "a"), _task(admin, "b")
+    tg = _group(admin, [t1.id])
+    resp = client.get(f"/task_groups/assigned_tasks/{tg.id}/add_task/{t2.id}",
+                      follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert json.loads(TaskGroups.query.get(tg.id).tasks) == [t1.id, t2.id]
+
+
+def test_assigned_tasks_promote_task_moves_up(app, client):
+    admin = make_admin()
+    login(client, admin)
+    t1, t2 = _task(admin, "a"), _task(admin, "b")
+    tg = _group(admin, [t1.id, t2.id])
+    resp = client.get(f"/task_groups/assigned_tasks/{tg.id}/promote_task/{t2.id}",
+                      follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert json.loads(TaskGroups.query.get(tg.id).tasks) == [t2.id, t1.id]
+
+
+def test_assigned_tasks_promote_top_is_noop(app, client):
+    admin = make_admin()
+    login(client, admin)
+    t1, t2 = _task(admin, "a"), _task(admin, "b")
+    tg = _group(admin, [t1.id, t2.id])
+    client.get(f"/task_groups/assigned_tasks/{tg.id}/promote_task/{t1.id}",
+               follow_redirects=False)
+    assert json.loads(TaskGroups.query.get(tg.id).tasks) == [t1.id, t2.id]
+
+
+def test_assigned_tasks_demote_task_moves_down(app, client):
+    admin = make_admin()
+    login(client, admin)
+    t1, t2 = _task(admin, "a"), _task(admin, "b")
+    tg = _group(admin, [t1.id, t2.id])
+    resp = client.get(f"/task_groups/assigned_tasks/{tg.id}/demote_task/{t1.id}",
+                      follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert json.loads(TaskGroups.query.get(tg.id).tasks) == [t2.id, t1.id]
+
+
+def test_validate_task_rejects_duplicate(app):
+    admin = make_admin()
+    _task(admin, "TakenName")
+    form = TaskGroupsForm()
+
+    class _Field:
+        data = "TakenName"
+
+    with pytest.raises(ValidationError):
+        form.validate_task(_Field())

--- a/tests/unit/test_tasks_routes.py
+++ b/tests/unit/test_tasks_routes.py
@@ -1,0 +1,83 @@
+"""Regression tests for tasks routes + form (function-coverage batch)."""
+
+import pytest
+from wtforms.validators import ValidationError
+
+from hashview.models import Tasks, Wordlists, db
+from hashview.tasks.forms import TasksForm
+from tests.unit.helpers import login, make_admin
+
+
+def _wordlist(owner, name="wl"):
+    wl = Wordlists(name=name, owner_id=owner.id, type="static",
+                   path="/nonexistent/wl.gz", size=1, checksum="0" * 64)
+    db.session.add(wl)
+    db.session.commit()
+    return wl
+
+
+def test_human_size_formats():
+    from hashview.tasks.routes import _human_size
+    assert _human_size(0) == "0 B"
+    assert _human_size(512) == "512 B"
+    assert _human_size(1024) == "1 KB"
+    assert _human_size(1536) == "1.5 KB"
+    assert _human_size(1024 * 1024) == "1 MB"
+
+
+def test_tasks_list_renders(app, client):
+    admin = make_admin()
+    login(client, admin)
+    t = Tasks(name="ListedTask", hc_attackmode=0, owner_id=admin.id)
+    db.session.add(t)
+    db.session.commit()
+    resp = client.get("/tasks")
+    assert resp.status_code == 200
+    assert b"ListedTask" in resp.data
+
+
+def test_tasks_add_creates_straight_task(app, client):
+    admin = make_admin()
+    login(client, admin)
+    wl = _wordlist(admin)
+    # Both wordlist selects render with a chosen option in the real form, so a
+    # valid submission carries wl_id and wl_id_2 even for a straight attack.
+    resp = client.post("/tasks/add", data={
+        "name": "StraightTask", "hc_attackmode": "0",
+        "wl_id": str(wl.id), "wl_id_2": str(wl.id),
+        "rule_id": "None", "submit": "Create",
+    }, follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    task = Tasks.query.filter_by(name="StraightTask").first()
+    assert task is not None
+    assert task.hc_attackmode == 0
+    assert task.wl_id == wl.id
+    assert task.rule_id is None
+
+
+def test_tasks_add_mask_mode(app, client):
+    admin = make_admin()
+    login(client, admin)
+    wl = _wordlist(admin)
+    resp = client.post("/tasks/add", data={
+        "name": "MaskTask", "hc_attackmode": "3",
+        "wl_id": str(wl.id), "wl_id_2": str(wl.id),
+        "mask": "?d?d?d?d", "rule_id": "None", "submit": "Create",
+    }, follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    task = Tasks.query.filter_by(name="MaskTask").first()
+    assert task is not None and task.hc_attackmode == 3
+    assert task.hc_mask == "?d?d?d?d"
+
+
+def test_validate_task_rejects_duplicate(app):
+    admin = make_admin()
+    db.session.add(Tasks(name="Dup", hc_attackmode=0, owner_id=admin.id))
+    db.session.commit()
+    form = TasksForm()
+
+    class _Field:
+        data = "Dup"
+
+    with pytest.raises(ValidationError):
+        form.validate_task(_Field())

--- a/tests/unit/test_users_routes.py
+++ b/tests/unit/test_users_routes.py
@@ -1,0 +1,216 @@
+"""Regression tests for users routes and forms (function-coverage batch: users)."""
+
+import pytest
+from wtforms.validators import ValidationError
+
+from hashview.models import Users, db
+from hashview.users.forms import UsersForm
+from tests.unit.helpers import login, make_admin, make_user
+
+
+# --- _safe_next (open-redirect guard) --------------------------------------
+
+def test_safe_next_allows_relative(app):
+    from hashview.users.routes import _safe_next
+    with app.test_request_context("/profile?next=/jobs"):
+        assert _safe_next() == "/jobs"
+
+
+def test_safe_next_rejects_offsite(app):
+    from hashview.users.routes import _safe_next
+    with app.test_request_context("/profile?next=https://evil.example"):
+        assert _safe_next() != "https://evil.example"
+    with app.test_request_context("/profile?next=//evil.example"):
+        assert _safe_next() != "//evil.example"
+
+
+# --- login / logout --------------------------------------------------------
+
+def test_login_get_renders_anonymous(app, client):
+    resp = client.get("/login")
+    assert resp.status_code == 200
+
+
+def test_logout_redirects_and_clears_session(app, client):
+    admin = make_admin()
+    login(client, admin)
+    resp = client.get("/logout", follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    # protected page now bounces to login
+    resp2 = client.get("/users", follow_redirects=False)
+    assert resp2.status_code in (301, 302)
+
+
+# --- user listing / creation ------------------------------------------------
+
+def test_users_list_shows_user(app, client):
+    admin = make_admin(email="admin@example.com")
+    login(client, admin)
+    resp = client.get("/users")
+    assert resp.status_code == 200
+    assert b"admin@example.com" in resp.data
+
+
+def test_users_add_creates_user(app, client):
+    admin = make_admin()
+    login(client, admin)
+    resp = client.post("/users/add", data={
+        "first_name": "New", "last_name": "Person",
+        "email": "new@example.com", "password": "abcdefghijklmn",
+        "confirm_password": "abcdefghijklmn", "submit": "Register",
+    }, follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert Users.query.filter_by(email_address="new@example.com").first() is not None
+
+
+def test_users_add_non_admin_rejected(app, client):
+    user = make_user()
+    login(client, user)
+    resp = client.post("/users/add", data={
+        "first_name": "New", "last_name": "Person",
+        "email": "blocked@example.com", "password": "abcdefghijklmn",
+        "confirm_password": "abcdefghijklmn", "submit": "Register",
+    }, follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert Users.query.filter_by(email_address="blocked@example.com").first() is None
+
+
+# --- profile ---------------------------------------------------------------
+
+def test_profile_get_renders(app, client):
+    admin = make_admin()
+    login(client, admin)
+    resp = client.get("/profile")
+    assert resp.status_code == 200
+
+
+def test_profile_post_updates_user(app, client):
+    admin = make_admin()
+    login(client, admin)
+    resp = client.post("/profile", data={
+        "first_name": "Changed", "last_name": "Name",
+        "email": "admin@example.com", "submit": "Update",
+    }, follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert Users.query.get(admin.id).first_name == "Changed"
+
+
+# --- test-notification + api-key endpoints ---------------------------------
+
+def test_send_test_pushover_invokes_sender(app, client, monkeypatch):
+    admin = make_admin()
+    login(client, admin)
+    calls = []
+    monkeypatch.setattr("hashview.users.routes.send_pushover",
+                        lambda u, s, b: calls.append(u.id))
+    resp = client.get("/profile/send_test_pushover", follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert calls == [admin.id]
+
+
+def test_send_test_slack_invokes_sender(app, client, monkeypatch):
+    admin = make_admin()
+    login(client, admin)
+    calls = []
+    monkeypatch.setattr("hashview.users.routes.send_slack",
+                        lambda u, s, b: calls.append(u.id))
+    resp = client.get("/profile/send_test_slack", follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert calls == [admin.id]
+
+
+def test_send_test_email_success_flash(app, client, monkeypatch):
+    admin = make_admin()
+    login(client, admin)
+    monkeypatch.setattr("hashview.users.routes.send_email", lambda u, s, b: True)
+    resp = client.get("/profile/send_test_email", follow_redirects=True)
+    assert resp.status_code == 200
+    assert b"Email Sent" in resp.data
+
+
+def test_send_test_email_failure_flash(app, client, monkeypatch):
+    admin = make_admin()
+    login(client, admin)
+    monkeypatch.setattr("hashview.users.routes.send_email", lambda u, s, b: False)
+    resp = client.get("/profile/send_test_email", follow_redirects=True)
+    assert resp.status_code == 200
+    assert b"Email Failure" in resp.data
+
+
+def test_generate_api_key_sets_key(app, client):
+    admin = make_admin()
+    login(client, admin)
+    assert admin.api_key is None
+    resp = client.get("/profile/generate_api_key", follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert Users.query.get(admin.id).api_key is not None
+
+
+# --- admin reset / promote / demote ----------------------------------------
+
+def test_admin_reset_sends_email(app, client, monkeypatch):
+    admin = make_admin()
+    login(client, admin)
+    target = make_user(email="target@example.com")
+    calls = []
+    monkeypatch.setattr("hashview.users.routes.send_email",
+                        lambda u, s, b: calls.append(u.id) or True)
+    resp = client.get(f"/admin_reset_password/{target.id}", follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert calls == [target.id]
+
+
+def test_promote_user_sets_admin(app, client):
+    admin = make_admin()
+    login(client, admin)
+    target = make_user()
+    resp = client.post(f"/users/promote/{target.id}", follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert Users.query.get(target.id).admin is True
+
+
+def test_demote_user_clears_admin(app, client):
+    admin = make_admin()
+    login(client, admin)
+    target = make_admin(email="other@example.com")
+    resp = client.post(f"/users/demote/{target.id}", follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert Users.query.get(target.id).admin is False
+
+
+def test_promote_user_non_admin_forbidden(app, client):
+    user = make_user()
+    login(client, user)
+    target = make_user(email="target2@example.com")
+    resp = client.post(f"/users/promote/{target.id}", follow_redirects=False)
+    assert resp.status_code == 403
+
+
+# --- form validators --------------------------------------------------------
+
+def test_validate_email_rejects_duplicate(app):
+    make_user(email="dupe@example.com")
+    form = UsersForm()
+
+    class _Field:
+        data = "dupe@example.com"
+
+    with pytest.raises(ValidationError):
+        form.validate_email(_Field())
+
+
+def test_validate_pushover_requires_both(app):
+    form = UsersForm()
+
+    class _App:
+        data = "appid"
+
+    class _Empty:
+        data = ""
+
+    with pytest.raises(ValidationError):
+        form.validate_pushover(_App(), _Empty())
+    with pytest.raises(ValidationError):
+        form.validate_pushover(_Empty(), _App())
+    # both empty -> OK
+    assert form.validate_pushover(_Empty(), _Empty()) is None

--- a/tests/unit/test_utils_misc.py
+++ b/tests/unit/test_utils_misc.py
@@ -1,0 +1,131 @@
+"""Regression tests for utils helpers (function-coverage batch: utils).
+
+Covers the helpers that remained uncovered after the triage pass:
+save_file, send_email, send_html_email, send_pushover, getTimeFormat, and
+wordlist_import.run_import_async. External boundaries (Flask-Mail, the Pushover
+HTTP call, the import worker, threads) are mocked.
+"""
+
+import os
+
+import hashview.utils.utils as u
+import hashview.utils.wordlist_import as wi
+from hashview.models import Users, db
+
+
+def _user(**kw):
+    defaults = dict(first_name="A", last_name="B", email_address="a@e.com",
+                    password="x" * 60, admin=True)
+    defaults.update(kw)
+    user = Users(**defaults)
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+# --- getTimeFormat (pure) ---------------------------------------------------
+
+def test_get_time_format_buckets():
+    assert u.getTimeFormat(30) == "less then 1 minute"
+    assert u.getTimeFormat(120) == "2 minute(s)"
+    assert u.getTimeFormat(7200) == "2 hour(s)"
+    assert u.getTimeFormat(172800) == "2 day(s)"
+    assert u.getTimeFormat(1209600) == "2 week(s)"
+
+
+# --- save_file --------------------------------------------------------------
+
+def test_save_file_writes_and_returns_path(app):
+    class _FormFile:
+        filename = "upload.txt"
+
+        def save(self, dst):
+            with open(dst, "wb") as fh:
+                fh.write(b"data")
+
+    path = u.save_file("control/tmp", _FormFile())
+    try:
+        assert path.endswith(".txt")
+        assert os.path.exists(path)
+    finally:
+        if os.path.exists(path):
+            os.remove(path)
+
+
+# --- email helpers ----------------------------------------------------------
+
+def test_send_email_uses_mail_extension(app):
+    sent = []
+    app.extensions["mail"].send = lambda msg: sent.append(msg)
+    user = _user()
+    assert u.send_email(user, "subj", "body") is True
+    assert sent and sent[0].subject == "subj"
+    assert user.email_address in sent[0].recipients
+
+
+def test_send_email_returns_false_on_error(app):
+    def _boom(msg):
+        raise RuntimeError("smtp down")
+    app.extensions["mail"].send = _boom
+    user = _user()
+    assert u.send_email(user, "subj", "body") is False
+
+
+def test_send_html_email_sets_html_body(app):
+    sent = []
+    app.extensions["mail"].send = lambda msg: sent.append(msg)
+    user = _user()
+    u.send_html_email(user, "subj", "<b>hi</b>")
+    assert sent and sent[0].html == "<b>hi</b>"
+
+
+# --- send_pushover ----------------------------------------------------------
+
+def test_send_pushover_skips_without_keys(app, monkeypatch):
+    calls = []
+    monkeypatch.setattr(u.requests, "post", lambda *a, **kw: calls.append(a))
+    user = _user(pushover_app_id=None, pushover_user_key=None)
+    u.send_pushover(user, "s", "m")
+    assert calls == []  # no HTTP call when keys are missing
+
+
+def test_send_pushover_posts_payload(app, monkeypatch):
+    captured = {}
+
+    class _Resp:
+        status_code = 200
+
+        def json(self):
+            return {"status": 1}
+
+    def _post(url, params=None, timeout=None):
+        captured["url"] = url
+        captured["params"] = params
+        return _Resp()
+
+    monkeypatch.setattr(u.requests, "post", _post)
+    user = _user(pushover_app_id="appid", pushover_user_key="userkey")
+    u.send_pushover(user, "Title", "Message body")
+    assert "pushover.net" in captured["url"]
+    assert captured["params"]["token"] == "appid"
+    assert captured["params"]["user"] == "userkey"
+    assert captured["params"]["message"] == "Message body"
+
+
+# --- run_import_async -------------------------------------------------------
+
+def test_run_import_async_runs_within_app_context(app, monkeypatch):
+    seen = {}
+
+    def _fake_run_import(passed_app, filenames, owner_id):
+        # The body runs inside `with app.app_context()`, so this must be true.
+        from flask import has_app_context
+        seen["ctx"] = has_app_context()
+        seen["args"] = (filenames, owner_id)
+        return {"ok": True}
+
+    monkeypatch.setattr(wi, "run_import", _fake_run_import)
+    result = wi.run_import_async(app, ["a.txt"], 7)
+    assert result == {"ok": True}
+    assert seen["ctx"] is True
+    assert seen["args"] == (["a.txt"], 7)


### PR DESCRIPTION
## Summary
Brings the unit suite to **every function in `hashview/` having a regression test**, enforced by a committed coverage checker, and adds idempotent e2e DB seeding so the data-dependent e2e tests can actually run. Stacked on top of merged #191 (e2e harness repair).

## What's here

### Function coverage gate
- `tests/check_function_coverage.py` — AST + `coverage.json` checker that fails if any function in `hashview/` has zero executed body lines (migrations excluded). `tests/function_coverage_allowlist.txt` is the (empty) waiver list.
- Documented in `TESTING.md`; `pytest-cov` pinned in `requirements-dev.txt`.
- Result: **322 functions scanned, 0 zero-coverage.**

### Unit tests (540 passing)
New `tests/unit/` coverage across jobs, users, agent API protocol, setup defaults/first-run, tasks & task groups, agents/customers/notifications, utils (mail/pushover/files/async import), the app factory + Entra OAuth config, main/searches/analytics, and small-module helpers. Shared seeding/login helpers in `tests/unit/helpers.py`.

### Bug fix found while writing tests
- `hashview/utils/backup.py`: a non-MySQL deployment without the `mysql` client reported "Missing required tool(s): mysqldump" instead of the accurate "only supported for MySQL"; the backend check now runs first and `mysqldump` is only required when the dump command isn't overridden.

### Test-harness repairs
- `tests/unit/conftest.py`: session fixture creates the gitignored `control/` runtime dirs a fresh clone lacks.
- Repaired the drifted `test_wordlist_gzip_storage` agent-sim harness (`LOG` global + `_prune_orphan_files`).

### E2E DB seeding
- `tests/seed_e2e_db.py` — idempotent seeder (admin user, Settings, Customer/Hashfile/Job at the pinned IDs, plus an optional non-admin second user for the IDOR test).
- `tests/run_e2e_compose.sh` — additive, **gated** seed step: seeds when the e2e env is configured (local `.env.test`), skips cleanly in CI so data-dependent tests skip individually rather than aborting the harness.

## Test plan
- [x] `pytest tests/unit -q --cov=hashview --cov-report=json:coverage.json` → 540 passed
- [x] `python tests/check_function_coverage.py` → zero-coverage: 0 (exit 0)
- [x] e2e CI green (seed skips in CI; e2e test files are unchanged from merged #191)

## Notes
- No product behavior changes except the verified `backup.py` fix.
- The branch was rebased onto merged #191, so it carries no e2e test-file or `docker-compose.yml` changes — only the unit suite, checker, `backup.py` fix, seed script, and the additive seed block in the harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)