### PR TITLE
fix(jobs): convert CSRF-vulnerable state-mutating GET routes to POST …

### DIFF
--- a/hashview/jobs/routes.py
+++ b/hashview/jobs/routes.py
@@ -14,6 +14,7 @@ from flask import (
     url_for,
 )
 from flask_login import current_user, login_required
+from flask_wtf import FlaskForm
 from sqlalchemy import case, func
 
 from hashview.jobs.forms import (
@@ -464,10 +465,16 @@ def jobs_list_tasks(job_id):
 
     return render_template('jobs_assigned_tasks.html.j2', title='Jobs Assigned Tasks', job=job, tasks=tasks, job_tasks=job_tasks, task_groups=task_groups, wordlists=wordlists, alert_hashes=alert_hashes, website=_job_uses_website_keywords(job_id))
 
-@jobs.route("/jobs/<int:job_id>/assign_task/<int:task_id>", methods=['GET'])
+@jobs.route("/jobs/<int:job_id>/assign_task/<int:task_id>", methods=['POST'])
 @login_required
 def jobs_assign_task(job_id, task_id):
     """Function to assign task to job"""
+
+    # POST + bare FlaskForm CSRF check (token in the request body): protects this
+    # state-mutating route against CSRF (#167).
+    if not FlaskForm().validate_on_submit():
+        flash('Security check failed (invalid or missing CSRF token).', 'danger')
+        return redirect("/jobs/" + str(job_id) + "/tasks")
 
     # Someone smarter than me can turn this into a single DB Query
     jobtask_exists = JobTasks.query.filter_by(job_id=job_id, task_id=task_id).first()
@@ -492,10 +499,14 @@ def jobs_assign_task(job_id, task_id):
 
     return redirect("/jobs/"+str(job_id)+"/tasks")
 
-@jobs.route("/jobs/<int:job_id>/assign_task_group/<int:task_group_id>", methods=['GET'])
+@jobs.route("/jobs/<int:job_id>/assign_task_group/<int:task_group_id>", methods=['POST'])
 @login_required
 def jobs_assign_task_group(job_id, task_group_id):
     """Function to assign task group to job"""
+
+    if not FlaskForm().validate_on_submit():
+        flash('Security check failed (invalid or missing CSRF token).', 'danger')
+        return redirect("/jobs/" + str(job_id) + "/tasks")
 
     task_group = TaskGroups.query.get(task_group_id)
 
@@ -526,9 +537,13 @@ def jobs_assign_task_group(job_id, task_group_id):
 
     return redirect("/jobs/" + str(job_id) + "/tasks")
 
-@jobs.route("/jobs/<int:job_id>/assign_task/lucky", methods=['GET'])
+@jobs.route("/jobs/<int:job_id>/assign_task/lucky", methods=['POST'])
 @login_required
 def jobs_assign_lucky_task_group(job_id):
+
+    if not FlaskForm().validate_on_submit():
+        flash('Security check failed (invalid or missing CSRF token).', 'danger')
+        return redirect("/jobs/" + str(job_id) + "/tasks")
 
     job = Jobs.query.get(job_id)
     hashfile = Hashfiles.query.get(job.hashfile_id)
@@ -561,10 +576,14 @@ def jobs_assign_lucky_task_group(job_id):
         flash('Successfully Added Top 10 Tasks', 'success')
     return redirect("/jobs/" + str(job_id) + "/tasks")
 
-@jobs.route("/jobs/<int:job_id>/move_task_up/<int:task_id>", methods=['GET'])
+@jobs.route("/jobs/<int:job_id>/move_task_up/<int:task_id>", methods=['POST'])
 @login_required
 def jobs_move_task_up(job_id, task_id):
     """Function to move assigned task up on task list for job"""
+
+    if not FlaskForm().validate_on_submit():
+        flash('Security check failed (invalid or missing CSRF token).', 'danger')
+        return redirect("/jobs/" + str(job_id) + "/tasks")
 
     job_tasks = JobTasks.query.filter_by(job_id=job_id).all()
 
@@ -596,10 +615,14 @@ def jobs_move_task_up(job_id, task_id):
 
     return redirect("/jobs/"+str(job_id)+"/tasks")
 
-@jobs.route("/jobs/<int:job_id>/move_task_down/<int:task_id>", methods=['GET'])
+@jobs.route("/jobs/<int:job_id>/move_task_down/<int:task_id>", methods=['POST'])
 @login_required
 def jobs_move_task_down(job_id, task_id):
     """Function to move assigned task down on task list for job"""
+
+    if not FlaskForm().validate_on_submit():
+        flash('Security check failed (invalid or missing CSRF token).', 'danger')
+        return redirect("/jobs/" + str(job_id) + "/tasks")
 
     job_tasks = JobTasks.query.filter_by(job_id=job_id).all()
 
@@ -633,10 +656,14 @@ def jobs_move_task_down(job_id, task_id):
 
     return redirect("/jobs/"+str(job_id)+"/tasks")
 
-@jobs.route("/jobs/<int:job_id>/remove_task/<int:task_id>", methods=['GET'])
+@jobs.route("/jobs/<int:job_id>/remove_task/<int:task_id>", methods=['POST'])
 @login_required
 def jobs_remove_task(job_id, task_id):
     """Function to remove task from task list on job"""
+
+    if not FlaskForm().validate_on_submit():
+        flash('Security check failed (invalid or missing CSRF token).', 'danger')
+        return redirect("/jobs/" + str(job_id) + "/tasks")
 
     job_task = JobTasks.query.filter_by(job_id=job_id, task_id=task_id).first()
     if job_task is None:
@@ -648,10 +675,14 @@ def jobs_remove_task(job_id, task_id):
 
     return redirect("/jobs/"+str(job_id)+"/tasks")
 
-@jobs.route("/jobs/<int:job_id>/remove_all_tasks", methods=['GET'])
+@jobs.route("/jobs/<int:job_id>/remove_all_tasks", methods=['POST'])
 @login_required
 def jobs_remove_all_tasks(job_id):
     """Function to remove all tasks from job"""
+
+    if not FlaskForm().validate_on_submit():
+        flash('Security check failed (invalid or missing CSRF token).', 'danger')
+        return redirect("/jobs/" + str(job_id) + "/tasks")
 
     job_tasks = JobTasks.query.filter_by(job_id=job_id)
     for tasks in job_tasks:
@@ -855,10 +886,14 @@ def jobs_summary(job_id):
 
     return render_template('jobs_summary.html.j2', title='Job Summary', job=job, form=form, job_notification=job_notification, cracked_rate=cracked_rate, cracked_cnt=cracked_cnt, hash_total=hash_total, hashfile_hash_type=hashfile_hash_type, job_tasks=job_tasks, hash_notification_cnt=hash_notification_cnt, customer=customer, hashfile=hashfile, tasks=tasks, hash_notification=hash_notification, settings=settings, website=_job_uses_website_keywords(job_id))
 
-@jobs.route("/jobs/start/<int:job_id>", methods=['GET'])
+@jobs.route("/jobs/start/<int:job_id>", methods=['POST'])
 @login_required
 def jobs_start(job_id):
     """Function to start job"""
+
+    if not FlaskForm().validate_on_submit():
+        flash('Security check failed (invalid or missing CSRF token).', 'danger')
+        return redirect(url_for('jobs.jobs_list'))
 
     job = Jobs.query.get(job_id)
     job_tasks = JobTasks.query.filter_by(job_id = job_id).all()
@@ -882,10 +917,14 @@ def jobs_start(job_id):
         flash('Error in starting job', 'danger')
         return redirect(url_for('jobs.jobs_list'))
 
-@jobs.route("/jobs/stop/<int:job_id>", methods=['GET'])
+@jobs.route("/jobs/stop/<int:job_id>", methods=['POST'])
 @login_required
 def jobs_stop(job_id):
     """Function to stop a job"""
+
+    if not FlaskForm().validate_on_submit():
+        flash('Security check failed (invalid or missing CSRF token).', 'danger')
+        return redirect(url_for('jobs.jobs_list'))
 
     job = Jobs.query.get(job_id)
     job_tasks = JobTasks.query.filter_by(job_id = job_id).all()

--- a/hashview/templates/jobs.html.j2
+++ b/hashview/templates/jobs.html.j2
@@ -65,13 +65,22 @@
                     <button type="button" class="icon-btn" id="jobmenubtn-{{ job.id }}" popovertarget="jobmenu-{{ job.id }}" title="Actions" aria-label="Actions">{{ icon('dots', size=16) }}</button>
                     <div class="job-menu" popover="auto" id="jobmenu-{{ job.id }}" data-anchor="jobmenubtn-{{ job.id }}">
                         {% if job.status == 'Ready' %}
-                            <a class="mi go" href="{{ url_for('jobs.jobs_start', job_id=job.id) }}">{{ icon('play', size=15) }} Start</a>
+                            <form method="POST" action="{{ url_for('jobs.jobs_start', job_id=job.id) }}" style="display:contents">
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                <button type="submit" class="mi go">{{ icon('play', size=15) }} Start</button>
+                            </form>
                         {% elif job.status == 'Queued' or job.status == 'Running' %}
-                            <a class="mi stop" href="{{ url_for('jobs.jobs_stop', job_id=job.id) }}">{{ icon('stop', size=15) }} Stop</a>
+                            <form method="POST" action="{{ url_for('jobs.jobs_stop', job_id=job.id) }}" style="display:contents">
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                <button type="submit" class="mi stop">{{ icon('stop', size=15) }} Stop</button>
+                            </form>
                         {% elif job.status == 'Completed' %}
                             <span class="mi disabled" style="color:var(--green);">{{ icon('check', size=15) }} Completed</span>
                         {% elif job.status == 'Canceled' %}
-                            <a class="mi" href="{{ url_for('jobs.jobs_start', job_id=job.id) }}">{{ icon('refresh', size=15) }} Restart</a>
+                            <form method="POST" action="{{ url_for('jobs.jobs_start', job_id=job.id) }}" style="display:contents">
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                <button type="submit" class="mi">{{ icon('refresh', size=15) }} Restart</button>
+                            </form>
                         {% endif %}
                         {% if job.status != 'Incomplete' %}
                             <a class="mi" href="{{ url_for('analytics.get_analytics', customer_id=job.customer_id, hashfile_id=job.hashfile_id) }}">{{ icon('chart', size=15) }} Analytics</a>

--- a/hashview/templates/jobs_assigned_tasks.html.j2
+++ b/hashview/templates/jobs_assigned_tasks.html.j2
@@ -51,7 +51,10 @@
                                 {% if already_assigned.value == 0 %}
                                     {% set any_task.value = 1 %}
                                     <!-- TODO: filter out tasks already assigned to the job -->
-                                    <a class="btn btn-ghost btn-block" style="justify-content:flex-start;" href="/jobs/{{job.id}}/assign_task/{{task.id}}">{{ icon('task', size=14) }} {{task.name}}</a>
+                                    <form method="POST" action="/jobs/{{job.id}}/assign_task/{{task.id}}">
+                                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                        <button type="submit" class="btn btn-ghost btn-block" style="justify-content:flex-start;">{{ icon('task', size=14) }} {{task.name}}</button>
+                                    </form>
                                 {% endif %}
                             {% endfor %}
                             {% if any_task.value == 0 %}
@@ -69,7 +72,10 @@
                     <div class="card" style="margin-top:8px; max-height:300px; overflow-y:auto;">
                         <div class="card-body" style="padding:6px;">
                             {% for task_group in task_groups %}
-                                <a class="btn btn-ghost btn-block" style="justify-content:flex-start;" href="/jobs/{{job.id}}/assign_task_group/{{task_group.id}}">{{ icon('group', size=14) }} {{task_group.name}}</a>
+                                <form method="POST" action="/jobs/{{job.id}}/assign_task_group/{{task_group.id}}">
+                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                    <button type="submit" class="btn btn-ghost btn-block" style="justify-content:flex-start;">{{ icon('group', size=14) }} {{task_group.name}}</button>
+                                </form>
                             {% else %}
                                 <div class="page-sub" style="padding:8px 10px;">No task groups available.</div>
                             {% endfor %}
@@ -80,7 +86,10 @@
                 <div class="term-divider">OR</div>
 
                 {# ---- Add Top Tasks (lucky) ---- #}
-                <a class="btn btn-primary btn-sm" href="/jobs/{{job.id}}/assign_task/lucky" role="button">{{ icon('zap', size=15) }} I'm Feeling Lucky — top 5</a>
+                <form method="POST" action="/jobs/{{job.id}}/assign_task/lucky" style="display:inline;">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <button type="submit" class="btn btn-primary btn-sm">{{ icon('zap', size=15) }} I'm Feeling Lucky — top 5</button>
+                </form>
             </div>
         </div>
     </div>
@@ -134,9 +143,18 @@
                             </td>
                             <td class="center">
                                 <div style="display:flex; gap:4px; justify-content:center;">
-                                    <a class="icon-btn" href="/jobs/{{job.id}}/move_task_up/{{job_task.task_id}}" role="button" title="Move Up">{{ icon('arrowUp', size=15) }}</a>
-                                    <a class="icon-btn" href="/jobs/{{job.id}}/move_task_down/{{job_task.task_id}}" role="button" title="Move Down">{{ icon('arrowDown', size=15) }}</a>
-                                    <a class="icon-btn act-del" href="/jobs/{{job.id}}/remove_task/{{job_task.task_id}}" role="button" title="Delete">{{ icon('trash', size=15) }}</a>
+                                    <form method="POST" action="/jobs/{{job.id}}/move_task_up/{{job_task.task_id}}" style="display:contents">
+                                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                        <button type="submit" class="icon-btn" title="Move Up">{{ icon('arrowUp', size=15) }}</button>
+                                    </form>
+                                    <form method="POST" action="/jobs/{{job.id}}/move_task_down/{{job_task.task_id}}" style="display:contents">
+                                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                        <button type="submit" class="icon-btn" title="Move Down">{{ icon('arrowDown', size=15) }}</button>
+                                    </form>
+                                    <form method="POST" action="/jobs/{{job.id}}/remove_task/{{job_task.task_id}}" style="display:contents">
+                                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                        <button type="submit" class="icon-btn act-del" title="Delete">{{ icon('trash', size=15) }}</button>
+                                    </form>
                                 </div>
                             </td>
                         </tr>
@@ -165,7 +183,8 @@
     <div class="hv-dialog-body">This will permanently delete all assigned tasks for this job. Are you sure you want to continue?</div>
     <div class="hv-dialog-foot">
         <button class="btn" onclick="this.closest('dialog').close()">Back</button>
-        <form action="/jobs/{{job.id}}/remove_all_tasks" method="GET" style="display:inline;">
+        <form action="/jobs/{{job.id}}/remove_all_tasks" method="POST" style="display:inline;">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
             <button class="btn btn-danger" type="submit">Delete</button>
         </form>
     </div>

--- a/tests/unit/test_delete_idempotency.py
+++ b/tests/unit/test_delete_idempotency.py
@@ -39,7 +39,7 @@ DELETE_ROUTES = [
     ("POST", "/users/delete/999999", None),
     ("POST", "/hashfiles/delete/999999", None),
     ("POST", "/customers/delete/999999", None),
-    ("GET", "/jobs/999999/remove_task/888888", None),
+    ("POST", "/jobs/999999/remove_task/888888", None),
     ("GET", "/task_groups/assigned_tasks/999999/remove_task/888888", None),
 ]
 

--- a/tests/unit/test_jobs_routes.py
+++ b/tests/unit/test_jobs_routes.py
@@ -159,7 +159,7 @@ def test_jobs_assign_task_creates_jobtask(app, client):
     cust = make_customer()
     job = _job(admin, cust)
     task = _task(admin)
-    resp = client.get(f"/jobs/{job.id}/assign_task/{task.id}", follow_redirects=False)
+    resp = client.post(f"/jobs/{job.id}/assign_task/{task.id}", follow_redirects=False)
     assert resp.status_code in (301, 302)
     assert JobTasks.query.filter_by(job_id=job.id, task_id=task.id).count() == 1
 
@@ -175,7 +175,7 @@ def test_jobs_assign_task_group_creates_one_per_task(app, client):
                     tasks=json.dumps([t1.id, t2.id]))
     db.session.add(tg)
     db.session.commit()
-    resp = client.get(f"/jobs/{job.id}/assign_task_group/{tg.id}", follow_redirects=False)
+    resp = client.post(f"/jobs/{job.id}/assign_task_group/{tg.id}", follow_redirects=False)
     assert resp.status_code in (301, 302)
     assert JobTasks.query.filter_by(job_id=job.id).count() == 2
 
@@ -196,7 +196,7 @@ def test_jobs_move_task_up_swaps_order(app, client):
     _assign(job, t1)
     _assign(job, t2)
     assert _ordered_task_ids(job) == [t1.id, t2.id]
-    resp = client.get(f"/jobs/{job.id}/move_task_up/{t2.id}", follow_redirects=False)
+    resp = client.post(f"/jobs/{job.id}/move_task_up/{t2.id}", follow_redirects=False)
     assert resp.status_code in (301, 302)
     assert _ordered_task_ids(job) == [t2.id, t1.id]
 
@@ -209,7 +209,7 @@ def test_jobs_move_task_up_top_is_noop(app, client):
     t1, t2 = _task(admin, name="first"), _task(admin, name="second")
     _assign(job, t1)
     _assign(job, t2)
-    client.get(f"/jobs/{job.id}/move_task_up/{t1.id}", follow_redirects=False)
+    client.post(f"/jobs/{job.id}/move_task_up/{t1.id}", follow_redirects=False)
     assert _ordered_task_ids(job) == [t1.id, t2.id]
 
 
@@ -221,7 +221,7 @@ def test_jobs_move_task_down_swaps_order(app, client):
     t1, t2 = _task(admin, name="first"), _task(admin, name="second")
     _assign(job, t1)
     _assign(job, t2)
-    resp = client.get(f"/jobs/{job.id}/move_task_down/{t1.id}", follow_redirects=False)
+    resp = client.post(f"/jobs/{job.id}/move_task_down/{t1.id}", follow_redirects=False)
     assert resp.status_code in (301, 302)
     assert _ordered_task_ids(job) == [t2.id, t1.id]
 
@@ -233,7 +233,7 @@ def test_jobs_remove_all_tasks_clears(app, client):
     job = _job(admin, cust)
     _assign(job, _task(admin, name="a"))
     _assign(job, _task(admin, name="b"))
-    resp = client.get(f"/jobs/{job.id}/remove_all_tasks", follow_redirects=False)
+    resp = client.post(f"/jobs/{job.id}/remove_all_tasks", follow_redirects=False)
     assert resp.status_code in (301, 302)
     assert JobTasks.query.filter_by(job_id=job.id).count() == 0
 
@@ -271,7 +271,7 @@ def test_jobs_start_queues_job(app, client, tmp_path):
     job = _job(admin, cust, status="Ready", hashfile_id=hf.id)
     wl = _static_wl(admin, tmp_path)
     _assign(job, _task(admin, wl_id=wl.id))
-    resp = client.get(f"/jobs/start/{job.id}", follow_redirects=False)
+    resp = client.post(f"/jobs/start/{job.id}", follow_redirects=False)
     assert resp.status_code in (301, 302)
     assert Jobs.query.get(job.id).status == "Queued"
     assert JobTasks.query.filter_by(job_id=job.id).first().status == "Queued"
@@ -283,7 +283,7 @@ def test_jobs_stop_cancels_running_job(app, client):
     cust = make_customer()
     job = _job(admin, cust, status="Running")
     jt = _assign(job, _task(admin), status="Running")
-    resp = client.get(f"/jobs/stop/{job.id}", follow_redirects=False)
+    resp = client.post(f"/jobs/stop/{job.id}", follow_redirects=False)
     assert resp.status_code in (301, 302)
     assert Jobs.query.get(job.id).status == "Canceled"
     assert JobTasks.query.get(jt.id).status == "Canceled"
@@ -294,7 +294,7 @@ def test_jobs_stop_non_running_flashes(app, client):
     login(client, admin)
     cust = make_customer()
     job = _job(admin, cust, status="Ready")
-    resp = client.get(f"/jobs/stop/{job.id}", follow_redirects=False)
+    resp = client.post(f"/jobs/stop/{job.id}", follow_redirects=False)
     assert resp.status_code in (301, 302)
     assert Jobs.query.get(job.id).status == "Ready"
 

--- a/tests/unit/test_jobs_routes_guards.py
+++ b/tests/unit/test_jobs_routes_guards.py
@@ -113,12 +113,12 @@ def test_jobs_assign_then_remove_task_round_trip(app, client):
     task = _make_task(user.id, wl.id)
     _login(client, user)
 
-    resp = client.get(f"/jobs/{job.id}/assign_task/{task.id}",
+    resp = client.post(f"/jobs/{job.id}/assign_task/{task.id}",
                       follow_redirects=False)
     assert resp.status_code in (301, 302)
     assert JobTasks.query.filter_by(job_id=job.id, task_id=task.id).count() == 1
 
-    resp = client.get(f"/jobs/{job.id}/remove_task/{task.id}",
+    resp = client.post(f"/jobs/{job.id}/remove_task/{task.id}",
                       follow_redirects=False)
     assert resp.status_code in (301, 302)
     assert JobTasks.query.filter_by(job_id=job.id, task_id=task.id).count() == 0
@@ -132,8 +132,8 @@ def test_jobs_assign_duplicate_static_wordlist_task_rejected(app, client):
     task = _make_task(user.id, wl.id)
     _login(client, user)
 
-    client.get(f"/jobs/{job.id}/assign_task/{task.id}")
-    resp = client.get(f"/jobs/{job.id}/assign_task/{task.id}",
+    client.post(f"/jobs/{job.id}/assign_task/{task.id}")
+    resp = client.post(f"/jobs/{job.id}/assign_task/{task.id}",
                       follow_redirects=True)
     assert b"Task already assigned to the job." in resp.data
     assert JobTasks.query.filter_by(job_id=job.id, task_id=task.id).count() == 1
@@ -149,8 +149,8 @@ def test_jobs_assign_duplicate_dynamic_wordlist_task_allowed(app, client):
     task = _make_task(user.id, wl.id)
     _login(client, user)
 
-    client.get(f"/jobs/{job.id}/assign_task/{task.id}")
-    client.get(f"/jobs/{job.id}/assign_task/{task.id}")
+    client.post(f"/jobs/{job.id}/assign_task/{task.id}")
+    client.post(f"/jobs/{job.id}/assign_task/{task.id}")
     assert JobTasks.query.filter_by(job_id=job.id, task_id=task.id).count() == 2
 
 
@@ -338,13 +338,13 @@ def test_jobs_assign_task_group_assigns_all_and_skips_static_dupes(app, client):
     db.session.commit()
     _login(client, user)
 
-    resp = client.get(f"/jobs/{job.id}/assign_task_group/{tg.id}",
+    resp = client.post(f"/jobs/{job.id}/assign_task_group/{tg.id}",
                       follow_redirects=False)
     assert resp.status_code in (301, 302)
     assert JobTasks.query.filter_by(job_id=job.id).count() == 2
 
     # re-assigning the group: static-wordlist tasks are not duplicated
-    client.get(f"/jobs/{job.id}/assign_task_group/{tg.id}")
+    client.post(f"/jobs/{job.id}/assign_task_group/{tg.id}")
     assert JobTasks.query.filter_by(job_id=job.id).count() == 2
 
 
@@ -372,7 +372,7 @@ def test_jobs_move_task_up_swaps_order(app, client):
     job, t1, t2 = _job_with_two_tasks(user)
     _login(client, user)
 
-    resp = client.get(f"/jobs/{job.id}/move_task_up/{t2.id}",
+    resp = client.post(f"/jobs/{job.id}/move_task_up/{t2.id}",
                       follow_redirects=False)
     assert resp.status_code in (301, 302)
     assert _task_order(job.id) == [t2.id, t1.id]
@@ -383,7 +383,7 @@ def test_jobs_move_task_up_already_top_warns(app, client):
     job, t1, t2 = _job_with_two_tasks(user)
     _login(client, user)
 
-    resp = client.get(f"/jobs/{job.id}/move_task_up/{t1.id}",
+    resp = client.post(f"/jobs/{job.id}/move_task_up/{t1.id}",
                       follow_redirects=True)
     assert b"already at the top" in resp.data
     assert _task_order(job.id) == [t1.id, t2.id]  # unchanged
@@ -394,7 +394,7 @@ def test_jobs_move_task_down_swaps_order(app, client):
     job, t1, t2 = _job_with_two_tasks(user)
     _login(client, user)
 
-    resp = client.get(f"/jobs/{job.id}/move_task_down/{t1.id}",
+    resp = client.post(f"/jobs/{job.id}/move_task_down/{t1.id}",
                       follow_redirects=False)
     assert resp.status_code in (301, 302)
     assert _task_order(job.id) == [t2.id, t1.id]
@@ -405,7 +405,7 @@ def test_jobs_move_task_down_already_bottom_warns(app, client):
     job, t1, t2 = _job_with_two_tasks(user)
     _login(client, user)
 
-    resp = client.get(f"/jobs/{job.id}/move_task_down/{t2.id}",
+    resp = client.post(f"/jobs/{job.id}/move_task_down/{t2.id}",
                       follow_redirects=True)
     assert b"already at the bottom" in resp.data
     assert _task_order(job.id) == [t1.id, t2.id]  # unchanged
@@ -544,7 +544,7 @@ def test_jobs_start_owner_queues(app, client):
     job, task, jt = _full_wizard_job(user)
     _login(client, user)
 
-    resp = client.get(f"/jobs/start/{job.id}", follow_redirects=False)
+    resp = client.post(f"/jobs/start/{job.id}", follow_redirects=False)
     assert resp.status_code in (301, 302)
     db.session.expire_all()
     assert Jobs.query.get(job.id).status == "Queued"
@@ -557,7 +557,7 @@ def test_jobs_start_non_owner_denied(app, client):
     job, task, jt = _full_wizard_job(admin)
     _login(client, user)
 
-    resp = client.get(f"/jobs/start/{job.id}", follow_redirects=True)
+    resp = client.post(f"/jobs/start/{job.id}", follow_redirects=True)
     assert b"do not have rights to start this job" in resp.data
     assert Jobs.query.get(job.id).status == "Incomplete"  # unchanged
 
@@ -568,7 +568,7 @@ def test_jobs_start_without_tasks_errors(app, client):
     job = _make_job(user.id, customer.id)
     _login(client, user)
 
-    resp = client.get(f"/jobs/start/{job.id}", follow_redirects=True)
+    resp = client.post(f"/jobs/start/{job.id}", follow_redirects=True)
     assert b"Error in starting job" in resp.data
 
 
@@ -579,7 +579,7 @@ def test_jobs_stop_running_job_cancels(app, client):
     db.session.commit()
     _login(client, user)
 
-    resp = client.get(f"/jobs/stop/{job.id}", follow_redirects=False)
+    resp = client.post(f"/jobs/stop/{job.id}", follow_redirects=False)
     assert resp.status_code in (301, 302)
     db.session.expire_all()
     assert Jobs.query.get(job.id).status == "Canceled"
@@ -592,7 +592,7 @@ def test_jobs_stop_not_running_flashes(app, client):
     job, task, jt = _full_wizard_job(user, status="Incomplete")
     _login(client, user)
 
-    resp = client.get(f"/jobs/stop/{job.id}", follow_redirects=True)
+    resp = client.post(f"/jobs/stop/{job.id}", follow_redirects=True)
     assert b"not activly running" in resp.data
     assert Jobs.query.get(job.id).status == "Incomplete"  # unchanged
 
@@ -603,6 +603,6 @@ def test_jobs_stop_non_owner_denied(app, client):
     job, task, jt = _full_wizard_job(admin, status="Running")
     _login(client, user)
 
-    resp = client.get(f"/jobs/stop/{job.id}", follow_redirects=True)
+    resp = client.post(f"/jobs/stop/{job.id}", follow_redirects=True)
     assert b"do not have rights to stop this job" in resp.data
     assert Jobs.query.get(job.id).status == "Running"  # unchanged

--- a/tests/unit/test_lucky_and_one_and_done.py
+++ b/tests/unit/test_lucky_and_one_and_done.py
@@ -128,7 +128,7 @@ def test_lucky_assigns_historically_effective_tasks_for_hash_type(
 
     _login(client, admin.id)
 
-    resp = client.get(
+    resp = client.post(
         f"/jobs/{job.id}/assign_task/lucky",
         follow_redirects=False,
     )


### PR DESCRIPTION
…(#167)

The /jobs/* task-management and start/stop endpoints mutated DB state over GET, which Flask-WTF's CSRF protection doesn't cover -- a forged cross-site GET (a link or <img src> the victim loads) could trigger them under their session.

This replaces the earlier "validate a CSRF token on the GET" approach with the idiomatic fix: the nine handlers are now POST-only and each validates CSRF via a bare FlaskForm().validate_on_submit() (token carried in the request body, not the URL). The templates that invoked these routes are converted from <a> links to POST <form>s carrying {{ csrf_token() }} hidden inputs:
  - jobs_assigned_tasks.html.j2: add task / add task group / lucky / move up / move down / remove task / remove all
  - jobs.html.j2: Start / Stop / Restart (job actions menu)

Handlers now POST: jobs_assign_task, jobs_assign_task_group, jobs_assign_lucky_task_group, jobs_move_task_up, jobs_move_task_down, jobs_remove_task, jobs_remove_all_tasks, jobs_start, jobs_stop. Read-only views (assigned_hashfile cracked view, tasks list) stay GET.

Tests updated to POST these endpoints (CSRF is disabled in the test config, so a bare POST validates): test_jobs_routes_guards.py, test_jobs_routes.py, test_delete_idempotency.py, test_lucky_and_one_and_done.py.