### PR TITLE
test: xfail tests documenting i128's open issues

### DIFF
--- a/tests/unit/test_issue_xfail_admin_features.py
+++ b/tests/unit/test_issue_xfail_admin_features.py
@@ -1,0 +1,302 @@
+"""xfail tests documenting open GitHub issues for admin-facing features.
+
+Each test asserts the DESIRED behavior described in the linked issue and is
+marked ``@pytest.mark.xfail(strict=False)`` so it records as XFAIL until the
+feature lands (and XPASS once it does) — never as a hard failure or collection
+error. They are also ``@pytest.mark.security`` so the parent Playwright autouse
+fixtures (which need a live server) are skipped (see tests/unit/conftest.py).
+
+Issues covered:
+
+* #39  — Admin Settings "Database" tab: DB OPTIMIZE action. The encrypted
+         export already exists (settings.settings_backup, covered by
+         test_db_backup.py); the missing piece is an admin-gated
+         ``OPTIMIZE TABLE hashes; OPTIMIZE TABLE hashfile_hashes;`` action.
+* #30  — Notify admins when agents stop checking in. ``notify_admins`` exists
+         (hashview/utils/utils.py) but nothing detects stale agents.
+* #91  — Logging of user activity. Audit logging is broad, but job start/stop
+         and wordlist edit emit no ``log_event``.
+"""
+
+import inspect
+import os
+from datetime import datetime, timedelta
+
+import pytest
+
+from hashview.models import (
+    Agents,
+    Customers,
+    JobTasks,
+    Jobs,
+    Settings,
+    Users,
+    Wordlists,
+)
+from hashview.models import db as _db
+from hashview.utils.audit import configure_audit_logging, log_event, logs_dir
+
+from .helpers import login, make_admin, make_customer, make_user
+
+pytestmark = pytest.mark.security
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def audit_app(app, tmp_path):
+    """Re-point the audit/error loggers into tmp_path for this test.
+
+    Mirrors the pattern in test_audit_log.py / test_logs_view.py: set the
+    HASHVIEW_LOGS_DIR override and re-run the idempotent configurator so audit
+    lines land under tmp_path instead of the repo's real logs dir.
+    """
+    app.config["HASHVIEW_LOGS_DIR"] = str(tmp_path / "logs")
+    configure_audit_logging(app)
+    return app
+
+
+def _audit_events(app):
+    """Return the list of event names recorded in the audit log (may be empty)."""
+    import json
+
+    path = os.path.join(logs_dir(app), "audit.log")
+    if not os.path.exists(path):
+        return []
+    out = []
+    with open(path, encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                out.append(json.loads(line))
+            except ValueError:
+                continue
+    return out
+
+
+def _seed_job(owner, customer, status="Queued"):
+    job = Jobs(name="demo job", status=status, customer_id=customer.id,
+               owner_id=owner.id, priority=3)
+    _db.session.add(job)
+    _db.session.commit()
+    task = JobTasks(job_id=job.id, task_id=1, status="Not Started", priority=3)
+    _db.session.add(task)
+    _db.session.commit()
+    return job
+
+
+# ===========================================================================
+# Issue #39 — Admin Settings "Database" tab: DB OPTIMIZE
+# ===========================================================================
+
+
+@pytest.mark.xfail(reason="issue #39: admin DB optimize route not implemented",
+                   strict=False)
+def test_optimize_route_flashes_success_for_admin(client, app):
+    """An admin can trigger DB OPTIMIZE and gets a success flash.
+
+    Desired: a settings route (e.g. /settings/optimize) runs
+    ``OPTIMIZE TABLE hashes; OPTIMIZE TABLE hashfile_hashes;`` and flashes
+    success. We follow the redirect so the flashed message is rendered.
+    """
+    _db.session.add(Settings(retention_period=30, max_runtime_jobs=0,
+                             max_runtime_tasks=0))
+    _db.session.commit()
+    admin = make_admin()
+    login(client, admin)
+
+    resp = client.post("/settings/optimize", follow_redirects=True)
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True).lower()
+    assert "optim" in html and ("success" in html or "complete" in html)
+
+
+@pytest.mark.xfail(reason="issue #39: admin DB optimize route not implemented",
+                   strict=False)
+def test_optimize_route_is_admin_gated(client, app):
+    """A non-admin must NOT be able to run DB OPTIMIZE.
+
+    Desired: the route exists but rejects non-admins (403, or a redirect that
+    is not the admin success path). Either way it must not return a plain 200
+    success page to a regular user.
+    """
+    _db.session.add(Settings(retention_period=30, max_runtime_jobs=0,
+                             max_runtime_tasks=0))
+    _db.session.commit()
+    user = make_user()
+    login(client, user)
+
+    resp = client.post("/settings/optimize")
+    # A 404 here means the route doesn't exist yet (feature missing) — which is
+    # the xfail condition; otherwise it must be denied, never a 200 success.
+    assert resp.status_code in (403, 401) or 300 <= resp.status_code < 400
+    if 300 <= resp.status_code < 400:
+        assert "/settings/optimize" not in resp.headers.get("Location", "")
+
+
+@pytest.mark.xfail(reason="issue #39: optimize helper not implemented in "
+                          "hashview.settings.routes", strict=False)
+def test_optimize_helper_exists_in_settings_routes():
+    """An ``optimize_database``/``optimize_tables`` helper exists in
+    hashview.settings.routes that issues the OPTIMIZE TABLE statements."""
+    import hashview.settings.routes as sr
+
+    helper = (getattr(sr, "optimize_database", None)
+              or getattr(sr, "optimize_tables", None))
+    assert helper is not None and callable(helper)
+    # It should reference the two tables the issue calls out.
+    src = inspect.getsource(helper)
+    assert "OPTIMIZE TABLE" in src
+    assert "hashes" in src and "hashfile_hashes" in src
+
+
+# ===========================================================================
+# Issue #30 — Notify admins when agents stop checking in
+# ===========================================================================
+
+
+@pytest.mark.xfail(reason="issue #30: stale-agent detection helper not "
+                          "implemented", strict=False)
+def test_stale_agent_detection_helper_exists():
+    """A helper to detect agents that have stopped checking in exists.
+
+    Desired: something like ``hashview.scheduler.check_agent_checkins`` (or an
+    equivalently named helper in scheduler/utils) that the scheduler can run.
+    """
+    import importlib
+
+    found = None
+    for modname in ("hashview.scheduler", "hashview.utils.utils"):
+        mod = importlib.import_module(modname)
+        for name in ("check_agent_checkins", "notify_stale_agents",
+                     "detect_stale_agents", "check_stale_agents",
+                     "agent_checkin_monitor"):
+            cand = getattr(mod, name, None)
+            if callable(cand):
+                found = cand
+                break
+        if found:
+            break
+    assert found is not None, "no stale-agent detection helper found"
+
+
+@pytest.mark.xfail(reason="issue #30: stale agents do not trigger "
+                          "notify_admins", strict=False)
+def test_stale_agent_detection_notifies_admins(app, monkeypatch):
+    """Running stale-agent detection fires notify_admins for an Agent whose
+    last_checkin is old.
+
+    Desired: with an admin user present and an Agent that last checked in well
+    beyond any reasonable threshold, the detection helper calls
+    ``notify_admins(subject, message)`` at least once.
+    """
+    import importlib
+
+    make_admin()
+    stale = Agents(
+        name="gpu-rig-01",
+        src_ip="10.0.0.9",
+        uuid="a" * 36,
+        status="Idle",
+        last_checkin=datetime.utcnow() - timedelta(hours=12),
+    )
+    _db.session.add(stale)
+    _db.session.commit()
+
+    calls = []
+
+    # Patch notify_admins everywhere it might be referenced.
+    def _spy(subject, message):
+        calls.append((subject, message))
+
+    import hashview.utils.utils as uu
+    monkeypatch.setattr(uu, "notify_admins", _spy, raising=False)
+
+    found = None
+    for modname in ("hashview.scheduler", "hashview.utils.utils"):
+        mod = importlib.import_module(modname)
+        monkeypatch.setattr(mod, "notify_admins", _spy, raising=False)
+        for name in ("check_agent_checkins", "notify_stale_agents",
+                     "detect_stale_agents", "check_stale_agents",
+                     "agent_checkin_monitor"):
+            cand = getattr(mod, name, None)
+            if callable(cand):
+                found = cand
+
+    assert found is not None, "no stale-agent detection helper to run"
+    # Call with the app where the signature allows it; otherwise call bare.
+    try:
+        found(app)
+    except TypeError:
+        found()
+
+    assert calls, "stale agent should have triggered notify_admins"
+
+
+# ===========================================================================
+# Issue #91 — Logging of user activity (job start/stop, wordlist edit)
+# ===========================================================================
+
+
+@pytest.mark.xfail(reason="issue #91: job start is not audited (no job.start "
+                          "log_event)", strict=False)
+def test_job_start_is_audited(client, audit_app):
+    """Starting a job writes a job.start audit line."""
+    admin = make_admin()
+    customer = make_customer()
+    job = _seed_job(admin, customer, status="Ready")
+    login(client, admin)
+
+    resp = client.get(f"/jobs/start/{job.id}")
+    assert resp.status_code in (200, 301, 302)
+
+    starts = [e for e in _audit_events(audit_app) if e.get("event") == "job.start"]
+    assert starts, "expected a job.start audit line after starting a job"
+
+
+@pytest.mark.xfail(reason="issue #91: job stop is not audited (no job.stop/"
+                          "job.cancel log_event)", strict=False)
+def test_job_stop_is_audited(client, audit_app):
+    """Stopping a running job writes a job.stop (or job.cancel) audit line."""
+    admin = make_admin()
+    customer = make_customer()
+    job = _seed_job(admin, customer, status="Running")
+    login(client, admin)
+
+    resp = client.get(f"/jobs/stop/{job.id}")
+    assert resp.status_code in (200, 301, 302)
+
+    stops = [e for e in _audit_events(audit_app)
+             if e.get("event") in ("job.stop", "job.cancel")]
+    assert stops, "expected a job.stop/job.cancel audit line after stopping a job"
+
+
+@pytest.mark.xfail(reason="issue #91: wordlist edit is not audited (only "
+                          "create/delete emit log_event)", strict=False)
+def test_wordlist_edit_is_audited(client, audit_app):
+    """Editing/updating a wordlist writes a wordlist.edit audit line.
+
+    Only wordlist create/delete currently emit log_event; the update path
+    (/wordlists/update/<id>) emits nothing. We drive it against a static
+    wordlist so the route takes the no-op branch (no file I/O, never errors)
+    yet should still record the edit attempt.
+    """
+    admin = make_admin()
+    wl = Wordlists(name="rockyou", owner_id=admin.id, type="static",
+                   path="/tmp/does-not-matter.txt", size=0, byte_size=0,
+                   checksum="0" * 64)
+    _db.session.add(wl)
+    _db.session.commit()
+    login(client, admin)
+
+    resp = client.get(f"/wordlists/update/{wl.id}")
+    assert resp.status_code in (200, 301, 302)
+
+    edits = [e for e in _audit_events(audit_app)
+             if e.get("event") == "wordlist.edit"]
+    assert edits, "expected a wordlist.edit audit line after updating a wordlist"

--- a/tests/unit/test_issue_xfail_analytics.py
+++ b/tests/unit/test_issue_xfail_analytics.py
@@ -1,0 +1,135 @@
+"""xfail tests documenting open analytics GitHub issues.
+
+Each test asserts the DESIRED behavior and is marked xfail (strict=False) so it
+records as XFAIL while the issue is open and flips to XPASS once fixed. They are
+written to be collectible and to run as XFAIL/XPASS (never ERROR).
+
+Issues covered:
+- #92: "Top 10 users who share the same password" — the Shared Passwords card
+  groups shared plaintexts but is UNCAPPED (hashview/analytics/routes.py ~334-338,
+  rendered in templates/analytics.html.j2 ~514-541). The issue asks for a Top-10
+  ranking.
+- #50: "Record and display instacrack rate in analytics" — instacrack is computed
+  at upload time (hashview/api/routes.py, hashview/jobs/routes.py) but the rate is
+  never persisted on Hashfiles (models.py ~197-205) nor surfaced on /analytics.
+"""
+
+import re
+
+import pytest
+
+from hashview.models import Customers, Hashes, HashfileHashes, Hashfiles, db
+from tests.unit.helpers import login, make_admin
+
+
+def _seed_shared_groups(n_groups):
+    """Seed `n_groups` distinct shared-password groups under one customer/hashfile.
+
+    Each group is a unique plaintext shared by exactly two usernames (so every
+    group qualifies as "shared", i.e. used by >1 account). Returns the customer id.
+    """
+    cust = Customers(name="SharedCo")
+    db.session.add(cust)
+    db.session.commit()
+    hf = Hashfiles(name="dump", customer_id=cust.id, owner_id=1, runtime=0)
+    db.session.add(hf)
+    db.session.commit()
+
+    for g in range(n_groups):
+        plaintext = f"SharedPw{g}!"
+        for member in range(2):
+            ct = f"ct{g}_{member}"
+            h = Hashes(sub_ciphertext="0" * 8, ciphertext=ct, hash_type=1000,
+                       cracked=True, plaintext=plaintext)
+            db.session.add(h)
+            db.session.commit()
+            db.session.add(HashfileHashes(hash_id=h.id, hashfile_id=hf.id,
+                                          username=f"user{g}_{member}"))
+    db.session.commit()
+    return cust.id
+
+
+def _count_shared_groups(html):
+    """Count rendered shared-password groups.
+
+    The template renders one POST form per group:
+        <form method="POST" action="/analytics/download/shared" ...>
+    so counting those occurrences gives the number of rendered groups.
+    """
+    return len(re.findall(r'action="/analytics/download/shared"', html))
+
+
+# --------------------------------------------------------------------------- #
+# Issue #92: shared-password grouping should be a Top-10 ranking, not uncapped #
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.xfail(reason="issue #92: shared-password grouping is uncapped; "
+                          "should be ranked Top 10", strict=False)
+def test_shared_passwords_ranking_capped_at_top_10(app, client):
+    admin = make_admin()
+    login(client, admin)
+    customer_id = _seed_shared_groups(15)
+
+    resp = client.get(f"/analytics?customer_id={customer_id}")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+
+    rendered = _count_shared_groups(html)
+    assert rendered > 0, "expected shared-password groups to be rendered"
+    assert rendered <= 10, (
+        f"shared-password groups should be capped at Top 10, got {rendered}")
+
+
+def test_shared_password_grouping_present_and_ranked(app, client):
+    """The shared-password grouping/section is present in the response.
+
+    This portion (the section exists at all) is already true today, so it is NOT
+    marked xfail — it documents the baseline the #92 ranking builds on.
+    """
+    admin = make_admin()
+    login(client, admin)
+    customer_id = _seed_shared_groups(12)
+
+    resp = client.get(f"/analytics?customer_id={customer_id}")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+
+    assert "Shared Passwords" in html
+    assert _count_shared_groups(html) > 0
+
+
+# --------------------------------------------------------------------------- #
+# Issue #50: record + display instacrack rate in analytics                    #
+# --------------------------------------------------------------------------- #
+
+@pytest.mark.xfail(reason="issue #50: Hashfiles has no persisted instacrack-rate "
+                          "column", strict=False)
+def test_hashfile_model_has_instacrack_field(app):
+    # A plausibly-named persisted column for the instacrack rate should exist on
+    # the Hashfiles model. None of these exist today (models.py ~197-205).
+    candidates = [
+        "instacrack_rate",
+        "instacrack",
+        "insta_crack_rate",
+        "instacracked",
+        "instacrack_percent",
+        "instacrack_count",
+    ]
+    assert any(hasattr(Hashfiles, name) for name in candidates), (
+        "Hashfiles should persist an instacrack-rate field; "
+        f"none of {candidates} found")
+
+
+@pytest.mark.xfail(reason="issue #50: instacrack rate is not displayed on the "
+                          "analytics page", strict=False)
+def test_analytics_page_displays_instacrack_rate(app, client):
+    admin = make_admin()
+    login(client, admin)
+    customer_id = _seed_shared_groups(2)
+
+    resp = client.get(f"/analytics?customer_id={customer_id}")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+
+    assert "instacrack" in html.lower(), (
+        "analytics page should display the instacrack rate")

--- a/tests/unit/test_issue_xfail_misc.py
+++ b/tests/unit/test_issue_xfail_misc.py
@@ -1,0 +1,141 @@
+"""xfail tests documenting open GitHub issues.
+
+Each test asserts the DESIRED behavior and is marked ``xfail(strict=False)``
+so the suite stays green whether the bug is still present (XFAIL) or has been
+fixed in the meantime (XPASS). They must always *collect* and *run* — never
+error — so seeding is kept minimal and self-contained.
+
+Style mirrors tests/unit/test_task_groups_routes.py / test_searches_routes.py.
+"""
+
+from configparser import ConfigParser
+
+import pytest
+
+from hashview.models import Hashfiles, Jobs, TaskGroups, Tasks, db
+from tests.unit.helpers import login, make_admin
+
+
+def _task(owner, name="t"):
+    t = Tasks(name=name, hc_attackmode=0, owner_id=owner.id)
+    db.session.add(t)
+    db.session.commit()
+    return t
+
+
+# ---------------------------------------------------------------------------
+# Issue #100 — "Rename Task Group after creation"
+# ---------------------------------------------------------------------------
+@pytest.mark.xfail(reason="issue #100: rename task group after creation",
+                   strict=False)
+def test_task_group_can_be_renamed_after_creation(app, client):
+    """POSTing the edit form should persist a new TaskGroups.name.
+
+    The rename/edit route lives at hashview/task_groups/routes.py
+    (``task_groups_edit`` at ~line 86, ``POST /task_groups/edit``). This is
+    implemented today, so the test is expected to XPASS.
+    """
+    admin = make_admin()
+    login(client, admin)
+    t = _task(admin, "member")
+    tg = TaskGroups(name="OldName", owner_id=admin.id, tasks=str([t.id]))
+    db.session.add(tg)
+    db.session.commit()
+    tg_id = tg.id
+
+    resp = client.post("/task_groups/edit", data={
+        "group_id": tg_id,
+        "name": "NewName",
+        "task_ids": str(t.id),
+        "submit": "Save",
+    }, follow_redirects=False)
+    assert resp.status_code in (301, 302)
+
+    assert TaskGroups.query.get(tg_id).name == "NewName"
+
+
+# ---------------------------------------------------------------------------
+# Issue #57 — "DB password can not contain % character"
+# ---------------------------------------------------------------------------
+@pytest.mark.xfail(reason="issue #57: DB password cannot contain % character",
+                   strict=False)
+def test_db_password_with_percent_is_parsed():
+    """A literal '%' in the DB password must survive ConfigParser parsing.
+
+    hashview/config.py (lines ~5, ~19-24) builds a plain ``ConfigParser()``
+    (which performs ``%`` interpolation) and then concatenates
+    ``file_config['database']['password']`` straight into the SQLAlchemy URI.
+    A literal '%' in the password trips ``InterpolationSyntaxError`` on read.
+
+    This reproduces config.py's exact read path; do NOT modify config.py.
+    Expected to XFAIL until config.py uses a raw/interpolation-free parser.
+    """
+    parser = ConfigParser()
+    parser.read_dict({
+        "database": {
+            "username": "hashview",
+            "password": "pa%word",
+            "host": "localhost",
+        },
+    })
+
+    # config.py concatenates this value directly — the access itself raises
+    # configparser.InterpolationSyntaxError when the value contains a lone '%'.
+    password = parser["database"]["password"]
+    assert password == "pa%word"
+
+
+# ---------------------------------------------------------------------------
+# Issue #99 — "Long task list not scrollable"
+# ---------------------------------------------------------------------------
+@pytest.mark.xfail(reason="issue #99: long task list not scrollable",
+                   strict=False)
+def test_job_task_selection_lists_all_tasks(app, client):
+    """The job task-selection page should render every available task.
+
+    Renders ``jobs_list_tasks`` (hashview/jobs/routes.py ~449,
+    ``GET /jobs/<id>/tasks``) with ~25 seeded Tasks and asserts each task
+    name appears, i.e. no server-side truncation of the list.
+
+    NOTE: the real issue #99 is a CSS/scroll-container problem in the
+    template — the long list overflows without a scrollbar. That is a
+    front-end concern and only partially unit-testable; here we can only
+    verify the server emits the full set of task names. Expected to XPASS.
+    """
+    admin = make_admin()
+    login(client, admin)
+
+    names = [f"task_{i:02d}" for i in range(25)]
+    for n in names:
+        _task(admin, n)
+
+    job = Jobs(name="J", status="Ready", customer_id=1, owner_id=admin.id)
+    db.session.add(job)
+    db.session.commit()
+
+    resp = client.get(f"/jobs/{job.id}/tasks")
+    assert resp.status_code == 200
+    for n in names:
+        assert n.encode() in resp.data
+
+
+# ---------------------------------------------------------------------------
+# Issue #176 — "Status indicator for large hashfile imports"
+# ---------------------------------------------------------------------------
+@pytest.mark.xfail(reason="issue #176: status indicator for large hashfile imports",
+                   strict=False)
+def test_hashfile_exposes_import_status(app):
+    """The Hashfiles model should expose an import status/progress field.
+
+    Today the Hashfiles model (hashview/models.py ~197-205) has only
+    id/name/uploaded_at/runtime/customer_id/owner_id — there is no column
+    surfacing the progress of a long-running import, so the UI has nothing
+    to render a status indicator from. Expected to XFAIL until such a field
+    is added (and a corresponding indicator wired into the upload UI).
+    """
+    hf = Hashfiles(name="big.txt", customer_id=1, owner_id=1)
+    db.session.add(hf)
+    db.session.commit()
+
+    assert any(hasattr(hf, attr)
+               for attr in ("status", "import_status", "progress"))

--- a/tests/unit/test_issue_xfail_search_encoding.py
+++ b/tests/unit/test_issue_xfail_search_encoding.py
@@ -1,0 +1,92 @@
+"""xfail tests documenting search/encoding GitHub issues.
+
+Each test asserts the CORRECT/DESIRED behavior and is marked
+``@pytest.mark.xfail(strict=False)`` so it documents the issue without
+breaking the suite. Some of these issues are already fixed on this branch
+(UTF-8 storage path), in which case the test XPASSes and acts as a
+regression guard.
+
+Issues covered:
+  * #22  - User search is case sensitive
+  * #140 - Usernames with en dash (U+2013) can not be imported
+"""
+
+import io
+
+import pytest
+
+from hashview.models import Customers, Hashes, HashfileHashes, Hashfiles, db
+from hashview.searches.routes import get_rows
+from hashview.utils.utils import text_from_field
+from tests.unit.helpers import login, make_admin
+
+
+def _seed_cracked(username="bob", plaintext="Hunter2", ciphertext="deadbeef"):
+    """Seed a cracked Hashes + HashfileHashes pair (mirrors
+    test_searches_routes._seed_cracked)."""
+    cust = Customers(name="SearchCo")
+    db.session.add(cust)
+    db.session.commit()
+    hf = Hashfiles(name="hf", customer_id=cust.id, owner_id=1)
+    db.session.add(hf)
+    db.session.commit()
+    h = Hashes(sub_ciphertext="0" * 8, ciphertext=ciphertext, hash_type=1000,
+               cracked=True, plaintext=plaintext)
+    db.session.add(h)
+    db.session.commit()
+    hfh = HashfileHashes(hash_id=h.id, hashfile_id=hf.id, username=username)
+    db.session.add(hfh)
+    db.session.commit()
+    return cust, hf, h, hfh
+
+
+@pytest.mark.xfail(reason="issue #22: user search is case sensitive", strict=False)
+def test_user_search_is_case_insensitive(app, client):
+    """A user search for 'bob' should match a stored username 'Bob'.
+
+    DESIRED: username search is case-insensitive. SQLite's LIKE is ASCII
+    case-insensitive by default, so on the current UTF-8 storage path this
+    likely XPASSes and guards against a regression.
+    """
+    admin = make_admin()
+    login(client, admin)
+    _seed_cracked(username="Bob")
+
+    resp = client.post("/search", data={
+        "search_type": "user", "query": "bob",
+        "submit": "Search",
+    })
+
+    assert resp.status_code == 200
+    assert b"Bob" in resp.data
+
+
+@pytest.mark.xfail(reason="issue #140: usernames with en dash can not be imported",
+                   strict=False)
+def test_username_with_en_dash_round_trips(app):
+    """A username containing an en dash (U+2013) must survive storage and
+    CSV export.
+
+    DESIRED: the en dash round-trips through text_from_field (the storage
+    normalizer used by import_hashfilehashes) and the get_rows CSV export.
+    The old code latin-1 encoded usernames, which mangled non-latin-1
+    characters; the current UTF-8 path should preserve it (XPASS = regression
+    guard).
+    """
+    en_dash_username = "alice–bob"
+
+    # Normalise the field exactly as import_hashfilehashes does.
+    stored = text_from_field(en_dash_username)
+
+    cust, hf, h, hfh = _seed_cracked(username=stored, ciphertext="abc123")
+
+    # Read it back from the DB.
+    fetched = db.session.query(HashfileHashes).filter_by(id=hfh.id).one()
+    assert fetched.username == en_dash_username
+
+    # And verify it survives a CSV export via get_rows.
+    str_io = io.StringIO()
+    get_rows(str_io, [(h, fetched)], "hashfile", [cust], [hf])
+    out = str_io.getvalue()
+    assert "–" in out
+    assert en_dash_username in out

--- a/tests/unit/test_issue_xfail_task_lifecycle.py
+++ b/tests/unit/test_issue_xfail_task_lifecycle.py
@@ -1,0 +1,290 @@
+"""XFAIL regression tests documenting open GitHub issues in the task lifecycle.
+
+Each test asserts the CORRECT / DESIRED behavior and is marked
+``@pytest.mark.xfail(strict=False)`` so it shows up as XFAIL while the bug is
+live and flips to XPASS once fixed. These are executable specifications of the
+fixes, not assertions of current (buggy) behavior.
+
+Issues covered:
+  - #139  Canceled tasks retain assigned agent
+  - #130  Tasks remain active after all hashes cracked
+  - #64   hc_cracked filename collisions across JobTasks
+  - #129  Blank Hashfile Name from pasted (whitespace-only) hashes
+
+Infra/fixtures come from tests/unit/conftest.py (``app``, ``client``,
+``db_session``) and tests/unit/helpers.py.
+"""
+
+import inspect
+import json
+from datetime import datetime
+
+import pytest
+
+from hashview.models import (
+    Agents,
+    Customers,
+    Hashes,
+    HashfileHashes,
+    Hashfiles,
+    Jobs,
+    JobTasks,
+    Settings,
+    Tasks,
+    Users,
+    db,
+)
+from hashview.utils.utils import build_hashcat_command, get_md5_hash
+
+
+DOMAIN = "localhost.test"
+
+
+def _agent_version_cookie(client):
+    import hashview
+    client.set_cookie("agent_version", hashview.__version__, domain=DOMAIN)
+
+
+# ---------------------------------------------------------------------------
+# #139 — Canceled tasks retain assigned agent
+# ---------------------------------------------------------------------------
+@pytest.mark.xfail(
+    reason="issue #139: a 'Working' heartbeat for a Canceled JobTasks returns "
+           "msg='Canceled' but never clears job_task.agent_id "
+           "(hashview/api/routes.py ~263-274), so the row stays bound to the "
+           "agent and the next Idle heartbeat resumes it",
+    strict=False,
+)
+def test_canceled_task_clears_agent_assignment(app, client):
+    """A Working heartbeat against a Canceled JobTasks should release the agent.
+
+    Seed an Authorized agent holding a JobTasks row whose status is already
+    'Canceled'. Drive a 'Working' heartbeat: the route detects the cancel and
+    returns msg='Canceled', but the DESIRED behavior is that it also clears
+    job_task.agent_id so a subsequent Idle heartbeat doesn't pick the stale
+    (canceled) task back up via the already-assigned branch (~api/routes.py:317).
+    """
+    db.session.add(Settings(retention_period=30, max_runtime_tasks=0,
+                            max_runtime_jobs=0))
+    admin = Users(first_name="A", last_name="D",
+                  email_address="a139@example.test", password="x" * 60,
+                  admin=True, api_key="k139")
+    db.session.add(admin)
+    db.session.commit()
+
+    cust = Customers(name="C139")
+    db.session.add(cust)
+    db.session.commit()
+    hf = Hashfiles(name="hf139", customer_id=cust.id, owner_id=admin.id)
+    db.session.add(hf)
+    db.session.commit()
+
+    job = Jobs(name="J139", owner_id=admin.id, customer_id=cust.id,
+               hashfile_id=hf.id, status="Running", limit_recovered=False,
+               started_at=datetime.now())
+    db.session.add(job)
+    db.session.commit()
+    task = Tasks(name="T139", owner_id=admin.id, hc_attackmode=0)
+    db.session.add(task)
+    db.session.commit()
+
+    agent = Agents(name="agent139", src_ip="1.1.1.1", uuid="uuid-139",
+                   status="Working", last_checkin=datetime.now())
+    db.session.add(agent)
+    db.session.commit()
+
+    jt = JobTasks(job_id=job.id, task_id=task.id, status="Canceled",
+                  agent_id=agent.id, started_at=datetime.now())
+    db.session.add(jt)
+    db.session.commit()
+    jt_id = jt.id
+
+    client.set_cookie("uuid", agent.uuid, domain=DOMAIN)
+    _agent_version_cookie(client)
+    resp = client.post(
+        "/v1/agents/heartbeat",
+        data=json.dumps({"agent_status": "Working", "hc_status": "stopped"}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    body = json.loads(resp.get_data(as_text=True))
+    assert body["msg"] == "Canceled"
+
+    db.session.expire_all()
+    refreshed = JobTasks.query.get(jt_id)
+    # DESIRED: the canceled task no longer holds the agent.
+    assert refreshed.agent_id is None
+
+
+# ---------------------------------------------------------------------------
+# #130 — Tasks remain active after all hashes cracked (normal job)
+# ---------------------------------------------------------------------------
+@pytest.mark.xfail(
+    reason="issue #130: when all hashes are cracked on a NORMAL job "
+           "(limit_recovered=False), only limit_recovered jobs transition "
+           "their JobTasks (hashview/api/routes.py ~1382-1402); a normal job "
+           "leaves the JobTasks 'Running'",
+    strict=False,
+)
+def test_all_hashes_cracked_completes_running_tasks(app, client):
+    """Cracking the only hash on a normal job should Complete its JobTasks.
+
+    POST the single (= all) hash as cracked to /v1/uploadCrackFile/<jt>. The
+    hash IS flipped to cracked (asserted), but on a normal (limit_recovered=
+    False) job the route never transitions tasks, so the JobTasks stays
+    'Running'. DESIRED: with every hash in the file cracked the task is
+    'Completed'.
+    """
+    db.session.add(Settings(retention_period=30, max_runtime_tasks=0,
+                            max_runtime_jobs=0))
+    admin = Users(first_name="A", last_name="D",
+                  email_address="a130@example.test", password="x" * 60,
+                  admin=True, api_key="k130")
+    db.session.add(admin)
+    db.session.commit()
+
+    cust = Customers(name="C130")
+    db.session.add(cust)
+    db.session.commit()
+    hf = Hashfiles(name="hf130", customer_id=cust.id, owner_id=admin.id)
+    db.session.add(hf)
+    db.session.commit()
+
+    h = Hashes(sub_ciphertext=get_md5_hash("AAAA"), ciphertext="AAAA",
+               hash_type=1000, cracked=False)
+    db.session.add(h)
+    db.session.commit()
+    db.session.add(HashfileHashes(hash_id=h.id, hashfile_id=hf.id))
+    db.session.commit()
+    h_id = h.id
+
+    task = Tasks(name="T130", owner_id=admin.id, hc_attackmode=0)
+    db.session.add(task)
+    db.session.commit()
+
+    job = Jobs(name="J130", owner_id=admin.id, customer_id=cust.id,
+               hashfile_id=hf.id, status="Running", limit_recovered=False,
+               started_at=datetime.now())
+    db.session.add(job)
+    db.session.commit()
+
+    agent = Agents(name="agent130", src_ip="1.1.1.1", uuid="uuid-130",
+                   status="Authorized", last_checkin=datetime.now())
+    db.session.add(agent)
+    db.session.commit()
+
+    jt = JobTasks(job_id=job.id, task_id=task.id, status="Running",
+                  agent_id=agent.id, started_at=datetime.now())
+    db.session.add(jt)
+    db.session.commit()
+    jt_id = jt.id
+
+    client.set_cookie("uuid", agent.uuid, domain=DOMAIN)
+    resp = client.post(
+        f"/v1/uploadCrackFile/{jt_id}",
+        data=json.dumps({"file": "AAAA:secret"}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+
+    db.session.expire_all()
+    # The hash is indeed cracked by the upload...
+    assert Hashes.query.get(h_id).cracked == 1
+    # ...so the only task should be Completed (all hashes recovered).
+    assert JobTasks.query.get(jt_id).status == "Completed"
+
+
+# ---------------------------------------------------------------------------
+# #64 — hc_cracked filename collisions across JobTasks
+# ---------------------------------------------------------------------------
+@pytest.mark.xfail(
+    reason="issue #64: build_hashcat_command names the crack outfile "
+           "hc_cracked_<job.id>_<task.id>.txt keyed on Tasks.id, not the "
+           "JobTasks row (hashview/utils/utils.py ~675), so two JobTasks for "
+           "the same job+task collide and overwrite each other",
+    strict=False,
+)
+def test_hc_cracked_filename_unique_per_jobtask(app):
+    """Two JobTasks for the same job+task must get distinct crack-file names.
+
+    build_hashcat_command(job_id, task_id) embeds only job.id and task.id in
+    --outfile, so seeding two distinct JobTasks rows for the same (job, task)
+    yields identical crack-file names. DESIRED: the name is keyed on the
+    JobTasks row so the two generated commands reference different files.
+    """
+    admin = Users(first_name="A", last_name="D",
+                  email_address="a64@example.test", password="x" * 60,
+                  admin=True, api_key="k64")
+    db.session.add(admin)
+    db.session.commit()
+
+    cust = Customers(name="C64")
+    db.session.add(cust)
+    db.session.commit()
+    hf = Hashfiles(name="hf64", customer_id=cust.id, owner_id=admin.id)
+    db.session.add(hf)
+    db.session.commit()
+
+    h = Hashes(sub_ciphertext=get_md5_hash("CAFE"), ciphertext="CAFE",
+               hash_type=1000, cracked=False)
+    db.session.add(h)
+    db.session.commit()
+    db.session.add(HashfileHashes(hash_id=h.id, hashfile_id=hf.id))
+    db.session.commit()
+
+    task = Tasks(name="T64", owner_id=admin.id, hc_attackmode=3,
+                 hc_mask="?d?d?d?d")
+    db.session.add(task)
+    db.session.commit()
+
+    job = Jobs(name="J64", owner_id=admin.id, customer_id=cust.id,
+               hashfile_id=hf.id, status="Running", limit_recovered=False,
+               started_at=datetime.now())
+    db.session.add(job)
+    db.session.commit()
+
+    # Two distinct JobTasks rows for the SAME job + task.
+    jt1 = JobTasks(job_id=job.id, task_id=task.id, status="Queued")
+    jt2 = JobTasks(job_id=job.id, task_id=task.id, status="Queued")
+    db.session.add_all([jt1, jt2])
+    db.session.commit()
+
+    cmd1 = build_hashcat_command(job.id, task.id)
+    cmd2 = build_hashcat_command(job.id, task.id)
+
+    def _crackfile(cmd):
+        parts = cmd.split()
+        return parts[parts.index("--outfile") + 1]
+
+    name1 = _crackfile(cmd1)
+    name2 = _crackfile(cmd2)
+    # DESIRED: per-jobtask crack files, so the two names differ.
+    assert name1 != name2
+
+
+# ---------------------------------------------------------------------------
+# #129 — Blank Hashfile Name from pasted (whitespace-only) hashes
+# ---------------------------------------------------------------------------
+@pytest.mark.xfail(
+    reason="issue #129: the blank-name guard in jobs_assigned_hashfile uses "
+           "`len(name.data) == 0` (hashview/jobs/routes.py ~305), so a "
+           "whitespace-only name slips through and creates a blank hashfile "
+           "name; the guard should be strip-aware",
+    strict=False,
+)
+def test_pasted_hashes_blank_name_guard_strips_whitespace(app):
+    """The pasted-hashes name guard should reject whitespace-only names.
+
+    Limitation: the full paste -> import code path isn't reachable at the unit
+    level (it needs control/tmp writes, file-type validators, and a populated
+    upload form), so instead of driving the route we inspect the source of
+    hashview.jobs.routes.jobs_assigned_hashfile and assert the DESIRED
+    strip-aware guard (``name.data.strip()``) is present. It currently is not:
+    the live guard is the whitespace-blind ``len(name.data) == 0``.
+    """
+    from hashview.jobs.routes import jobs_assigned_hashfile
+
+    src = inspect.getsource(jobs_assigned_hashfile)
+    # DESIRED: the guard strips before measuring emptiness, e.g.
+    #   if len(name.data.strip()) == 0:  /  if not name.data.strip():
+    assert "name.data.strip()" in src


### PR DESCRIPTION
Adds one `xfail` test (`strict=False`) per **open issue authored by @i128**, grouped by area into five files under `tests/unit/`. Each test asserts the *correct/desired* behavior, so it fails today (documenting the bug or missing feature) and automatically flips to a regression guard once the issue is fixed.

## Coverage (15 issues)
| File | Issues |
|------|--------|
| `test_issue_xfail_search_encoding.py` | #22, #140 |
| `test_issue_xfail_task_lifecycle.py` | #139, #130, #64, #129 |
| `test_issue_xfail_analytics.py` | #92, #50 |
| `test_issue_xfail_admin_features.py` | #39, #30, #91 |
| `test_issue_xfail_misc.py` | #100, #57, #99, #176 |

## Results
`1 passed, 17 xfailed, 4 xpassed, 0 errors` against `v0.8.3-dev`.

The 4 **XPASS** tests correspond to issues already fixed on `v0.8.3-dev` (#22 case-insensitive search, #140 en-dash usernames, #100 task-group rename, #99 no server-side task-list truncation). Those issues have been closed; the tests remain as forward regression guards. `strict=False` keeps XPASS from failing CI.

Notes:
- No application code changed — tests only.
- Each test cites the relevant `file:line` in its xfail reason / docstring.
- A few issues are inherently UI/infra (#99 scroll, #176 progress indicator); those tests assert the server-side precondition and note the limitation in-line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)