### PR TITLE
chore(readme): add CI status badges + live coverage badge

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -34,3 +34,42 @@ jobs:
         with:
           name: coverage-xml
           path: coverage.xml
+
+  # Render a live coverage badge from coverage.xml and publish it to an orphan
+  # `badges` branch using the built-in GITHUB_TOKEN (no PAT, no third-party
+  # service). The README points at the raw SVG on that branch. Runs only on
+  # pushes to the active dev/release branches — never on PRs (fork tokens are
+  # read-only) — and force-pushes a single-commit branch so history never grows.
+  coverage-badge:
+    needs: unit
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/v0.8.3-dev' || github.ref == 'refs/heads/main')
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Download coverage report
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-xml
+      - name: Render coverage badge
+        run: |
+          python -m pip install --upgrade pip
+          pip install "genbadge[coverage]"
+          genbadge coverage -i coverage.xml -o coverage.svg
+      - name: Publish badge to badges branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tmp="$(mktemp -d)"
+          cp coverage.svg "$tmp/coverage.svg"
+          cd "$tmp"
+          git init -q
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -q -b badges
+          git add coverage.svg
+          git commit -q -m "ci: update coverage badge [skip ci]"
+          git push -f -q "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" badges

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Hashview v0.8.2
 
+[![Unit Tests](https://github.com/hashview/hashview/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/hashview/hashview/actions/workflows/unit-tests.yml)
+[![E2E](https://github.com/hashview/hashview/actions/workflows/e2e.yml/badge.svg)](https://github.com/hashview/hashview/actions/workflows/e2e.yml)
+[![Lint & Security](https://github.com/hashview/hashview/actions/workflows/lint.yml/badge.svg)](https://github.com/hashview/hashview/actions/workflows/lint.yml)
+[![Pylint](https://github.com/hashview/hashview/actions/workflows/pylint.yml/badge.svg)](https://github.com/hashview/hashview/actions/workflows/pylint.yml)
+[![Coverage](https://img.shields.io/badge/coverage-%E2%89%A570%25-brightgreen)](https://github.com/hashview/hashview/actions/workflows/unit-tests.yml)
+
 >**Hashview** is a tool for security professionals to help organize and automate the repetitious tasks related to password cracking. It is broken into two compoents, the Hashview Server, and Hashview Agent. The Hashview Server is a web application that manages one or more agents, deployed by you on dedicated hardware. (note you can run the server and agent on the same machine). Hashview strives to bring constiency in your hashcat tasks while delivering analytics with pretty pictures ready for ctrl+c, ctrl+v into your reports.
 
 ## Note: If you are running version v0.8.0 and want to upgrade. All you need to do is git pull on main and start hashview.py, this should automatically upgrade your instance to the latest version.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![E2E](https://github.com/hashview/hashview/actions/workflows/e2e.yml/badge.svg)](https://github.com/hashview/hashview/actions/workflows/e2e.yml)
 [![Lint & Security](https://github.com/hashview/hashview/actions/workflows/lint.yml/badge.svg)](https://github.com/hashview/hashview/actions/workflows/lint.yml)
 [![Pylint](https://github.com/hashview/hashview/actions/workflows/pylint.yml/badge.svg)](https://github.com/hashview/hashview/actions/workflows/pylint.yml)
-[![Coverage](https://img.shields.io/badge/coverage-%E2%89%A570%25-brightgreen)](https://github.com/hashview/hashview/actions/workflows/unit-tests.yml)
+[![Coverage](https://raw.githubusercontent.com/hashview/hashview/badges/coverage.svg)](https://github.com/hashview/hashview/actions/workflows/unit-tests.yml)
 
 >**Hashview** is a tool for security professionals to help organize and automate the repetitious tasks related to password cracking. It is broken into two compoents, the Hashview Server, and Hashview Agent. The Hashview Server is a web application that manages one or more agents, deployed by you on dedicated hardware. (note you can run the server and agent on the same machine). Hashview strives to bring constiency in your hashcat tasks while delivering analytics with pretty pictures ready for ctrl+c, ctrl+v into your reports.
 


### PR DESCRIPTION
## Summary

Add status/coverage badges to the top of the README and wire up a self-hosted live coverage badge — no external service, no PAT.

### README badges
- **Unit Tests**, **E2E**, **Lint & Security**, **Pylint** — GitHub Actions status badges (each links to its workflow).
- **Coverage** — live SVG rendered from `coverage.xml`.

### Coverage badge mechanism (`unit-tests.yml`)
A new `coverage-badge` job:
- downloads the existing `coverage.xml` artifact, renders an SVG via `genbadge`,
- force-pushes a single-commit orphan `badges` branch using the built-in `GITHUB_TOKEN` (job scoped to `contents: write`),
- runs **only on push to `v0.8.3-dev` / `main`** — never on PRs, so fork tokens stay read-only,
- tags the commit `[skip ci]` to avoid CI loops.

No Codecov / third-party account or token required.

### Note
The coverage badge image **404s until the first post-merge run** on `v0.8.3-dev`/`main` creates the `badges` branch, then self-updates on every subsequent run. The four workflow-status badges work immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)