### PR TITLE
Fix for issue #226

### DIFF
--- a/hashview/api/routes.py
+++ b/hashview/api/routes.py
@@ -152,6 +152,21 @@ def versionCheck(agent_version):
     else:
         return False
 
+
+def _remove_file(path):
+    try:
+        os.remove(path)
+    except FileNotFoundError:
+        pass
+
+
+def _send_generated_file(directory, filename, **kwargs):
+    file_path = os.path.join(directory, filename)
+    response = send_from_directory(directory, filename, **kwargs)
+    response.call_on_close(lambda: _remove_file(file_path))
+    return response
+
+
 @api.route('/v1/not_authorized', methods=['GET', 'POST'])
 def v1_api_unauthorized():
     message = {
@@ -408,7 +423,8 @@ def v1_api_get_rules_download(rules_id):
 
     tmp_gz = os.path.join(tmp_dir, secrets.token_hex(8) + '.gz')
     compress_to_gz(src_path, tmp_gz, 9)
-    return send_from_directory(tmp_dir, os.path.basename(tmp_gz), mimetype='application/octet-stream')
+    return _send_generated_file(
+        tmp_dir, os.path.basename(tmp_gz), mimetype='application/octet-stream')
 
 # Create new rule
 @api.route('/v1/rules/add/<rule_name>', methods=['POST'])
@@ -524,7 +540,8 @@ def v1_api_get_wordlist_download(wordlist_id):
     # and serve that. No shell; pure-Python streamed gzip -9.
     tmp_gz = os.path.join(tmp_dir, secrets.token_hex(8) + '.gz')
     compress_to_gz(wordlist.path, tmp_gz, 9)
-    return send_from_directory(tmp_dir, os.path.basename(tmp_gz), mimetype='application/octet-stream')
+    return _send_generated_file(
+        tmp_dir, os.path.basename(tmp_gz), mimetype='application/octet-stream')
 
 # Update Dynamic Wordlist
 @api.route('/v1/updateWordlist/<int:wordlist_id>', methods=['GET'])
@@ -1138,7 +1155,7 @@ def v1_api_get_hashfile(hashfile_id):
         for result in dbresults:
             file_object.write(result[0].ciphertext + '\n')
 
-    return send_from_directory(tmp_dir, random_hex)
+    return _send_generated_file(tmp_dir, random_hex)
 
 # List hashfiles containing at least one hash of the given hash type.
 # No collision with /v1/hashfiles/<int:hashfile_id>: the static 'hash_type/'

--- a/hashview/api/routes.py
+++ b/hashview/api/routes.py
@@ -158,6 +158,11 @@ def _remove_file(path):
         os.remove(path)
     except FileNotFoundError:
         pass
+    except OSError as error:
+        # Don't fail the request, but surface the problem so an admin can
+        # troubleshoot temp files stacking up in control/tmp (see issue #226).
+        current_app.logger.warning(
+            'Failed to remove temporary file %s: %s', path, error)
 
 
 def _send_generated_file(directory, filename, **kwargs):

--- a/tests/unit/test_api_endpoints.py
+++ b/tests/unit/test_api_endpoints.py
@@ -748,6 +748,25 @@ def test_rules_download_serves_gzip_roundtrip(
     assert gzip.decompress(resp.data) == content
 
 
+@pytest.mark.security
+def test_send_generated_file_removes_file_after_response_close(app, tmp_path):
+    """Generated API download files are removed after the response closes."""
+    from hashview.api import routes as api_routes
+
+    tmp_dir = tmp_path / "control" / "tmp"
+    tmp_dir.mkdir(parents=True)
+    generated = tmp_dir / "download.txt"
+    generated.write_bytes(b"payload")
+
+    with app.test_request_context("/v1/generated"):
+        response = api_routes._send_generated_file(str(tmp_dir), generated.name)
+        assert b"".join(response.response) == b"payload"
+        assert generated.exists()
+
+        response.close()
+        assert not generated.exists()
+
+
 # ---------------------------------------------------------------------------
 # POST /v1/tasks/add
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_api_endpoints.py
+++ b/tests/unit/test_api_endpoints.py
@@ -15,6 +15,7 @@ Auth model recap (see ``is_authorized``):
 
 import json
 import os
+from unittest import mock
 
 import pytest
 
@@ -765,6 +766,25 @@ def test_send_generated_file_removes_file_after_response_close(app, tmp_path):
 
         response.close()
         assert not generated.exists()
+
+
+@pytest.mark.security
+def test_remove_file_logs_warning_on_oserror(app, tmp_path, monkeypatch):
+    """A cleanup failure is logged (not swallowed) so admins can troubleshoot."""
+    from hashview.api import routes as api_routes
+
+    def boom(_path):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(api_routes.os, "remove", boom)
+
+    with app.app_context():
+        with mock.patch.object(api_routes.current_app.logger, "warning") as warn:
+            api_routes._remove_file(str(tmp_path / "stuck.txt"))
+
+    assert warn.called
+    logged = " ".join(str(a) for a in warn.call_args.args)
+    assert "stuck.txt" in logged
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- remove generated API download files after the response closes
- apply the cleanup to rules downloads, dynamic wordlist downloads, and generated hashfile exports
- add a regression test for generated download cleanup

Fixes #226.

## Tests
- PYTHONPATH=. uv run --python 3.11 --with-requirements requirements.txt --with-requirements requirements-dev.txt pytest tests/unit/test_api_endpoints.py tests/security/test_command_injection_poc.py tests/unit/test_wordlist_gzip_storage.py tests/unit/test_api_agent_protocol.py -q
- PYTHONPATH=. uv run --python 3.11 --with-requirements requirements.txt --with-requirements requirements-dev.txt python -m compileall -q hashview tests
- PYTHONPATH=. uv run --python 3.11 --with-requirements requirements.txt --with-requirements requirements-dev.txt ruff check hashview/api/routes.py tests/unit/test_api_endpoints.py
- git diff --check
- PYTHONPATH=. uv run --python 3.11 --with pylint --with-requirements requirements.txt pylint --verbose --jobs=1 --rcfile=.pylintrc --output-format=colorized --reports=n --score=y hashview/ hashview.py

AI assistance was used under my direction.
