### PR TITLE
fix(customers): count the query before comparing in delete (#208)

### DIFF
--- a/hashview/customers/routes.py
+++ b/hashview/customers/routes.py
@@ -182,7 +182,7 @@ def customers_delete(customer_id):
             hashes = Hashes.query.filter_by(id=hashfile_hash.id, cracked=0).all()
             for hash in hashes:
                 # Check to see if our hashfile is the ONLY hashfile for this customer that has this hash
-                customer_cnt = HashfileHashes.query.filter_by(hash_id=hash.id).distinct('customer_id')
+                customer_cnt = HashfileHashes.query.filter_by(hash_id=hash.id).distinct('customer_id').count()
                 if customer_cnt < 2:
                     db.session.delete(hash)
                     HashNotifications.query.filter_by(hash_id=hashfile_hash.hash_id).delete()


### PR DESCRIPTION
customers_delete built customer_cnt from a Query but never executed it:
  customer_cnt = HashfileHashes.query.filter_by(hash_id=hash.id).distinct('customer_id')
  if customer_cnt < 2:
In Python 3 `Query < 2` raises TypeError ("'<' not supported between instances of 'Query' and 'int'"), so deleting a customer that has uncracked hashes in their hashfiles 500'd. Append .count() so the comparison operates on an int.