### PR TITLE
ci: coverage ratchet at 70%

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -24,10 +24,11 @@ jobs:
           pip install -r requirements.txt -r requirements-dev.txt
       - name: Create runtime control dirs (gitignored, required by tests)
         run: mkdir -p hashview/control/{hashes,logs,rules,tmp,wordlists,wordlists_import}
+      # Coverage ratchet: raise --cov-fail-under as coverage improves; never lower it.
       - name: Run unit + security tests with coverage
         run: |
           python -m pytest tests/unit tests/security \
-            --cov=hashview --cov-report=term-missing --cov-report=xml -q
+            --cov=hashview --cov-report=term-missing --cov-report=xml --cov-fail-under=71 -q
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Run unit + security tests with coverage
         run: |
           python -m pytest tests/unit tests/security \
-            --cov=hashview --cov-report=term-missing --cov-report=xml --cov-fail-under=71 -q
+            --cov=hashview --cov-report=term-missing --cov-report=xml --cov-fail-under=70 -q
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Adds `--cov-fail-under=70` to the unit-test job (current total: 71.52% after #198/#199). Ratchet rule: floor(total) − 1; raise as coverage improves, never lower.

Verified locally: gate passes at the floor, fails at 99.

Part of the testing-robustness plan (2/5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)