### PR TITLE
fix(customers): delete loop must resolve the hash by hash_id, not the…

### DIFF
--- a/hashview/customers/routes.py
+++ b/hashview/customers/routes.py
@@ -179,10 +179,10 @@ def customers_delete(customer_id):
     for hashfile in hashfiles:
         hashfile_hashes = HashfileHashes.query.filter_by(hashfile_id = hashfile.id).all()
         for hashfile_hash in hashfile_hashes:
-            hashes = Hashes.query.filter_by(id=hashfile_hash.id, cracked=0).all()
+            hashes = Hashes.query.filter_by(id=hashfile_hash.hash_id, cracked=0).all()
             for hash in hashes:
                 # Check to see if our hashfile is the ONLY hashfile for this customer that has this hash
-                customer_cnt = HashfileHashes.query.filter_by(hash_id=hash.id).distinct('customer_id')
+                customer_cnt = HashfileHashes.query.filter_by(hash_id=hash.id).distinct('customer_id').count()
                 if customer_cnt < 2:
                     db.session.delete(hash)
                     HashNotifications.query.filter_by(hash_id=hashfile_hash.hash_id).delete()


### PR DESCRIPTION
… association id

customers_delete walks each hashfile's HashfileHashes association rows to prune orphaned uncracked hashes, but looked the hash up by the association's OWN primary key:

    hashes = Hashes.query.filter_by(id=hashfile_hash.id, cracked=0).all()

HashfileHashes.id identifies the association row; the hash it points at is HashfileHashes.hash_id (the FK to Hashes.id). The wrong key matched an unrelated Hashes row (or none), so genuinely-orphaned uncracked hashes were left behind when their customer was deleted. Fixed to:

    hashes = Hashes.query.filter_by(id=hashfile_hash.hash_id, cracked=0).all()

With the lookup corrected, the existing customer_cnt check is now actually reached on the common path -- and it compared a Query to an int (missing .count()), raising TypeError -> HTTP 500 (the same defect tracked in #208). Append .count() so this loop is internally consistent; deleting a customer with uncracked hashes now prunes the orphaned hashes and succeeds.