### PR TITLE
refactor(tasks): remove dead duplicate hybrid attack-mode blocks in t…

### DIFF
--- a/hashview/tasks/routes.py
+++ b/hashview/tasks/routes.py
@@ -215,30 +215,6 @@ def tasks_add():
             db.session.add(task)
             db.session.commit()
             flash(f'Task {tasksForm.name.data} created!', 'success')
-        # Hybrid Wordlist + Mask or Hybrid Mask + Wordlist
-        elif tasksForm.hc_attackmode.data == 6 or tasksForm.hc_attackmode.data == 7:
-            task = Tasks(   name=tasksForm.name.data,
-                            owner_id=current_user.id,
-                            wl_id=tasksForm.wl_id.data,
-                            rule_id=None,
-                            hc_attackmode=tasksForm.hc_attackmode.data,
-                            hc_mask=tasksForm.mask.data,
-            )
-            db.session.add(task)
-            db.session.commit()
-            flash(f'Task {tasksForm.name.data} created!', 'success')
-        # Hybrid Wordlist + Mask or Hybrid Mask + Wordlist
-        elif tasksForm.hc_attackmode.data == 6 or tasksForm.hc_attackmode.data == 7:
-            task = Tasks(   name=tasksForm.name.data,
-                            owner_id=current_user.id,
-                            wl_id=tasksForm.wl_id.data,
-                            rule_id=None,
-                            hc_attackmode=tasksForm.hc_attackmode.data,
-                            hc_mask=tasksForm.mask.data,
-            )
-            db.session.add(task)
-            db.session.commit()
-            flash(f'Task {tasksForm.name.data} created!', 'success')            
         else:
             flash('Attack Mode not supported... yet...', 'danger')
         if task is not None:


### PR DESCRIPTION
…asks_add (#207)

tasks_add had the
    elif tasksForm.hc_attackmode.data == 6 or tasksForm.hc_attackmode.data == 7:
hybrid branch (with identical body and comment) written three times in a row. Only the first is reachable — an elif chain can never re-enter an identical condition — so the 2nd and 3rd copies were unreachable dead code. Removed the two duplicates, leaving the single reachable branch. No behavior change (hybrid mode 6/7 task creation already ran through the first block).