### PR TITLE
test: cover weak route modules (tasks, customers, jobs, scheduler)

### DIFF
--- a/tests/unit/test_customers_routes_guards.py
+++ b/tests/unit/test_customers_routes_guards.py
@@ -144,3 +144,53 @@ def test_customers_delete_happy_path_cascades_hashfiles(app, client):
     assert Customers.query.get(customer_id) is None
     assert Hashfiles.query.get(hashfile_id) is None
     assert HashfileHashes.query.filter_by(hashfile_id=hashfile_id).count() == 0
+
+
+# --------------------------------------------- customers_list / customers_info
+
+def _customer_with_hashfile(owner_id, cracked=True, name="StatsCo"):
+    customer = _make_customer(name)
+    hashfile = Hashfiles(name=f"{name}.txt", customer_id=customer.id,
+                         owner_id=owner_id)
+    db.session.add(hashfile)
+    db.session.commit()
+    h = Hashes(sub_ciphertext="c" * 32, ciphertext="d" * 32, hash_type=1000,
+               cracked=cracked, plaintext="hunter2" if cracked else None)
+    db.session.add(h)
+    db.session.commit()
+    db.session.add(HashfileHashes(hash_id=h.id, hashfile_id=hashfile.id))
+    db.session.commit()
+    return customer, hashfile
+
+
+def test_customers_list_renders_per_customer_stats(app, client):
+    admin = _admin()
+    _login(client, admin)
+    customer, _ = _customer_with_hashfile(admin.id, cracked=True)
+    db.session.add(Jobs(name="job-stats", status="Incomplete",
+                        customer_id=customer.id, owner_id=admin.id))
+    db.session.commit()
+
+    resp = client.get("/customers")
+    assert resp.status_code == 200
+    assert b"StatsCo" in resp.data
+
+
+def test_customers_info_modal_renders_stats(app, client):
+    admin = _admin()
+    _login(client, admin)
+    customer, hashfile = _customer_with_hashfile(admin.id, cracked=True)
+    db.session.add(Jobs(name="info-job", status="Incomplete",
+                        customer_id=customer.id, owner_id=admin.id))
+    db.session.commit()
+
+    resp = client.get(f"/customers/{customer.id}/info")
+    assert resp.status_code == 200
+    assert b"StatsCo.txt" in resp.data   # the hashfile is listed
+    assert b"NTLM" in resp.data          # mode 1000 reverse-mapped to a name
+
+
+def test_customers_info_missing_customer_404s(app, client):
+    _login(client, _admin())
+    resp = client.get("/customers/999999/info")
+    assert resp.status_code == 404

--- a/tests/unit/test_customers_routes_guards.py
+++ b/tests/unit/test_customers_routes_guards.py
@@ -1,0 +1,146 @@
+"""Behavior-pinning tests for the customers routes guard branches.
+
+Covers customers_add (create + duplicate-name rejection), customers_edit
+(rename + duplicate-name rejection) and customers_delete (non-admin denied,
+blocked while jobs exist, happy path including the hashfile cascade).
+"""
+
+from hashview.models import (
+    Customers,
+    HashfileHashes,
+    Hashfiles,
+    Hashes,
+    Jobs,
+    Users,
+    db,
+)
+
+
+def _admin():
+    u = Users(first_name="Ad", last_name="Min", email_address="admin@example.com",
+              password="x" * 60, admin=True)
+    db.session.add(u)
+    db.session.commit()
+    return u
+
+
+def _nonadmin():
+    u = Users(first_name="No", last_name="Body", email_address="user@example.com",
+              password="x" * 60, admin=False)
+    db.session.add(u)
+    db.session.commit()
+    return u
+
+
+def _login(client, user):
+    with client.session_transaction() as sess:
+        sess["_user_id"] = str(user.id)
+        sess["_fresh"] = True
+
+
+def _make_customer(name="Acme"):
+    c = Customers(name=name)
+    db.session.add(c)
+    db.session.commit()
+    return c
+
+
+# -------------------------------------------------------------- customers_add
+
+def test_customers_add_creates_row(app, client):
+    _login(client, _admin())
+    resp = client.post("/customers/add", data={"name": "NewCo"},
+                       follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert Customers.query.filter_by(name="NewCo").count() == 1
+
+
+def test_customers_add_duplicate_name_rejected(app, client):
+    _login(client, _admin())
+    _make_customer("DupeCo")
+    resp = client.post("/customers/add", data={"name": "DupeCo"},
+                       follow_redirects=True)
+    assert b"That customer already exists" in resp.data
+    assert Customers.query.filter_by(name="DupeCo").count() == 1  # no second row
+
+
+# ------------------------------------------------------------- customers_edit
+
+def test_customers_edit_renames(app, client):
+    _login(client, _admin())
+    customer = _make_customer("OldName")
+    resp = client.post("/customers/edit",
+                       data={"customer_id": str(customer.id), "name": "NewName"},
+                       follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert Customers.query.get(customer.id).name == "NewName"
+
+
+def test_customers_edit_duplicate_name_rejected(app, client):
+    _login(client, _admin())
+    _make_customer("TakenName")
+    customer = _make_customer("MyName")
+    resp = client.post("/customers/edit",
+                       data={"customer_id": str(customer.id), "name": "TakenName"},
+                       follow_redirects=True)
+    assert b"That customer already exists" in resp.data
+    assert Customers.query.get(customer.id).name == "MyName"  # unchanged
+
+
+def test_customers_edit_blank_name_rejected(app, client):
+    _login(client, _admin())
+    customer = _make_customer("KeepMe")
+    resp = client.post("/customers/edit",
+                       data={"customer_id": str(customer.id), "name": "   "},
+                       follow_redirects=True)
+    assert b"Customer name is required" in resp.data
+    assert Customers.query.get(customer.id).name == "KeepMe"  # unchanged
+
+
+# ----------------------------------------------------------- customers_delete
+
+def test_customers_delete_non_admin_denied(app, client):
+    _admin()
+    user = _nonadmin()
+    customer = _make_customer("Protected")
+    _login(client, user)
+
+    resp = client.post(f"/customers/delete/{customer.id}", follow_redirects=True)
+    assert b"Permission Denied" in resp.data
+    assert Customers.query.get(customer.id) is not None  # NOT deleted
+
+
+def test_customers_delete_blocked_when_job_exists(app, client):
+    admin = _admin()
+    _login(client, admin)
+    customer = _make_customer("HasJob")
+    db.session.add(Jobs(name="j1", status="Incomplete",
+                        customer_id=customer.id, owner_id=admin.id))
+    db.session.commit()
+
+    resp = client.post(f"/customers/delete/{customer.id}", follow_redirects=True)
+    assert b"Customer has active job" in resp.data
+    assert Customers.query.get(customer.id) is not None  # NOT deleted
+
+
+def test_customers_delete_happy_path_cascades_hashfiles(app, client):
+    admin = _admin()
+    _login(client, admin)
+    customer = _make_customer("GoneSoon")
+    hashfile = Hashfiles(name="hf1", customer_id=customer.id, owner_id=admin.id)
+    db.session.add(hashfile)
+    db.session.commit()
+    # a cracked hash linked through the hashfile (cracked rows are kept by design)
+    h = Hashes(sub_ciphertext="a" * 32, ciphertext="b" * 32, hash_type=1000,
+               cracked=True)
+    db.session.add(h)
+    db.session.commit()
+    db.session.add(HashfileHashes(hash_id=h.id, hashfile_id=hashfile.id))
+    db.session.commit()
+    hashfile_id, customer_id = hashfile.id, customer.id
+
+    resp = client.post(f"/customers/delete/{customer_id}", follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert Customers.query.get(customer_id) is None
+    assert Hashfiles.query.get(hashfile_id) is None
+    assert HashfileHashes.query.filter_by(hashfile_id=hashfile_id).count() == 0

--- a/tests/unit/test_jobs_routes_guards.py
+++ b/tests/unit/test_jobs_routes_guards.py
@@ -190,3 +190,419 @@ def test_jobs_assigned_hashfile_select_existing_sets_job_hashfile(app, client):
     assert resp.status_code in (301, 302)
     assert resp.headers["Location"].endswith(f"/jobs/{job.id}/notifications")
     assert int(Jobs.query.get(job.id).hashfile_id) == hf.id
+
+
+# ------------------------------------------------------ wizard / list helpers
+
+def _settings(**overrides):
+    from hashview.models import Settings
+    kwargs = dict(retention_period=30, max_runtime_jobs=0, max_runtime_tasks=0)
+    kwargs.update(overrides)
+    s = Settings(**kwargs)
+    db.session.add(s)
+    db.session.commit()
+    return s
+
+
+def _attach_hashfile(job, owner_id, cracked=False, name="hf-jobs.txt"):
+    from hashview.models import Hashes, HashfileHashes
+    hf = Hashfiles(name=name, customer_id=job.customer_id, owner_id=owner_id)
+    db.session.add(hf)
+    db.session.commit()
+    h = Hashes(sub_ciphertext="e" * 32, ciphertext="f" * 32, hash_type=1000,
+               cracked=cracked, plaintext="pw" if cracked else None)
+    db.session.add(h)
+    db.session.commit()
+    db.session.add(HashfileHashes(hash_id=h.id, hashfile_id=hf.id))
+    job.hashfile_id = hf.id
+    db.session.commit()
+    return hf, h
+
+
+# -------------------------------------------------------------------- jobs_list
+
+def test_jobs_list_renders_progress_runtime_and_filter(app, client):
+    from datetime import datetime, timedelta
+    from hashview.models import JobNotifications
+    user = _nonadmin()
+    customer = _make_customer()
+    job = _make_job(user.id, customer.id, name="listed-job")
+    _attach_hashfile(job, user.id, cracked=True)
+    job.started_at = datetime.utcnow() - timedelta(hours=2)
+    job.ended_at = datetime.utcnow()
+    db.session.add(JobNotifications(owner_id=user.id, job_id=job.id, method="email"))
+    db.session.commit()
+    _login(client, user)
+
+    resp = client.get("/jobs")
+    assert resp.status_code == 200
+    assert b"listed-job" in resp.data
+
+    resp = client.get("/jobs?show_only_mine=true")
+    assert resp.status_code == 200
+    assert b"listed-job" in resp.data
+
+
+# --------------------------------------------------------------------- jobs_add
+
+def test_jobs_add_get_renders(app, client):
+    user = _nonadmin()
+    _settings()
+    _make_customer()
+    _login(client, user)
+    resp = client.get("/jobs/add")
+    assert resp.status_code == 200
+
+
+def test_jobs_add_post_creates_job_default_priority(app, client):
+    user = _nonadmin()
+    _settings()  # enabled_job_weights defaults False -> priority forced to 3
+    customer = _make_customer()
+    _login(client, user)
+
+    resp = client.post("/jobs/add", data={
+        "name": "created-job",
+        "priority": "5",
+        "customer_id": str(customer.id),
+    }, follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    job = Jobs.query.filter_by(name="created-job").first()
+    assert job is not None
+    assert job.status == "Incomplete"
+    assert job.owner_id == user.id
+    assert int(job.customer_id) == customer.id
+    assert job.priority == 3  # weights disabled -> forced to normal
+    assert resp.headers["Location"].endswith(f"{job.id}/assigned_hashfile/")
+
+
+def test_jobs_add_post_honors_priority_when_weights_enabled(app, client):
+    user = _nonadmin()
+    _settings(enabled_job_weights=True)
+    customer = _make_customer()
+    _login(client, user)
+
+    client.post("/jobs/add", data={
+        "name": "weighted-job",
+        "priority": "5",
+        "customer_id": str(customer.id),
+    })
+    job = Jobs.query.filter_by(name="weighted-job").first()
+    assert job is not None and int(job.priority) == 5
+
+
+# ------------------------------------------- jobs_assigned_hashfile_cracked
+
+def test_jobs_assigned_hashfile_cracked_flashes_instacracks(app, client):
+    user = _nonadmin()
+    customer = _make_customer()
+    job = _make_job(user.id, customer.id)
+    hf, _ = _attach_hashfile(job, user.id, cracked=True)
+    _login(client, user)
+
+    resp = client.get(f"/jobs/{job.id}/assigned_hashfile/{hf.id}",
+                      follow_redirects=False)
+    assert resp.status_code == 200
+    assert b"instacracked" in resp.data
+
+
+# ------------------------------------------------------------ jobs_list_tasks
+
+def test_jobs_list_tasks_renders(app, client):
+    user = _nonadmin()
+    customer = _make_customer()
+    job = _make_job(user.id, customer.id)
+    _attach_hashfile(job, user.id)
+    wl = _make_wordlist(user.id)
+    task = _make_task(user.id, wl.id, name="assignable")
+    _login(client, user)
+
+    resp = client.get(f"/jobs/{job.id}/tasks")
+    assert resp.status_code == 200
+    assert b"assignable" in resp.data
+
+
+# ------------------------------------------------------- jobs_assign_task_group
+
+def test_jobs_assign_task_group_assigns_all_and_skips_static_dupes(app, client):
+    import json as _json
+    from hashview.models import TaskGroups
+    user = _nonadmin()
+    customer = _make_customer()
+    job = _make_job(user.id, customer.id)
+    wl = _make_wordlist(user.id, wl_type="static")
+    t1 = _make_task(user.id, wl.id, name="tg-task-1")
+    t2 = _make_task(user.id, wl.id, name="tg-task-2")
+    tg = TaskGroups(name="group-1", owner_id=user.id,
+                    tasks=_json.dumps([str(t1.id), str(t2.id)]))
+    db.session.add(tg)
+    db.session.commit()
+    _login(client, user)
+
+    resp = client.get(f"/jobs/{job.id}/assign_task_group/{tg.id}",
+                      follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert JobTasks.query.filter_by(job_id=job.id).count() == 2
+
+    # re-assigning the group: static-wordlist tasks are not duplicated
+    client.get(f"/jobs/{job.id}/assign_task_group/{tg.id}")
+    assert JobTasks.query.filter_by(job_id=job.id).count() == 2
+
+
+# ------------------------------------------------- jobs_move_task_up / _down
+
+def _job_with_two_tasks(user):
+    customer = _make_customer()
+    job = _make_job(user.id, customer.id)
+    wl = _make_wordlist(user.id)
+    t1 = _make_task(user.id, wl.id, name="order-1")
+    t2 = _make_task(user.id, wl.id, name="order-2")
+    db.session.add(JobTasks(job_id=job.id, task_id=t1.id, status="Not Started"))
+    db.session.add(JobTasks(job_id=job.id, task_id=t2.id, status="Not Started"))
+    db.session.commit()
+    return job, t1, t2
+
+
+def _task_order(job_id):
+    return [jt.task_id for jt in
+            JobTasks.query.filter_by(job_id=job_id).order_by(JobTasks.id).all()]
+
+
+def test_jobs_move_task_up_swaps_order(app, client):
+    user = _nonadmin()
+    job, t1, t2 = _job_with_two_tasks(user)
+    _login(client, user)
+
+    resp = client.get(f"/jobs/{job.id}/move_task_up/{t2.id}",
+                      follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert _task_order(job.id) == [t2.id, t1.id]
+
+
+def test_jobs_move_task_up_already_top_warns(app, client):
+    user = _nonadmin()
+    job, t1, t2 = _job_with_two_tasks(user)
+    _login(client, user)
+
+    resp = client.get(f"/jobs/{job.id}/move_task_up/{t1.id}",
+                      follow_redirects=True)
+    assert b"already at the top" in resp.data
+    assert _task_order(job.id) == [t1.id, t2.id]  # unchanged
+
+
+def test_jobs_move_task_down_swaps_order(app, client):
+    user = _nonadmin()
+    job, t1, t2 = _job_with_two_tasks(user)
+    _login(client, user)
+
+    resp = client.get(f"/jobs/{job.id}/move_task_down/{t1.id}",
+                      follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert _task_order(job.id) == [t2.id, t1.id]
+
+
+def test_jobs_move_task_down_already_bottom_warns(app, client):
+    user = _nonadmin()
+    job, t1, t2 = _job_with_two_tasks(user)
+    _login(client, user)
+
+    resp = client.get(f"/jobs/{job.id}/move_task_down/{t2.id}",
+                      follow_redirects=True)
+    assert b"already at the bottom" in resp.data
+    assert _task_order(job.id) == [t1.id, t2.id]  # unchanged
+
+
+# ---------------------------------------------------- notifications wizard step
+
+def test_jobs_notifications_get_renders(app, client):
+    user = _nonadmin()
+    _settings()
+    customer = _make_customer()
+    job = _make_job(user.id, customer.id)
+    _login(client, user)
+
+    resp = client.get(f"/jobs/{job.id}/notifications")
+    assert resp.status_code == 200
+
+
+def test_jobs_notifications_post_creates_job_notifications_once(app, client):
+    from hashview.models import JobNotifications
+    user = _nonadmin()
+    _settings()
+    customer = _make_customer()
+    job = _make_job(user.id, customer.id)
+    _login(client, user)
+
+    data = {"job_completion_email": "y", "job_completion_pushover": "y"}
+    resp = client.post(f"/jobs/{job.id}/notifications", data=data,
+                       follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert resp.headers["Location"].endswith(f"/jobs/{job.id}/tasks")
+    assert JobNotifications.query.filter_by(job_id=job.id, method="email").count() == 1
+    assert JobNotifications.query.filter_by(job_id=job.id, method="push").count() == 1
+
+    # idempotent: posting again does not duplicate rows
+    client.post(f"/jobs/{job.id}/notifications", data=data)
+    assert JobNotifications.query.filter_by(job_id=job.id).count() == 2
+
+
+def test_jobs_notifications_post_hash_methods_redirects_to_hash_picker(app, client):
+    user = _nonadmin()
+    _settings()
+    customer = _make_customer()
+    job = _make_job(user.id, customer.id)
+    _login(client, user)
+
+    resp = client.post(f"/jobs/{job.id}/notifications",
+                       data={"hash_completion_email": "y",
+                             "hash_completion_pushover": "y"},
+                       follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert resp.headers["Location"].endswith(
+        f"/jobs/{job.id}/notifications/email,push/hashes")
+
+
+def test_jobs_assign_notification_hashes_post_creates_rows(app, client):
+    from hashview.models import HashNotifications
+    user = _nonadmin()
+    customer = _make_customer()
+    job = _make_job(user.id, customer.id)
+    _, h = _attach_hashfile(job, user.id, cracked=False)
+    _login(client, user)
+
+    resp = client.post(f"/jobs/{job.id}/notifications/email/hashes",
+                       data={"selected": [str(h.id)]},
+                       follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert HashNotifications.query.filter_by(
+        hash_id=h.id, owner_id=user.id, method="email").count() == 1
+
+    # repeat POST does not duplicate the (hash, channel) pairing
+    client.post(f"/jobs/{job.id}/notifications/email/hashes",
+                data={"selected": [str(h.id)]})
+    assert HashNotifications.query.filter_by(hash_id=h.id, method="email").count() == 1
+
+
+# ------------------------------------------------------------------ jobs_summary
+
+def _full_wizard_job(user, status="Incomplete"):
+    customer = _make_customer()
+    job = _make_job(user.id, customer.id, status=status)
+    _attach_hashfile(job, user.id)
+    wl = _make_wordlist(user.id)
+    task = _make_task(user.id, wl.id, name="wizard-task")
+    jt = JobTasks(job_id=job.id, task_id=task.id, status="Not Started")
+    db.session.add(jt)
+    db.session.commit()
+    return job, task, jt
+
+
+def test_jobs_summary_redirects_when_no_tasks(app, client):
+    user = _nonadmin()
+    _settings()
+    customer = _make_customer()
+    job = _make_job(user.id, customer.id)
+    _login(client, user)
+
+    resp = client.get(f"/jobs/{job.id}/summary", follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert resp.headers["Location"].endswith(f"/jobs/{job.id}/tasks")
+
+
+def test_jobs_summary_get_renders(app, client):
+    user = _nonadmin()
+    _settings()
+    job, task, _ = _full_wizard_job(user)
+    _login(client, user)
+
+    resp = client.get(f"/jobs/{job.id}/summary")
+    assert resp.status_code == 200
+    assert b"wizard-task" in resp.data
+
+
+def test_jobs_summary_post_queues_job_and_tasks(app, client):
+    user = _nonadmin()
+    _settings()
+    job, task, jt = _full_wizard_job(user)
+    _login(client, user)
+
+    resp = client.post(f"/jobs/{job.id}/summary", data={"submit": "Create & Queue Job"},
+                       follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    db.session.expire_all()
+    job = Jobs.query.get(job.id)
+    jt = JobTasks.query.filter_by(job_id=job.id).first()
+    assert job.status == "Queued"
+    assert job.queued_at is not None
+    assert jt.status == "Queued"
+    assert jt.command  # hashcat command pre-built for the agent
+
+
+# --------------------------------------------------------- jobs_start / stop
+
+def test_jobs_start_owner_queues(app, client):
+    user = _nonadmin()
+    job, task, jt = _full_wizard_job(user)
+    _login(client, user)
+
+    resp = client.get(f"/jobs/start/{job.id}", follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    db.session.expire_all()
+    assert Jobs.query.get(job.id).status == "Queued"
+    assert JobTasks.query.filter_by(job_id=job.id).first().status == "Queued"
+
+
+def test_jobs_start_non_owner_denied(app, client):
+    admin = _admin()
+    user = _nonadmin()
+    job, task, jt = _full_wizard_job(admin)
+    _login(client, user)
+
+    resp = client.get(f"/jobs/start/{job.id}", follow_redirects=True)
+    assert b"do not have rights to start this job" in resp.data
+    assert Jobs.query.get(job.id).status == "Incomplete"  # unchanged
+
+
+def test_jobs_start_without_tasks_errors(app, client):
+    user = _nonadmin()
+    customer = _make_customer()
+    job = _make_job(user.id, customer.id)
+    _login(client, user)
+
+    resp = client.get(f"/jobs/start/{job.id}", follow_redirects=True)
+    assert b"Error in starting job" in resp.data
+
+
+def test_jobs_stop_running_job_cancels(app, client):
+    user = _nonadmin()
+    job, task, jt = _full_wizard_job(user, status="Running")
+    jt.status = "Running"
+    db.session.commit()
+    _login(client, user)
+
+    resp = client.get(f"/jobs/stop/{job.id}", follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    db.session.expire_all()
+    assert Jobs.query.get(job.id).status == "Canceled"
+    assert Jobs.query.get(job.id).ended_at is not None
+    assert JobTasks.query.filter_by(job_id=job.id).first().status == "Canceled"
+
+
+def test_jobs_stop_not_running_flashes(app, client):
+    user = _nonadmin()
+    job, task, jt = _full_wizard_job(user, status="Incomplete")
+    _login(client, user)
+
+    resp = client.get(f"/jobs/stop/{job.id}", follow_redirects=True)
+    assert b"not activly running" in resp.data
+    assert Jobs.query.get(job.id).status == "Incomplete"  # unchanged
+
+
+def test_jobs_stop_non_owner_denied(app, client):
+    admin = _admin()
+    user = _nonadmin()
+    job, task, jt = _full_wizard_job(admin, status="Running")
+    _login(client, user)
+
+    resp = client.get(f"/jobs/stop/{job.id}", follow_redirects=True)
+    assert b"do not have rights to stop this job" in resp.data
+    assert Jobs.query.get(job.id).status == "Running"  # unchanged

--- a/tests/unit/test_jobs_routes_guards.py
+++ b/tests/unit/test_jobs_routes_guards.py
@@ -1,0 +1,192 @@
+"""Behavior-pinning tests for the jobs routes guard branches.
+
+Covers jobs_delete (owner cascade + non-owner denied), the
+jobs_assign_task / jobs_remove_task round trip (including duplicate-assign
+behavior for static vs dynamic wordlists) and the jobs_assigned_hashfile GET
+view (own hashfiles listed, another customer's hashfiles not offered).
+"""
+
+from hashview.models import (
+    Customers,
+    Hashfiles,
+    Jobs,
+    JobTasks,
+    Tasks,
+    Users,
+    Wordlists,
+    db,
+)
+
+
+def _admin():
+    u = Users(first_name="Ad", last_name="Min", email_address="admin@example.com",
+              password="x" * 60, admin=True)
+    db.session.add(u)
+    db.session.commit()
+    return u
+
+
+def _nonadmin():
+    u = Users(first_name="No", last_name="Body", email_address="user@example.com",
+              password="x" * 60, admin=False)
+    db.session.add(u)
+    db.session.commit()
+    return u
+
+
+def _login(client, user):
+    with client.session_transaction() as sess:
+        sess["_user_id"] = str(user.id)
+        sess["_fresh"] = True
+
+
+def _make_customer(name="Acme"):
+    c = Customers(name=name)
+    db.session.add(c)
+    db.session.commit()
+    return c
+
+
+def _make_job(owner_id, customer_id, name="job-guards", status="Incomplete"):
+    job = Jobs(name=name, status=status, customer_id=customer_id,
+               owner_id=owner_id)
+    db.session.add(job)
+    db.session.commit()
+    return job
+
+
+def _make_wordlist(owner_id, name="wl-jobs", wl_type="static"):
+    wl = Wordlists(name=name, owner_id=owner_id, type=wl_type,
+                   path=f"control/wordlists/{name}.gz", size=10,
+                   checksum="0" * 64)
+    db.session.add(wl)
+    db.session.commit()
+    return wl
+
+
+def _make_task(owner_id, wl_id, name="task-jobs"):
+    task = Tasks(name=name, owner_id=owner_id, wl_id=wl_id, rule_id=None,
+                 hc_attackmode=0, loopback=False)
+    db.session.add(task)
+    db.session.commit()
+    return task
+
+
+# ----------------------------------------------------------------- jobs_delete
+
+def test_jobs_delete_owner_cascades_jobtasks(app, client):
+    user = _nonadmin()
+    customer = _make_customer()
+    job = _make_job(user.id, customer.id)
+    wl = _make_wordlist(user.id)
+    task = _make_task(user.id, wl.id)
+    db.session.add(JobTasks(job_id=job.id, task_id=task.id, status="Not Started"))
+    db.session.commit()
+    job_id = job.id
+    _login(client, user)
+
+    resp = client.post(f"/jobs/delete/{job_id}", follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert Jobs.query.get(job_id) is None
+    assert JobTasks.query.filter_by(job_id=job_id).count() == 0  # cascaded
+
+
+def test_jobs_delete_non_owner_denied(app, client):
+    admin = _admin()
+    user = _nonadmin()
+    customer = _make_customer()
+    job = _make_job(admin.id, customer.id)
+    _login(client, user)
+
+    resp = client.post(f"/jobs/delete/{job.id}", follow_redirects=True)
+    assert b"do not have rights to delete this job" in resp.data
+    assert Jobs.query.get(job.id) is not None  # NOT deleted
+
+
+# --------------------------------------------- jobs_assign_task / remove_task
+
+def test_jobs_assign_then_remove_task_round_trip(app, client):
+    user = _nonadmin()
+    customer = _make_customer()
+    job = _make_job(user.id, customer.id)
+    wl = _make_wordlist(user.id)
+    task = _make_task(user.id, wl.id)
+    _login(client, user)
+
+    resp = client.get(f"/jobs/{job.id}/assign_task/{task.id}",
+                      follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert JobTasks.query.filter_by(job_id=job.id, task_id=task.id).count() == 1
+
+    resp = client.get(f"/jobs/{job.id}/remove_task/{task.id}",
+                      follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert JobTasks.query.filter_by(job_id=job.id, task_id=task.id).count() == 0
+
+
+def test_jobs_assign_duplicate_static_wordlist_task_rejected(app, client):
+    user = _nonadmin()
+    customer = _make_customer()
+    job = _make_job(user.id, customer.id)
+    wl = _make_wordlist(user.id, wl_type="static")
+    task = _make_task(user.id, wl.id)
+    _login(client, user)
+
+    client.get(f"/jobs/{job.id}/assign_task/{task.id}")
+    resp = client.get(f"/jobs/{job.id}/assign_task/{task.id}",
+                      follow_redirects=True)
+    assert b"Task already assigned to the job." in resp.data
+    assert JobTasks.query.filter_by(job_id=job.id, task_id=task.id).count() == 1
+
+
+def test_jobs_assign_duplicate_dynamic_wordlist_task_allowed(app, client):
+    # Tasks whose wordlist is dynamic may be assigned repeatedly (the wordlist
+    # content changes between runs).
+    user = _nonadmin()
+    customer = _make_customer()
+    job = _make_job(user.id, customer.id)
+    wl = _make_wordlist(user.id, name="wl-dyn", wl_type="dynamic")
+    task = _make_task(user.id, wl.id)
+    _login(client, user)
+
+    client.get(f"/jobs/{job.id}/assign_task/{task.id}")
+    client.get(f"/jobs/{job.id}/assign_task/{task.id}")
+    assert JobTasks.query.filter_by(job_id=job.id, task_id=task.id).count() == 2
+
+
+# ------------------------------------------------------ jobs_assigned_hashfile
+
+def test_jobs_assigned_hashfile_lists_own_customers_hashfiles_only(app, client):
+    user = _nonadmin()
+    customer = _make_customer("Mine")
+    other_customer = _make_customer("Theirs")
+    job = _make_job(user.id, customer.id)
+    own_hf = Hashfiles(name="own-hashfile.txt", customer_id=customer.id,
+                       owner_id=user.id)
+    foreign_hf = Hashfiles(name="foreign-hashfile.txt",
+                           customer_id=other_customer.id, owner_id=user.id)
+    db.session.add_all([own_hf, foreign_hf])
+    db.session.commit()
+    _login(client, user)
+
+    resp = client.get(f"/jobs/{job.id}/assigned_hashfile/")
+    assert resp.status_code == 200
+    assert b"own-hashfile.txt" in resp.data           # offered
+    assert b"foreign-hashfile.txt" not in resp.data   # other customer's: not offered
+
+
+def test_jobs_assigned_hashfile_select_existing_sets_job_hashfile(app, client):
+    user = _nonadmin()
+    customer = _make_customer()
+    job = _make_job(user.id, customer.id)
+    hf = Hashfiles(name="picked.txt", customer_id=customer.id, owner_id=user.id)
+    db.session.add(hf)
+    db.session.commit()
+    _login(client, user)
+
+    resp = client.post(f"/jobs/{job.id}/assigned_hashfile/",
+                       data={"hashfile_id": str(hf.id)},
+                       follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert resp.headers["Location"].endswith(f"/jobs/{job.id}/notifications")
+    assert int(Jobs.query.get(job.id).hashfile_id) == hf.id

--- a/tests/unit/test_scheduler_retention_inner.py
+++ b/tests/unit/test_scheduler_retention_inner.py
@@ -1,0 +1,176 @@
+"""Direct tests for hashview.scheduler._data_retention_cleanup_inner.
+
+The outer data_retention_cleanup wrapper swallows exceptions; these tests call
+the inner function directly so failures surface, and pin the three behaviors:
+aged rows are purged, the retention_period setting is honored, and a run with
+nothing aged is a no-op (including the control/tmp file reaping rules).
+"""
+
+import os
+import time
+from datetime import datetime, timedelta
+
+from hashview.models import (
+    Customers,
+    Hashes,
+    HashfileHashes,
+    Hashfiles,
+    JobNotifications,
+    Jobs,
+    JobTasks,
+    Settings,
+    Users,
+    db,
+)
+from hashview.scheduler import _data_retention_cleanup_inner
+
+
+def _admin():
+    u = Users(first_name="Ad", last_name="Min", email_address="admin@example.com",
+              password="x" * 60, admin=True)
+    db.session.add(u)
+    db.session.commit()
+    return u
+
+
+def _settings(retention_period=30):
+    s = Settings(retention_period=retention_period, max_runtime_jobs=0,
+                 max_runtime_tasks=0)
+    db.session.add(s)
+    db.session.commit()
+    return s
+
+
+def _setup_tmp(tmp_path, monkeypatch):
+    """The cleanup reaps control/tmp via the relative path
+    'hashview/control/tmp'; chdir to a temp dir with a stand-in so the test
+    never touches the real control/tmp."""
+    monkeypatch.chdir(tmp_path)
+    tmp_dir = tmp_path / "hashview" / "control" / "tmp"
+    os.makedirs(tmp_dir)
+    return tmp_dir
+
+
+def _run_inner(app):
+    _data_retention_cleanup_inner(db, app.extensions["mail"], app.logger)
+
+
+def test_inner_purges_aged_job_and_hashfile_rows(app, tmp_path, monkeypatch):
+    _setup_tmp(tmp_path, monkeypatch)
+    _settings(retention_period=30)
+    admin = _admin()
+    cust = Customers(name="Acme")
+    db.session.add(cust)
+    db.session.commit()
+
+    aged = datetime.utcnow() - timedelta(days=90)
+
+    # aged job with a job task + job notification
+    job = Jobs(name="old-job", status="Completed", customer_id=cust.id,
+               owner_id=admin.id, created_at=aged)
+    db.session.add(job)
+    db.session.commit()
+    db.session.add(JobTasks(job_id=job.id, task_id=1, status="Not Started"))
+    db.session.add(JobNotifications(owner_id=admin.id, job_id=job.id, method="email"))
+
+    # aged hashfile with an uncracked, unshared hash
+    hashfile = Hashfiles(name="old.txt", customer_id=cust.id, owner_id=admin.id,
+                         uploaded_at=aged)
+    db.session.add(hashfile)
+    db.session.commit()
+    h = Hashes(sub_ciphertext="a" * 32, ciphertext="b" * 32, hash_type=1000,
+               cracked=False)
+    db.session.add(h)
+    db.session.commit()
+    db.session.add(HashfileHashes(hash_id=h.id, hashfile_id=hashfile.id))
+    db.session.commit()
+    job_id, hashfile_id, hash_id = job.id, hashfile.id, h.id
+
+    _run_inner(app)
+    db.session.expire_all()
+
+    assert Jobs.query.get(job_id) is None
+    assert JobTasks.query.filter_by(job_id=job_id).count() == 0
+    assert JobNotifications.query.filter_by(job_id=job_id).count() == 0
+    assert Hashfiles.query.get(hashfile_id) is None
+    assert HashfileHashes.query.filter_by(hashfile_id=hashfile_id).count() == 0
+    assert Hashes.query.get(hash_id) is None  # uncracked + unshared -> purged
+
+
+def test_inner_respects_retention_period_setting(app, tmp_path, monkeypatch):
+    _setup_tmp(tmp_path, monkeypatch)
+    _settings(retention_period=100)  # window wider than the rows' age
+    admin = _admin()
+    cust = Customers(name="Acme")
+    db.session.add(cust)
+    db.session.commit()
+
+    aged_90 = datetime.utcnow() - timedelta(days=90)
+    job = Jobs(name="90day-job", status="Completed", customer_id=cust.id,
+               owner_id=admin.id, created_at=aged_90)
+    hashfile = Hashfiles(name="90day.txt", customer_id=cust.id,
+                         owner_id=admin.id, uploaded_at=aged_90)
+    db.session.add_all([job, hashfile])
+    db.session.commit()
+    job_id, hashfile_id = job.id, hashfile.id
+
+    _run_inner(app)
+    db.session.expire_all()
+
+    # 90 days old but the retention window is 100 days -> kept
+    assert Jobs.query.get(job_id) is not None
+    assert Hashfiles.query.get(hashfile_id) is not None
+
+
+def test_inner_noop_when_nothing_aged(app, tmp_path, monkeypatch):
+    tmp_dir = _setup_tmp(tmp_path, monkeypatch)
+    _settings(retention_period=30)
+    admin = _admin()
+    cust = Customers(name="Acme")
+    db.session.add(cust)
+    db.session.commit()
+
+    job = Jobs(name="fresh-job", status="Completed", customer_id=cust.id,
+               owner_id=admin.id, created_at=datetime.utcnow())
+    hashfile = Hashfiles(name="fresh.txt", customer_id=cust.id,
+                         owner_id=admin.id, uploaded_at=datetime.utcnow())
+    db.session.add_all([job, hashfile])
+    db.session.commit()
+    job_id, hashfile_id = job.id, hashfile.id
+
+    fresh_file = tmp_dir / "fresh-upload"
+    fresh_file.write_text("data")
+
+    _run_inner(app)
+    db.session.expire_all()
+
+    assert Jobs.query.get(job_id) is not None
+    assert Hashfiles.query.get(hashfile_id) is not None
+    assert fresh_file.exists()  # within retention window -> left alone
+
+
+def test_inner_reaps_tmp_files_by_age_and_keeps_gitignore(app, tmp_path, monkeypatch):
+    tmp_dir = _setup_tmp(tmp_path, monkeypatch)
+    _settings(retention_period=30)
+
+    old_file = tmp_dir / "stale-upload"
+    old_file.write_text("old")
+    stale = time.time() - 40 * 86400
+    os.utime(old_file, (stale, stale))
+
+    gitignore = tmp_dir / ".gitignore"
+    gitignore.write_text("*")
+    os.utime(gitignore, (stale, stale))
+
+    # one-time DB backups are reaped after an hour regardless of the
+    # (day-granular) retention period
+    backup = tmp_dir / "backup.sql.gz.enc"
+    backup.write_text("enc")
+    two_hours_ago = time.time() - 7200
+    os.utime(backup, (two_hours_ago, two_hours_ago))
+
+    _run_inner(app)
+
+    assert not old_file.exists()       # past retention window -> removed
+    assert gitignore.exists()          # always kept
+    assert not backup.exists()         # backups reaped within the hour

--- a/tests/unit/test_scheduler_retention_inner.py
+++ b/tests/unit/test_scheduler_retention_inner.py
@@ -19,6 +19,7 @@ from hashview.models import (
     Jobs,
     JobTasks,
     Settings,
+    Tasks,
     Users,
     db,
 )
@@ -31,6 +32,14 @@ def _admin():
     db.session.add(u)
     db.session.commit()
     return u
+
+
+def _make_task(owner_id, name="task-retention"):
+    task = Tasks(name=name, owner_id=owner_id, wl_id=None, rule_id=None,
+                 hc_attackmode=0, loopback=False)
+    db.session.add(task)
+    db.session.commit()
+    return task
 
 
 def _settings(retention_period=30):
@@ -70,7 +79,8 @@ def test_inner_purges_aged_job_and_hashfile_rows(app, tmp_path, monkeypatch):
                owner_id=admin.id, created_at=aged)
     db.session.add(job)
     db.session.commit()
-    db.session.add(JobTasks(job_id=job.id, task_id=1, status="Not Started"))
+    task = _make_task(admin.id, name="task-aged-job")
+    db.session.add(JobTasks(job_id=job.id, task_id=task.id, status="Not Started"))
     db.session.add(JobNotifications(owner_id=admin.id, job_id=job.id, method="email"))
 
     # aged hashfile with an uncracked, unshared hash
@@ -194,7 +204,8 @@ def test_inner_purges_job_referencing_aged_hashfile(app, tmp_path, monkeypatch):
                hashfile_id=hashfile.id)
     db.session.add(job)
     db.session.commit()
-    db.session.add(JobTasks(job_id=job.id, task_id=1, status="Not Started"))
+    task = _make_task(admin.id, name="task-doomed-job")
+    db.session.add(JobTasks(job_id=job.id, task_id=task.id, status="Not Started"))
     db.session.add(JobNotifications(owner_id=admin.id, job_id=job.id, method="email"))
     db.session.commit()
     job_id, hashfile_id = job.id, hashfile.id

--- a/tests/unit/test_scheduler_retention_inner.py
+++ b/tests/unit/test_scheduler_retention_inner.py
@@ -174,3 +174,43 @@ def test_inner_reaps_tmp_files_by_age_and_keeps_gitignore(app, tmp_path, monkeyp
     assert not old_file.exists()       # past retention window -> removed
     assert gitignore.exists()          # always kept
     assert not backup.exists()         # backups reaped within the hour
+
+
+def test_inner_purges_job_referencing_aged_hashfile(app, tmp_path, monkeypatch):
+    # A *fresh* job that references an aged hashfile is deleted along with it.
+    _setup_tmp(tmp_path, monkeypatch)
+    _settings(retention_period=30)
+    admin = _admin()
+    cust = Customers(name="Acme")
+    db.session.add(cust)
+    db.session.commit()
+
+    hashfile = Hashfiles(name="aged.txt", customer_id=cust.id, owner_id=admin.id,
+                         uploaded_at=datetime.utcnow() - timedelta(days=90))
+    db.session.add(hashfile)
+    db.session.commit()
+    job = Jobs(name="fresh-but-doomed", status="Completed", customer_id=cust.id,
+               owner_id=admin.id, created_at=datetime.utcnow(),
+               hashfile_id=hashfile.id)
+    db.session.add(job)
+    db.session.commit()
+    db.session.add(JobTasks(job_id=job.id, task_id=1, status="Not Started"))
+    db.session.add(JobNotifications(owner_id=admin.id, job_id=job.id, method="email"))
+    db.session.commit()
+    job_id, hashfile_id = job.id, hashfile.id
+
+    _run_inner(app)
+    db.session.expire_all()
+
+    assert Hashfiles.query.get(hashfile_id) is None
+    assert Jobs.query.get(job_id) is None  # cascaded via the hashfile branch
+    assert JobTasks.query.filter_by(job_id=job_id).count() == 0
+    assert JobNotifications.query.filter_by(job_id=job_id).count() == 0
+
+
+def test_outer_wrapper_swallows_failures(app, tmp_path, monkeypatch):
+    # No Settings row -> the inner function raises; the scheduled-job wrapper
+    # must swallow it (log + continue) rather than crash the scheduler thread.
+    from hashview.scheduler import data_retention_cleanup
+    _setup_tmp(tmp_path, monkeypatch)
+    data_retention_cleanup(app)  # must not raise

--- a/tests/unit/test_tasks_routes_guards.py
+++ b/tests/unit/test_tasks_routes_guards.py
@@ -1,0 +1,208 @@
+"""Behavior-pinning tests for the tasks routes guard branches.
+
+Covers tasks_delete (job / task-group association blocks, ownership check,
+happy path), task_edit (job-association block, ownership check, successful
+edit) and tasks_add (attack mode 0 with and without a rule).
+"""
+
+from hashview.models import JobTasks, Rules, TaskGroups, Tasks, Users, Wordlists, db
+
+
+def _admin():
+    u = Users(first_name="Ad", last_name="Min", email_address="admin@example.com",
+              password="x" * 60, admin=True)
+    db.session.add(u)
+    db.session.commit()
+    return u
+
+
+def _nonadmin():
+    u = Users(first_name="No", last_name="Body", email_address="user@example.com",
+              password="x" * 60, admin=False)
+    db.session.add(u)
+    db.session.commit()
+    return u
+
+
+def _login(client, user):
+    with client.session_transaction() as sess:
+        sess["_user_id"] = str(user.id)
+        sess["_fresh"] = True
+
+
+def _make_wordlist(owner_id, name="wl-guards"):
+    wl = Wordlists(name=name, owner_id=owner_id, type="static",
+                   path="control/wordlists/wl-guards.gz", size=10,
+                   checksum="0" * 64)
+    db.session.add(wl)
+    db.session.commit()
+    return wl
+
+
+def _make_rule(owner_id, name="rule-guards"):
+    rule = Rules(name=name, owner_id=owner_id, path="control/rules/rg.rule",
+                 checksum="1" * 64, size=1)
+    db.session.add(rule)
+    db.session.commit()
+    return rule
+
+
+def _make_task(owner_id, name="task-guards", wl_id=None):
+    task = Tasks(name=name, owner_id=owner_id, wl_id=wl_id, rule_id=None,
+                 hc_attackmode=0, loopback=False)
+    db.session.add(task)
+    db.session.commit()
+    return task
+
+
+# ---------------------------------------------------------------- tasks_delete
+
+def test_tasks_delete_blocked_when_assigned_to_job(app, client):
+    admin = _admin()
+    _login(client, admin)
+    task = _make_task(admin.id)
+    db.session.add(JobTasks(job_id=1, task_id=task.id, status="Not Started"))
+    db.session.commit()
+
+    resp = client.post(f"/tasks/delete/{task.id}", follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert Tasks.query.get(task.id) is not None  # NOT deleted
+
+    follow = client.post(f"/tasks/delete/{task.id}", follow_redirects=True)
+    assert b"associated to one or more jobs" in follow.data
+
+
+def test_tasks_delete_blocked_when_in_task_group(app, client):
+    admin = _admin()
+    _login(client, admin)
+    task = _make_task(admin.id)
+    db.session.add(TaskGroups(name="tg", owner_id=admin.id, tasks=f'["{task.id}"]'))
+    db.session.commit()
+
+    resp = client.post(f"/tasks/delete/{task.id}", follow_redirects=True)
+    assert b"associated to one or more Task Groups" in resp.data
+    assert Tasks.query.get(task.id) is not None  # NOT deleted
+
+
+def test_tasks_delete_non_owner_non_admin_denied(app, client):
+    admin = _admin()
+    user = _nonadmin()
+    task = _make_task(admin.id)
+    _login(client, user)
+
+    resp = client.post(f"/tasks/delete/{task.id}", follow_redirects=True)
+    assert b"unauthorized to delete this task" in resp.data
+    assert Tasks.query.get(task.id) is not None  # NOT deleted
+
+
+def test_tasks_delete_owner_happy_path(app, client):
+    user = _nonadmin()
+    task = _make_task(user.id)
+    _login(client, user)
+
+    resp = client.post(f"/tasks/delete/{task.id}", follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert Tasks.query.get(task.id) is None  # deleted
+
+
+# ------------------------------------------------------------------ task_edit
+
+def test_task_edit_blocked_when_assigned_to_job(app, client):
+    admin = _admin()
+    _login(client, admin)
+    task = _make_task(admin.id, name="before-edit")
+    db.session.add(JobTasks(job_id=1, task_id=task.id, status="Not Started"))
+    db.session.commit()
+
+    resp = client.post(f"/tasks/edit/{task.id}", data={"name": "after-edit"},
+                       follow_redirects=True)
+    assert b"currently associated to one or more jobs" in resp.data
+    assert Tasks.query.get(task.id).name == "before-edit"  # unchanged
+
+
+def test_task_edit_non_owner_denied(app, client):
+    admin = _admin()
+    user = _nonadmin()
+    task = _make_task(admin.id, name="owned-by-admin")
+    _login(client, user)
+
+    resp = client.post(f"/tasks/edit/{task.id}", data={"name": "hijacked"},
+                       follow_redirects=True)
+    assert b"unauthorized to edit this task" in resp.data
+    assert Tasks.query.get(task.id).name == "owned-by-admin"  # unchanged
+
+
+def test_task_edit_owner_successful_post(app, client):
+    user = _nonadmin()
+    _login(client, user)
+    wl = _make_wordlist(user.id)
+    task = _make_task(user.id, name="old-name", wl_id=wl.id)
+
+    resp = client.post(
+        f"/tasks/edit/{task.id}",
+        data={
+            "name": "new-name",
+            "hc_attackmode": "0",
+            "wl_id": str(wl.id),
+            "wl_id_2": str(wl.id),  # hidden select still submits a value in the browser
+            "rule_id": "None",
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code in (301, 302)
+    edited = Tasks.query.get(task.id)
+    assert edited.name == "new-name"
+    assert edited.wl_id == wl.id
+    assert edited.rule_id is None  # 'None' sentinel normalized to NULL
+    assert edited.hc_attackmode == 0
+
+
+# ------------------------------------------------------------------ tasks_add
+
+def test_tasks_add_mode0_with_rule(app, client):
+    admin = _admin()
+    _login(client, admin)
+    wl = _make_wordlist(admin.id)
+    rule = _make_rule(admin.id)
+
+    resp = client.post(
+        "/tasks/add",
+        data={
+            "name": "dict-with-rule",
+            "hc_attackmode": "0",
+            "wl_id": str(wl.id),
+            "wl_id_2": str(wl.id),
+            "rule_id": str(rule.id),
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code in (301, 302)
+    task = Tasks.query.filter_by(name="dict-with-rule").first()
+    assert task is not None
+    assert task.hc_attackmode == 0
+    assert task.owner_id == admin.id
+    assert task.wl_id == wl.id
+    assert str(task.rule_id) == str(rule.id)
+
+
+def test_tasks_add_mode0_rule_none_sentinel(app, client):
+    admin = _admin()
+    _login(client, admin)
+    wl = _make_wordlist(admin.id)
+
+    resp = client.post(
+        "/tasks/add",
+        data={
+            "name": "dict-no-rule",
+            "hc_attackmode": "0",
+            "wl_id": str(wl.id),
+            "wl_id_2": str(wl.id),
+            "rule_id": "None",
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code in (301, 302)
+    task = Tasks.query.filter_by(name="dict-no-rule").first()
+    assert task is not None
+    assert task.rule_id is None  # sentinel stored as NULL, not the string 'None'
+    assert task.wl_id == wl.id

--- a/tests/unit/test_tasks_routes_guards.py
+++ b/tests/unit/test_tasks_routes_guards.py
@@ -206,3 +206,177 @@ def test_tasks_add_mode0_rule_none_sentinel(app, client):
     assert task is not None
     assert task.rule_id is None  # sentinel stored as NULL, not the string 'None'
     assert task.wl_id == wl.id
+
+
+# ------------------------------------------------------- tasks_list (sorting)
+
+def test_tasks_list_sort_branches_render(app, client):
+    admin = _admin()
+    _login(client, admin)
+    wl = _make_wordlist(admin.id)
+    _make_task(admin.id, name="alpha", wl_id=wl.id)
+    _make_task(admin.id, name="beta", wl_id=wl.id)
+
+    for qs in ("", "?sort_by=name&sort_order=desc",
+               "?sort_by=recovered", "?sort_by=recovered&sort_order=desc",
+               "?sort_by=owner", "?sort_by=owner&sort_order=desc",
+               "?sort_by=type", "?sort_by=type&sort_order=desc"):
+        resp = client.get(f"/tasks{qs}")
+        assert resp.status_code == 200, qs
+        assert b"alpha" in resp.data and b"beta" in resp.data
+
+
+def test_tasks_list_wordlist_filesize_best_effort(app, client, tmp_path):
+    # a wordlist whose file exists gets a human size; a missing file is skipped
+    admin = _admin()
+    _login(client, admin)
+    real = tmp_path / "real.gz"
+    real.write_bytes(b"x" * 2048)
+    wl_real = Wordlists(name="wl-real", owner_id=admin.id, type="static",
+                        path=str(real), size=10, checksum="2" * 64)
+    wl_gone = Wordlists(name="wl-gone", owner_id=admin.id, type="static",
+                        path=str(tmp_path / "missing.gz"), size=10,
+                        checksum="3" * 64)
+    db.session.add_all([wl_real, wl_gone])
+    db.session.commit()
+    _make_task(admin.id, name="t-real", wl_id=wl_real.id)
+    _make_task(admin.id, name="t-gone", wl_id=wl_gone.id)
+
+    resp = client.get("/tasks")
+    assert resp.status_code == 200
+    assert b"2 KB" in resp.data  # 2048 bytes -> human size for the real file
+
+
+# --------------------------------------------- tasks_add (other attack modes)
+
+def test_tasks_add_mode1_combinator(app, client):
+    admin = _admin()
+    _login(client, admin)
+    wl = _make_wordlist(admin.id)
+
+    resp = client.post("/tasks/add", data={
+        "name": "combi-task",
+        "hc_attackmode": "1",
+        "wl_id": str(wl.id),
+        "wl_id_2": str(wl.id),
+        "rule_id": "None",
+        "j_rule": "$-",
+        "k_rule": "$!",
+    }, follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    task = Tasks.query.filter_by(name="combi-task").first()
+    assert task is not None
+    assert task.hc_attackmode == 1
+    assert str(task.wl_id_2) == str(wl.id)
+    assert task.j_rule == "$-"
+    assert task.k_rule == "$!"
+    assert task.rule_id is None
+
+
+def test_tasks_add_mode3_mask(app, client):
+    admin = _admin()
+    _login(client, admin)
+    wl = _make_wordlist(admin.id)
+
+    resp = client.post("/tasks/add", data={
+        "name": "mask-task",
+        "hc_attackmode": "3",
+        "wl_id": str(wl.id),
+        "wl_id_2": str(wl.id),
+        "rule_id": "None",
+        "mask": "?u?l?l?l?d?d",
+    }, follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    task = Tasks.query.filter_by(name="mask-task").first()
+    assert task is not None
+    assert task.hc_attackmode == 3
+    assert task.hc_mask == "?u?l?l?l?d?d"
+    assert task.wl_id is None  # mask mode stores no wordlist
+
+
+def test_tasks_add_mode6_hybrid(app, client):
+    admin = _admin()
+    _login(client, admin)
+    wl = _make_wordlist(admin.id)
+
+    resp = client.post("/tasks/add", data={
+        "name": "hybrid-task",
+        "hc_attackmode": "6",
+        "wl_id": str(wl.id),
+        "wl_id_2": str(wl.id),
+        "rule_id": "None",
+        "mask": "?d?d",
+    }, follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    task = Tasks.query.filter_by(name="hybrid-task").first()
+    assert task is not None
+    assert task.hc_attackmode == 6
+    assert task.hc_mask == "?d?d"
+    assert str(task.wl_id) == str(wl.id)
+
+
+# ------------------------------------------------ task_edit (other modes/GET)
+
+def test_task_edit_get_prefills_form(app, client):
+    user = _nonadmin()
+    _login(client, user)
+    wl = _make_wordlist(user.id)
+    rule = _make_rule(user.id)
+    task = Tasks(name="prefilled", owner_id=user.id, wl_id=wl.id,
+                 rule_id=rule.id, hc_attackmode=0, loopback=True)
+    db.session.add(task)
+    db.session.commit()
+
+    resp = client.get(f"/tasks/edit/{task.id}")
+    assert resp.status_code == 200
+    assert b"prefilled" in resp.data
+    assert b"Update" in resp.data  # submit label switched for edit
+
+
+# NOTE: task_edit attack mode 1 (combinator) is intentionally NOT exercised:
+# hashview/tasks/routes.py lines 321-322 have trailing commas
+# (`task.j_rule=tasksForm.j_rule.data,`) which assign 1-tuples to the string
+# columns, so any combinator edit POST 500s at commit time. Bug recorded in
+# the route-coverage report rather than pinned here.
+
+
+def test_task_edit_to_mode3_mask_clears_wordlist_and_rule(app, client):
+    user = _nonadmin()
+    _login(client, user)
+    wl = _make_wordlist(user.id)
+    task = _make_task(user.id, name="to-mask", wl_id=wl.id)
+
+    resp = client.post(f"/tasks/edit/{task.id}", data={
+        "name": "to-mask",
+        "hc_attackmode": "3",
+        "wl_id": str(wl.id),
+        "wl_id_2": str(wl.id),
+        "rule_id": "None",
+        "mask": "?a?a?a",
+    }, follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    edited = Tasks.query.get(task.id)
+    assert edited.hc_attackmode == 3
+    assert edited.hc_mask == "?a?a?a"
+    assert edited.wl_id is None
+    assert edited.rule_id is None
+
+
+def test_task_edit_to_mode7_hybrid(app, client):
+    user = _nonadmin()
+    _login(client, user)
+    wl = _make_wordlist(user.id)
+    task = _make_task(user.id, name="to-hybrid", wl_id=wl.id)
+
+    resp = client.post(f"/tasks/edit/{task.id}", data={
+        "name": "to-hybrid",
+        "hc_attackmode": "7",
+        "wl_id": str(wl.id),
+        "wl_id_2": str(wl.id),
+        "rule_id": "None",
+        "mask": "?d?d?d",
+    }, follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    edited = Tasks.query.get(task.id)
+    assert edited.hc_attackmode == 7
+    assert edited.hc_mask == "?d?d?d"

--- a/tests/unit/test_tasks_routes_guards.py
+++ b/tests/unit/test_tasks_routes_guards.py
@@ -64,12 +64,9 @@ def test_tasks_delete_blocked_when_assigned_to_job(app, client):
     db.session.add(JobTasks(job_id=1, task_id=task.id, status="Not Started"))
     db.session.commit()
 
-    resp = client.post(f"/tasks/delete/{task.id}", follow_redirects=False)
-    assert resp.status_code in (301, 302)
+    resp = client.post(f"/tasks/delete/{task.id}", follow_redirects=True)
+    assert b"associated to one or more jobs" in resp.data
     assert Tasks.query.get(task.id) is not None  # NOT deleted
-
-    follow = client.post(f"/tasks/delete/{task.id}", follow_redirects=True)
-    assert b"associated to one or more jobs" in follow.data
 
 
 def test_tasks_delete_blocked_when_in_task_group(app, client):


### PR DESCRIPTION
## Summary
65 new behavior-pinning unit tests across four files, asserting DB state (not just status codes):
- `test_tasks_routes_guards.py` — tasks delete/edit/add guard branches
- `test_customers_routes_guards.py` — customer delete/edit/add incl. cascade
- `test_jobs_routes_guards.py` — job delete cascade, task assign/remove, wizard paths
- `test_scheduler_retention_inner.py` — `_data_retention_cleanup_inner` purge/retention/no-op

Module coverage: tasks/routes 55→89%, customers/routes 61→95%, jobs/routes 67→80%, scheduler 55→99%.

## Suspected production bugs found (NOT fixed here — tests pin current behavior; branches that 500 are skipped with comments)
1. `tasks/routes.py:321-322` — trailing commas assign 1-tuples (`task.j_rule=...,`); any combinator (mode 1) edit POST 500s at commit
2. `customers/routes.py:182-186` — wrong id used in hash lookup + `Query < int` comparison → 500 deleting a customer with uncracked hashes
3. `TasksForm.validate_task`/`JobsForm.validate_job` never run (no matching field names) — duplicate names silently allowed
4. `jobs/routes.py:266` — `url_for('jobs.list')` BuildError → 500 on assigned_hashfile for Running/Queued jobs
5. `jobs_assigned_hashfile` POST doesn't validate the hashfile belongs to the job's customer (cross-customer assignment)
6. `tasks/routes.py:219-243` — duplicated unreachable attack-mode blocks

Part of the testing-robustness plan (3/5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)