### PR TITLE
fix(api): return JSON (not HTML) for empty/invalid request bodies (#212)

### DIFF
--- a/hashview/api/routes.py
+++ b/hashview/api/routes.py
@@ -223,7 +223,21 @@ def v1_api_set_agent_heartbeat():
             return jsonify(message)
         else:
             # check if job_task
-            agent_data = request.get_json()
+            # silent=True so an empty/invalid body returns None (-> JSON error) instead
+            # of Flask's HTML 400 page, which the agent can't parse (#212).
+            agent_data = request.get_json(silent=True)
+            if not agent_data:
+                return jsonify({
+                    'status': 400,
+                    'type': 'Error',
+                    'msg': 'Missing heartbeat data in request body'
+                })
+            if 'agent_status' not in agent_data:
+                return jsonify({
+                    'status': 400,
+                    'type': 'Error',
+                    'msg': "Missing 'agent_status' in heartbeat data"
+                })
 
             # Check authorization cookies
             if agent_data['agent_status'] == 'Working':
@@ -720,8 +734,9 @@ def v1_api_post_add_job():
             'msg': 'User not found'
         })
     
-    # Expect JSON body
-    job_data = request.get_json()
+    # Expect JSON body. silent=True so an empty/invalid body returns None (-> the JSON
+    # 400 below) instead of Flask's HTML 400 page, which JSON clients can't parse (#212).
+    job_data = request.get_json(silent=True)
     if not job_data:
         return jsonify({
             'status': 400,
@@ -1219,7 +1234,15 @@ def v1_api_put_jobtask_crackfile_upload(task_id, hash_type):
     # We really should validate if task_id is legit
     
     # save to file
-    file_contents = request.get_json()
+    # silent=True so an empty/invalid body returns None (-> JSON error) instead of
+    # Flask's HTML 400 page, which the agent can't parse (#212).
+    file_contents = request.get_json(silent=True)
+    if not file_contents or 'file' not in file_contents:
+        return jsonify({
+            'status': 400,
+            'type': 'Error',
+            'msg': 'Missing file data in request body'
+        })
 
     #for entry in lines:
     for entry in file_contents['file'].split('\n'):
@@ -1270,7 +1293,15 @@ def v1_api_post_jobtask_crackfile_upload(job_task_id):
     recovered_at_least_one_hash = False
 
     # save to file
-    file_contents = request.get_json()
+    # silent=True so an empty/invalid body returns None (-> JSON error) instead of
+    # Flask's HTML 400 page, which the agent can't parse (#212).
+    file_contents = request.get_json(silent=True)
+    if not file_contents or 'file' not in file_contents:
+        return jsonify({
+            'status': 400,
+            'type': 'Error',
+            'msg': 'Missing file data in request body'
+        })
 
     # Get Hashtype from job_task_id
     job_task = JobTasks.query.get(job_task_id)
@@ -1381,7 +1412,15 @@ def v1_api_set_queue_jobtask_status():
 
     update_heartbeat(request.cookies.get('uuid'))
 
-    status_json = request.get_json()
+    # silent=True so an empty/invalid body returns None (-> JSON error) instead of
+    # Flask's HTML 400 page, which the agent can't parse (#212).
+    status_json = request.get_json(silent=True)
+    if not status_json or 'job_task_id' not in status_json or 'task_status' not in status_json:
+        return jsonify({
+            'status': 400,
+            'type': 'Error',
+            'msg': 'Missing job task status data in request body'
+        })
 
     if (update_job_task_status(jobtask_id = status_json['job_task_id'], status = status_json['task_status'])):
         message = {

--- a/hashview/api_docs/openapi.yaml
+++ b/hashview/api_docs/openapi.yaml
@@ -1531,8 +1531,8 @@ components:
           type: string
           description: >-
             The agent's self-reported state. The server branches on "Working"
-            and "Idle"; anything else is acknowledged with OK. A missing key
-            raises an unhandled server error.
+            and "Idle"; anything else is acknowledged with OK. A missing/empty
+            body, or a body missing this key, returns body status 400.
           example: Idle
         hc_status:
           type: string


### PR DESCRIPTION
Every /v1 handler that read the request body called request.get_json() without silent=True, so an empty or malformed JSON body made Flask raise its HTML 400 page — which agents and other JSON clients can't parse — and the route's intended JSON error envelope was never reached.

Switch them all to request.get_json(silent=True) and return a proper JSON 400 when the body is missing or unusable:

- v1_api_post_add_job: empty body -> "Missing job data in request body" (the originally reported #212 route).
- v1_api_set_agent_heartbeat: empty body -> "Missing heartbeat data in request body"; missing agent_status -> "Missing 'agent_status' in heartbeat data" (the Working/Idle branches read it by direct key access).
- v1_api_put_jobtask_crackfile_upload / v1_api_post_jobtask_crackfile_upload: empty body or missing 'file' -> "Missing file data in request body".
- v1_api_set_queue_jobtask_status: empty body or missing job_task_id/ task_status -> "Missing job task status data in request body".

The required-key guards also stop the now-silenced None/{} bodies from turning into an HTML 500 on the immediately-following key access.

Update the OpenAPI HeartbeatRequest.agent_status description to reflect the new 400 behavior (was documented as "raises an unhandled server error").