### PR TITLE
fix(tasks): drop trailing commas storing j_rule/k_rule as tuples (#209)

### DIFF
--- a/hashview/tasks/routes.py
+++ b/hashview/tasks/routes.py
@@ -318,8 +318,8 @@ def task_edit(task_id):
                 task.name = tasksForm.name.data
                 task.wl_id = tasksForm.wl_id.data
                 task.wl_id_2 = tasksForm.wl_id_2.data
-                task.j_rule=tasksForm.j_rule.data,
-                task.k_rule=tasksForm.k_rule.data,
+                task.j_rule = tasksForm.j_rule.data
+                task.k_rule = tasksForm.k_rule.data
                 task.hc_attackmode = tasksForm.hc_attackmode.data
                 task.loopback = False
 


### PR DESCRIPTION
task_edit's combinator branch (hc_attackmode == 1) assigned
  task.j_rule = tasksForm.j_rule.data,
  task.k_rule = tasksForm.k_rule.data,
The trailing commas made each value a 1-tuple, which the DB driver rejects for the String(25) j_rule/k_rule columns (SQLite: "type 'tuple' is not supported"; MySQL likewise) — so editing any task into combinator mode raised on commit and 500'd, losing the edit. Remove the trailing commas so plain strings are stored (matching tasks_add).