### PR TITLE
fix(jobs): use correct url_for endpoint on running/queued hashfile ed…

### DIFF
--- a/hashview/jobs/routes.py
+++ b/hashview/jobs/routes.py
@@ -263,7 +263,7 @@ def jobs_assigned_hashfile(job_id):
 
     if job.status == 'Running' or job.status == 'Queued':
         flash('You can not edit a running or queued job. First stop and remove job from queue before editing.', 'danger')
-        return redirect(url_for('jobs.list', job_id=job_id))
+        return redirect(url_for('jobs.jobs_list'))
 
     for hashfile in hashfiles:
         # one aggregated query per hashfile: total hashes, cracked count, representative mode


### PR DESCRIPTION
…it (#210)

jobs_assigned_hashfile redirected with url_for('jobs.list', job_id=job_id), but there is no 'jobs.list' endpoint — it's 'jobs.jobs_list' (which takes no job_id). Opening the hashfile-assignment page for a Running/Queued job raised werkzeug.routing BuildError -> HTTP 500 instead of the intended "can't edit a running/queued job" warning + redirect. Use url_for('jobs.jobs_list').