### PR TITLE
test: cover guard/branch gaps + ratchet coverage floor to 85%

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -28,7 +28,12 @@ jobs:
       - name: Run unit + security + agent tests with coverage
         run: |
           python -m pytest tests/unit tests/security tests/agent_unit \
-            --cov=hashview --cov-report=term-missing --cov-report=xml --cov-fail-under=70 -q
+            --cov=hashview --cov-report=term-missing --cov-report=xml \
+            --cov-report=json:coverage.json --cov-fail-under=85 -q
+      # Enforce the function-level gate: fail if any function in hashview/ has
+      # zero executed body lines (waivers live in the allowlist, kept empty).
+      - name: Enforce function-level coverage gate
+        run: python tests/check_function_coverage.py coverage.json
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:

--- a/tests/unit/test_db_backup.py
+++ b/tests/unit/test_db_backup.py
@@ -17,6 +17,7 @@ import pytest
 from hashview.models import db, Users
 from hashview.utils.backup import (
     create_encrypted_db_backup, purge_stale_backups, _write_defaults_file, BackupError,
+    _sha256, _require_tools,
 )
 from sqlalchemy.engine.url import make_url
 
@@ -155,6 +156,40 @@ def test_purge_stale_backups(tmp_path):
     purge_stale_backups(str(tmp_path), max_age_seconds=3600)
     assert not old.exists()
     assert new.exists() and other.exists()
+
+
+def test_purge_stale_backups_missing_dir_is_noop(tmp_path):
+    # the function swallows OSError from a non-existent directory
+    purge_stale_backups(str(tmp_path / "does-not-exist"))
+
+
+def test_sha256_matches_hashlib(tmp_path):
+    import hashlib
+    # content just over one 1 MiB chunk -> exercises the multi-read loop
+    data = b"x" * (1024 * 1024 + 7)
+    path = tmp_path / "f.bin"
+    path.write_bytes(data)
+    assert _sha256(str(path)) == hashlib.sha256(data).hexdigest()
+
+    # empty file -> single (zero-length) read path
+    empty = tmp_path / "empty.bin"
+    empty.write_bytes(b"")
+    assert _sha256(str(empty)) == hashlib.sha256(b"").hexdigest()
+
+
+def test_require_tools_raises_when_tool_missing(monkeypatch):
+    monkeypatch.setattr("hashview.utils.backup.shutil.which", lambda name: None)
+    with pytest.raises(BackupError) as exc:
+        _require_tools(need_mysqldump=True)
+    assert "Missing required tool" in str(exc.value)
+    # gzip/openssl still required even without mysqldump
+    with pytest.raises(BackupError):
+        _require_tools(need_mysqldump=False)
+
+
+def test_require_tools_passes_when_present(monkeypatch):
+    monkeypatch.setattr("hashview.utils.backup.shutil.which", lambda name: "/usr/bin/" + name)
+    assert _require_tools() is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_jobs_assigned_hashfile.py
+++ b/tests/unit/test_jobs_assigned_hashfile.py
@@ -1,0 +1,200 @@
+"""Characterization tests for the hashfile-upload block of
+``jobs_assigned_hashfile`` (POST /jobs/<id>/assigned_hashfile/).
+
+Focus: the pasted-hashes happy path (write temp file -> validate -> import ->
+``finally:`` removes the temp file), the AJAX JSON 400 error branches, the
+existing-hashfile assignment path, and the running-job guard. All assertions
+pin ACTUAL behavior against the in-memory app; app source is never modified.
+"""
+
+import os
+
+import pytest
+
+from hashview.models import HashfileHashes, Hashfiles, Jobs, db
+from tests.unit.helpers import login, make_admin, make_customer
+
+# A valid hash_only line for hash_type '1000' (NTLM): 32 hex characters.
+VALID_NTLM = "8846f7eaee8fb117ad06bdd830b7586c"
+AJAX = {"X-Requested-With": "fetch"}
+
+# The real form renders five Hash-Type SelectFields; only the one matching the
+# chosen file_type carries a value, but the browser submits all of them. Each
+# non-active SelectField must receive its empty-string choice ('') or WTForms
+# rejects the POST with "Not a valid choice." Mirror that here.
+EMPTY_SUBTYPES = {
+    "shadow_hash_type": "",
+    "pwdump_hash_type": "",
+    "netntlm_hash_type": "",
+    "kerberos_hash_type": "",
+}
+
+
+def _paste_data(name, hashes=VALID_NTLM, hash_type="1000"):
+    return {
+        "name": name,
+        "file_type": "hash_only",
+        "hash_type": hash_type,
+        "hashfilehashes": hashes,
+        **EMPTY_SUBTYPES,
+    }
+
+
+def _job(owner, customer, status="Ready", name="j1"):
+    job = Jobs(name=name, status=status, owner_id=owner.id,
+               customer_id=customer.id)
+    db.session.add(job)
+    db.session.commit()
+    return job
+
+
+def _tmp_dir(app):
+    return os.path.join(app.root_path, "control", "tmp")
+
+
+@pytest.fixture
+def tmp_snapshot(app):
+    """Yield the control/tmp dir and clean up any NEW files left behind after
+    the test (mirrors the _clean_backups pattern in test_db_backup.py)."""
+    tmp_dir = _tmp_dir(app)
+
+    def snap():
+        return set(os.listdir(tmp_dir)) if os.path.isdir(tmp_dir) else set()
+
+    before = snap()
+    yield tmp_dir, before
+    for n in snap() - before:
+        try:
+            os.remove(os.path.join(tmp_dir, n))
+        except OSError:
+            pass
+
+
+def _new_files(tmp_dir, before):
+    after = set(os.listdir(tmp_dir)) if os.path.isdir(tmp_dir) else set()
+    return after - before
+
+
+def test_paste_hashes_happy_path_imports_and_cleans_tmp(app, client, tmp_snapshot):
+    tmp_dir, before = tmp_snapshot
+    admin = make_admin()
+    login(client, admin)
+    cust = make_customer()
+    job = _job(admin, cust)
+
+    resp = client.post(
+        f"/jobs/{job.id}/assigned_hashfile/",
+        data=_paste_data("PastedHF"),
+        headers=AJAX,
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["status"] == "ok"
+    assert "imported" in body["msg"]
+
+    hf = Hashfiles.query.filter_by(name="PastedHF").first()
+    assert hf is not None
+    assert HashfileHashes.query.filter_by(hashfile_id=hf.id).count() >= 1
+    assert Jobs.query.get(job.id).hashfile_id == hf.id
+
+    # The finally: removes the random-hex temp file on success.
+    assert _new_files(tmp_dir, before) == set()
+
+
+def test_paste_hashes_invalid_hash_ajax_returns_400_and_cleans_tmp(app, client, tmp_snapshot):
+    tmp_dir, before = tmp_snapshot
+    admin = make_admin()
+    login(client, admin)
+    cust = make_customer()
+    job = _job(admin, cust)
+
+    # hash_type '1000' has a curated rule requiring 32 hex chars -> rejected.
+    resp = client.post(
+        f"/jobs/{job.id}/assigned_hashfile/",
+        data=_paste_data("BadHF", hashes="not-a-hash"),
+        headers=AJAX,
+    )
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert body["status"] == "error"
+
+    # No hashfile created, job unchanged.
+    assert Hashfiles.query.filter_by(name="BadHF").first() is None
+    assert Jobs.query.get(job.id).hashfile_id is None
+
+    # finally: runs on the validation-error return path too.
+    assert _new_files(tmp_dir, before) == set()
+
+
+def test_paste_hashes_missing_name_ajax_400(app, client, tmp_snapshot):
+    tmp_dir, before = tmp_snapshot
+    admin = make_admin()
+    login(client, admin)
+    cust = make_customer()
+    job = _job(admin, cust)
+
+    resp = client.post(
+        f"/jobs/{job.id}/assigned_hashfile/",
+        data=_paste_data(""),
+        headers=AJAX,
+    )
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert body["status"] == "error"
+    assert "must assign a name" in body["msg"]
+
+    # This branch returns BEFORE any temp file is written.
+    assert _new_files(tmp_dir, before) == set()
+
+
+def test_validation_failed_ajax_returns_errors_400(app, client):
+    admin = make_admin()
+    login(client, admin)
+    cust = make_customer()
+    job = _job(admin, cust)
+
+    # Omit file_type (DataRequired fails) and provide no hashfile/hashes.
+    resp = client.post(
+        f"/jobs/{job.id}/assigned_hashfile/",
+        data={"name": "x"},
+        headers=AJAX,
+    )
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert body["status"] == "error"
+
+
+def test_assign_existing_hashfile_id_redirects(app, client):
+    admin = make_admin()
+    login(client, admin)
+    cust = make_customer()
+    job = _job(admin, cust)
+    hf = Hashfiles(name="existing", customer_id=cust.id, owner_id=admin.id)
+    db.session.add(hf)
+    db.session.commit()
+
+    resp = client.post(
+        f"/jobs/{job.id}/assigned_hashfile/",
+        data={"hashfile_id": str(hf.id)},
+        follow_redirects=False,
+    )
+    assert resp.status_code in (301, 302)
+    assert Jobs.query.get(job.id).hashfile_id == hf.id
+
+
+def test_running_job_cannot_edit(app, client, tmp_snapshot):
+    tmp_dir, before = tmp_snapshot
+    admin = make_admin()
+    login(client, admin)
+    cust = make_customer()
+    job = _job(admin, cust, status="Running")
+
+    resp = client.post(
+        f"/jobs/{job.id}/assigned_hashfile/",
+        data=_paste_data("ShouldNotImport"),
+        headers=AJAX,
+        follow_redirects=False,
+    )
+    assert resp.status_code in (301, 302)
+    assert Hashfiles.query.filter_by(name="ShouldNotImport").first() is None
+    assert _new_files(tmp_dir, before) == set()

--- a/tests/unit/test_searches_routes.py
+++ b/tests/unit/test_searches_routes.py
@@ -85,3 +85,81 @@ def test_export_results_hash_returns_attachment(app):
     assert resp.status_code == 200
     assert resp.headers["Content-Disposition"].startswith("attachment")
     assert "search_hash.csv" in resp.headers["Content-Disposition"]
+
+
+def test_searches_hash_id_with_hashfile_match_renders(app, client):
+    admin = make_admin()
+    login(client, admin)
+    cust, hf, h, hfh = _seed_cracked(ciphertext="abc123def")
+    resp = client.get(f"/search?hash_id={h.id}")
+    assert resp.status_code == 200
+    # Form was pre-filled with the matched ciphertext.
+    assert b"abc123def" in resp.data
+
+
+def test_searches_hash_id_no_hashfile_match_redacted(app, client):
+    admin = make_admin()
+    login(client, admin)
+    # A Hashes row NOT linked to any HashfileHashes -> redacted fallback path.
+    h = Hashes(sub_ciphertext="0" * 8, ciphertext="orphanhash", hash_type=1000,
+               cracked=False, plaintext="")
+    db.session.add(h)
+    db.session.commit()
+    resp = client.get(f"/search?hash_id={h.id}")
+    assert resp.status_code == 200
+
+
+def test_searches_hash_id_nonexistent_flashes_no_results(app, client):
+    admin = make_admin()
+    login(client, admin)
+    resp = client.get("/search?hash_id=999999", follow_redirects=True)
+    assert resp.status_code == 200
+    assert b"No results found" in resp.data
+
+
+def test_searches_export_hash_returns_csv(app, client):
+    admin = make_admin()
+    login(client, admin)
+    _seed_cracked(ciphertext="cafe9988", plaintext="ExpPw")
+    resp = client.post("/search", data={
+        "search_type": "hash", "query": "cafe9988", "submit": "Search",
+        "export": "hash",
+    })
+    assert resp.status_code == 200
+    assert resp.headers["Content-Disposition"].startswith("attachment")
+    assert "search_hash.csv" in resp.headers["Content-Disposition"]
+    assert b"cafe9988" in resp.data
+    assert b"ExpPw" in resp.data
+
+
+def test_searches_export_hashfile_returns_csv(app, client):
+    admin = make_admin()
+    login(client, admin)
+    _seed_cracked(username="dave", plaintext="ExpPw2", ciphertext="beef7766")
+    resp = client.post("/search", data={
+        "search_type": "hash", "query": "beef7766", "submit": "Search",
+        "export": "hashfile",
+    })
+    assert resp.status_code == 200
+    assert resp.headers["Content-Disposition"].startswith("attachment")
+    assert "search_hashfile.csv" in resp.headers["Content-Disposition"]
+    assert b"dave" in resp.data
+    assert b"SearchCo" in resp.data
+
+
+def test_searches_invalid_search_option(app, client):
+    """The `else: Invalid search option` branch in searches_list.
+
+    The SearchForm.search_type SelectField declares fixed `choices` without
+    `validate_choice=False`, so WTForms rejects any out-of-range value during
+    validate_on_submit(). The else-branch is therefore unreachable via normal
+    form submission. This test pins that reality.
+    """
+    admin = make_admin()
+    login(client, admin)
+    resp = client.post("/search", data={
+        "search_type": "bogus", "query": "x", "submit": "Search",
+    }, follow_redirects=True)
+    assert resp.status_code == 200
+    # SelectField validation fails, so we never hit the else-branch / its flash.
+    assert b"Invalid search option" not in resp.data

--- a/tests/unit/test_task_groups_routes.py
+++ b/tests/unit/test_task_groups_routes.py
@@ -7,7 +7,7 @@ from wtforms.validators import ValidationError
 
 from hashview.models import TaskGroups, Tasks, db
 from hashview.task_groups.forms import TaskGroupsForm
-from tests.unit.helpers import login, make_admin
+from tests.unit.helpers import login, make_admin, make_user
 
 
 def _task(owner, name="t"):
@@ -109,3 +109,129 @@ def test_validate_task_rejects_duplicate(app):
 
     with pytest.raises(ValidationError):
         form.validate_task(_Field())
+
+
+# --- edit route ------------------------------------------------------------
+
+
+def test_task_groups_edit_renames_and_reorders(app, client):
+    admin = make_admin()
+    login(client, admin)
+    t1, t2 = _task(admin, "a"), _task(admin, "b")
+    tg = _group(admin, [t1.id, t2.id], name="OldName")
+    resp = client.post("/task_groups/edit", data={
+        "group_id": tg.id, "name": "NewName",
+        "task_ids": f"{t2.id},{t1.id}", "submit": "Create",
+    }, follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    updated = TaskGroups.query.get(tg.id)
+    assert updated.name == "NewName"
+    assert json.loads(updated.tasks) == [t2.id, t1.id]
+
+
+def test_task_groups_edit_drops_invalid_and_duplicate_ids(app, client):
+    admin = make_admin()
+    login(client, admin)
+    t1 = _task(admin, "a")
+    tg = _group(admin, [t1.id])
+    resp = client.post("/task_groups/edit", data={
+        "group_id": tg.id, "name": "G",
+        "task_ids": f"{t1.id},abc,{t1.id},999999", "submit": "Create",
+    }, follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert json.loads(TaskGroups.query.get(tg.id).tasks) == [t1.id]
+
+
+def test_task_groups_edit_missing_group_flashes_warning(app, client):
+    admin = make_admin()
+    login(client, admin)
+    before = TaskGroups.query.count()
+    resp = client.post("/task_groups/edit", data={
+        "group_id": 999999, "name": "G", "task_ids": "", "submit": "Create",
+    }, follow_redirects=True)
+    assert b"Task Group not found" in resp.data
+    assert TaskGroups.query.count() == before
+
+
+def test_task_groups_edit_non_owner_non_admin_403(app, client):
+    admin = make_admin()
+    other = make_user(email="other@example.com")
+    t1 = _task(admin, "a")
+    tg = _group(admin, [t1.id], name="AdminGroup")
+    login(client, other)
+    resp = client.post("/task_groups/edit", data={
+        "group_id": tg.id, "name": "Hijacked",
+        "task_ids": f"{t1.id}", "submit": "Create",
+    }, follow_redirects=False)
+    assert resp.status_code == 403
+    assert TaskGroups.query.get(tg.id).name == "AdminGroup"
+
+
+def test_task_groups_edit_invalid_form_flashes_danger(app, client):
+    admin = make_admin()
+    login(client, admin)
+    t1 = _task(admin, "a")
+    tg = _group(admin, [t1.id], name="Keep")
+    resp = client.post("/task_groups/edit", data={
+        "group_id": tg.id, "name": "",
+        "task_ids": f"{t1.id}", "submit": "Create",
+    }, follow_redirects=True)
+    assert b"Could not update task group" in resp.data
+    assert TaskGroups.query.get(tg.id).name == "Keep"
+
+
+# --- remove_task route -----------------------------------------------------
+
+
+def test_task_groups_remove_task_not_in_group_flashes_warning(app, client):
+    admin = make_admin()
+    login(client, admin)
+    t1, t2 = _task(admin, "a"), _task(admin, "b")
+    tg = _group(admin, [t1.id])
+    resp = client.get(
+        f"/task_groups/assigned_tasks/{tg.id}/remove_task/{t2.id}",
+        follow_redirects=True)
+    assert b"no longer in this group" in resp.data
+    assert json.loads(TaskGroups.query.get(tg.id).tasks) == [t1.id]
+
+
+def test_task_groups_remove_task_missing_group_flashes_warning(app, client):
+    admin = make_admin()
+    login(client, admin)
+    resp = client.get(
+        "/task_groups/assigned_tasks/999999/remove_task/1",
+        follow_redirects=True)
+    assert b"Task Group not found" in resp.data
+
+
+# --- delete route ----------------------------------------------------------
+
+
+def test_task_groups_delete_happy_path(app, client):
+    admin = make_admin()
+    login(client, admin)
+    t1 = _task(admin, "a")
+    tg = _group(admin, [t1.id])
+    tg_id = tg.id
+    resp = client.post(f"/task_groups/delete/{tg_id}", follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert TaskGroups.query.get(tg_id) is None
+
+
+def test_task_groups_delete_missing_group_flashes_warning(app, client):
+    admin = make_admin()
+    login(client, admin)
+    resp = client.post("/task_groups/delete/999999", follow_redirects=True)
+    assert b"Task Group not found" in resp.data
+
+
+def test_task_groups_delete_non_owner_non_admin_403(app, client):
+    admin = make_admin()
+    other = make_user(email="other@example.com")
+    t1 = _task(admin, "a")
+    tg = _group(admin, [t1.id])
+    tg_id = tg.id
+    login(client, other)
+    resp = client.post(f"/task_groups/delete/{tg_id}", follow_redirects=False)
+    assert resp.status_code == 403
+    assert TaskGroups.query.get(tg_id) is not None


### PR DESCRIPTION
## What

Adds **26 regression tests** pinning previously-untested branch and error paths, then locks in the gains via CI.

### Tests (commit 1)
| Module | Before → After | Coverage added |
|---|---|---|
| `task_groups/routes.py` | 70% → 88% | edit authz/not-found, "could not update" branch, delete authz/403, remove_task guards |
| `searches/routes.py` | 72% → 92% | `hash_id` branch (match/redacted/none), CSV export targets |
| `jobs/routes.py` | 79% → 87% | paste-hash import + temp-file cleanup, AJAX 400 paths, existing-hashfile assign, running-job guard |
| `utils/backup.py` | 76% → 83% | `_sha256`, `_require_tools`, purge missing-dir |

New file: `tests/unit/test_jobs_assigned_hashfile.py`. Others appended to existing suites.

### CI (commit 2)
- Raise `--cov-fail-under` **70 → 85** (actual is now 87%; the workflow already documents this ratchet).
- Wire the existing `tests/check_function_coverage.py` into CI so the zero-coverage-function gate is enforced on every push/PR (currently **0** zero-coverage functions; allowlist empty).

## Verification
- Full CI suite (unit + security + agent): **697 passed, 2 skipped, 2 xfailed**, 87% coverage.
- Function-level gate: **0** zero-coverage functions, exit 0.

## Notes
- **Dead code found:** the `'Invalid search option.'` else-branch in `searches_list()` is unreachable — `SearchForm.search_type` is a `SelectField` whose validation rejects out-of-range values before the branch runs. Pinned by a test that asserts the flash never fires; worth a follow-up cleanup.
- These are characterization/regression tests for existing behavior — **no application source was changed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)