### PR TITLE
Remove dead two-arg uploadCrackFile route + API debug leftovers (#231)

### DIFF
--- a/hashview/api/routes.py
+++ b/hashview/api/routes.py
@@ -1073,7 +1073,8 @@ def v1_api_post_hashfile_upload(customer_id, file_format, hash_type, hashfile_na
 
     # import contents from file
     try:
-        print(f"[DEBUG] Validating hashfile {file_path} of type {file_format} for hashtype {hash_type}")
+        current_app.logger.debug('API: validating hashfile %s of format %s for hashtype %s',
+                                 file_path, file_format, hash_type)
         if file_format == 0:
             has_problem = validate_pwdump_hashfile(file_path, str(hash_type))
         elif file_format == 1:
@@ -1244,63 +1245,6 @@ def v1_api_get_hashfiles_by_hash_type(hash_type):
     return jsonify(message)
 
 # Upload Cracked Hashes
-# old and probably unused
-@api.route('/v1/uploadCrackFile/<int:task_id>/<int:hash_type>', methods=['POST'])
-def v1_api_put_jobtask_crackfile_upload(task_id, hash_type):
-    if not is_authorized(user=False, agent=True, request=request):
-        return redirect("/v1/not_authorized")
-
-    update_heartbeat(request.cookies.get('uuid'))
-
-    # TODO
-    # We really should validate if task_id is legit
-    
-    # save to file
-    # silent=True so an empty/invalid body returns None (-> JSON error) instead of
-    # Flask's HTML 400 page, which the agent can't parse (#212).
-    file_contents = request.get_json(silent=True)
-    if not file_contents or 'file' not in file_contents:
-        return jsonify({
-            'status': 400,
-            'type': 'Error',
-            'msg': 'Missing file data in request body'
-        })
-
-    #for entry in lines:
-    for entry in file_contents['file'].split('\n'):
-        if ':' in entry:
-            encoded_plaintext = entry.split(':')[-1]
-            elements = entry.split(':')
-            # Remove cracked hash
-            elements.pop()
-            ciphertext = ':'.join(elements)
-
-            #print('Plaintext: ' + str(bytes.fromhex(plaintext).decode('latin-1')))
-            #print('Ciphertext: ' + str(ciphertext))
-
-            record = Hashes.query.filter_by(hash_type=hash_type, sub_ciphertext=get_md5_hash(ciphertext), cracked='0').first()
-            if record:
-                try:
-                    record.plaintext = hexplain_to_text(encoded_plaintext)
-                    record.cracked = 1
-                    #print('i should be updating the datetime')
-                    record.recovered_at = datetime.today()
-                    record.task_id = task_id
-                    db.session.commit()
-                except Exception:
-                    current_app.logger.exception('API: failed to import a cracked hash during agent heartbeat')
-
-    # Send per-hash "recovered" notifications (email/push/slack) for any now-cracked watched hash.
-    process_recovered_hash_notifications()
-
-    message = {
-        'status': 200,
-        'type': 'message',
-        'msg': 'OK'
-    }
-    return jsonify(message)
-
-# Upload Cracked Hashes
 @api.route('/v1/uploadCrackFile/<int:job_task_id>', methods=['POST'])
 def v1_api_post_jobtask_crackfile_upload(job_task_id):
     if not is_authorized(user=False, agent=True, request=request):
@@ -1359,14 +1303,13 @@ def v1_api_post_jobtask_crackfile_upload(job_task_id):
                 partial_hash = "WPA*02*{}%".format(ciphertext.replace(':', '*'))
                 record = Hashes.query.filter_by(hash_type=hash_type, cracked='0').filter(Hashes.ciphertext.like(partial_hash)).first()
                 if not record:
-                    print(f"[DEBUG] No record found for partial hash {partial_hash}")
+                    current_app.logger.debug('API: no record found for partial hash %s', partial_hash)
             else:
                 record = Hashes.query.filter_by(hash_type=hash_type, sub_ciphertext=get_md5_hash(ciphertext), cracked='0').first()
             if record:
                 try:
                     record.plaintext = hexplain_to_text(encoded_plaintext)
                     record.cracked = 1
-                    #print('i should be updating the datetime')
                     record.recovered_at = datetime.today()
                     record.task_id = job_task.task_id
                     record.recovered_by = job.owner_id
@@ -1387,19 +1330,6 @@ def v1_api_post_jobtask_crackfile_upload(job_task_id):
         for jobtask in jobtasks:
             update_job_task_status( jobtask_id = jobtask.id,
                                     status = 'Canceled')
-        #     if jobtask.status == 'Running':
-        #         print(f"setting jobtask.id {jobtask.id} from {jobtask.status} to Canceled")
-        #         jobtask.status = 'Canceled'
-        #     elif jobtask.status == 'Ready':
-        #         print(f"setting jobtask.id {jobtask.id} from {jobtask.status} to Canceled")
-        #         jobtask.status = 'Canceled'
-        # db.session.commit()
-
-        # # set job status to completed
-        # job.status = 'Completed'
-        # job.ended_at = datetime.now()
-        # print(f"setting Job.id {job.id} to Completed")
-        # db.session.commit()
 
     message = {
         'status': 200,

--- a/hashview/api_docs/openapi.yaml
+++ b/hashview/api_docs/openapi.yaml
@@ -1065,46 +1065,6 @@ paths:
         '302':
           $ref: '#/components/responses/NotAuthorizedRedirect'
 
-  /v1/uploadCrackFile/{task_id}/{hash_type}:
-    post:
-      tags: [Hashes, Agent Protocol]
-      summary: Upload cracked hashes (legacy)
-      deprecated: true
-      description: >-
-        Legacy variant kept for old agents ("old and probably unused"). Does
-        NOT validate `task_id`. As with the current variant, a missing/empty
-        body or a body without `file` raises an unhandled HTTP 500. Prefer
-        `/v1/uploadCrackFile/{job_task_id}`.
-      operationId: uploadCrackFileLegacy
-      x-audience: agent
-      security:
-        - agentUuid: []
-      parameters:
-        - name: task_id
-          in: path
-          required: true
-          schema: {type: integer}
-        - name: hash_type
-          in: path
-          required: true
-          schema: {type: integer}
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CrackFileUpload'
-      responses:
-        '200':
-          description: Acknowledged.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ApiMessage'
-              example: {status: 200, type: message, msg: OK}
-        '302':
-          $ref: '#/components/responses/NotAuthorizedRedirect'
-
   # ---------------------------------------------------------------- Search
   /v1/search:
     post:

--- a/tests/unit/test_api_agent_protocol.py
+++ b/tests/unit/test_api_agent_protocol.py
@@ -221,29 +221,6 @@ def test_post_hashfile_upload_creates_hashfile(app, client):
     assert Hashfiles.query.get(body["hashfile_id"]) is not None
 
 
-def test_put_jobtask_crackfile_marks_hash_cracked(app, client, monkeypatch):
-    monkeypatch.setattr("hashview.api.routes.process_recovered_hash_notifications",
-                        lambda: None)
-    agent = _agent(uuid="crack-agent", status="Working")
-    # NTLM('password') sub_ciphertext keyed by get_md5_hash(ciphertext)
-    from hashview.utils.utils import get_md5_hash
-    ntlm = "8846F7EAEE8FB117AD06BDD830B7586C"
-    h = Hashes(sub_ciphertext=get_md5_hash(ntlm), ciphertext=ntlm,
-               hash_type=1000, cracked=False)
-    db.session.add(h)
-    db.session.commit()
-    client.set_cookie("uuid", "crack-agent", domain=DOMAIN)
-    # encoded_plaintext is hex; hexplain_to_text decodes it -> "password"
-    hexpw = "password".encode().hex()
-    resp = client.post("/v1/uploadCrackFile/1/1000",
-                       json={"file": f"{ntlm}:{hexpw}"})
-    body = _body(resp)
-    assert body["status"] == 200
-    refreshed = Hashes.query.get(h.id)
-    assert refreshed.cracked
-    assert refreshed.plaintext == "password"
-
-
 # --- privilege boundaries ---------------------------------------------------
 
 def test_user_only_route_rejects_agent(app, client):
@@ -257,6 +234,6 @@ def test_user_only_route_rejects_agent(app, client):
 def test_agent_only_route_rejects_user(app, client):
     _user()
     client.set_cookie("uuid", "user-key", domain=DOMAIN)
-    resp = client.post("/v1/uploadCrackFile/1/1000", json={"file": ""})
+    resp = client.post("/v1/uploadCrackFile/1", json={"file": ""})
     assert 300 <= resp.status_code < 400
     assert "not_authorized" in resp.headers.get("Location", "")

--- a/tests/unit/test_api_routes_branches.py
+++ b/tests/unit/test_api_routes_branches.py
@@ -1103,74 +1103,6 @@ def test_hashfile_get_returns_file(client, app, admin_user, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# /v1/uploadCrackFile/<task_id>/<hash_type>  (old route)
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.security
-def test_uploadcrackfile_old_route_no_cookie_redirects(client):
-    """POST /v1/uploadCrackFile/<task>/<type> without agent cookie redirects."""
-    resp = client.post(
-        "/v1/uploadCrackFile/1/1000",
-        data=json.dumps({"file": ""}),
-        content_type="application/json",
-    )
-    assert 300 <= resp.status_code < 400
-    assert "not_authorized" in resp.headers.get("Location", "")
-
-
-@pytest.mark.security
-def test_uploadcrackfile_old_route_processes_entry(
-    client, authorized_agent, monkeypatch
-):
-    """POST /v1/uploadCrackFile/<task>/<hash_type> processes a hash:plain pair."""
-    import hashview.utils.utils as utils_mod
-    monkeypatch.setattr(utils_mod, "process_recovered_hash_notifications", lambda: None)
-    monkeypatch.setattr(utils_mod, "hexplain_to_text", lambda s: s)
-
-    hash_val = NTLM_HASH
-    h = Hashes(
-        sub_ciphertext=get_md5_hash(hash_val),
-        ciphertext=hash_val,
-        hash_type=1000,
-        cracked=False,
-    )
-    _db.session.add(h)
-    _db.session.commit()
-
-    client.set_cookie("uuid", authorized_agent.uuid, domain="localhost.test")
-    resp = client.post(
-        "/v1/uploadCrackFile/1/1000",
-        data=json.dumps({"file": f"{hash_val}:password\n"}),
-        content_type="application/json",
-    )
-    body = _json(resp)
-    assert body["status"] == 200
-    assert body["msg"] == "OK"
-    _db.session.refresh(h)
-    assert h.cracked
-
-
-@pytest.mark.security
-def test_uploadcrackfile_old_route_no_matching_hash_is_noop(
-    client, authorized_agent, monkeypatch
-):
-    """POST /v1/uploadCrackFile/<task>/<hash_type> with unknown hash is a no-op."""
-    import hashview.utils.utils as utils_mod
-    monkeypatch.setattr(utils_mod, "process_recovered_hash_notifications", lambda: None)
-    monkeypatch.setattr(utils_mod, "hexplain_to_text", lambda s: s)
-
-    client.set_cookie("uuid", authorized_agent.uuid, domain="localhost.test")
-    resp = client.post(
-        "/v1/uploadCrackFile/1/1000",
-        data=json.dumps({"file": "AAAA1234AAAA1234AAAA1234AAAA1234:unknown\n"}),
-        content_type="application/json",
-    )
-    body = _json(resp)
-    assert body["status"] == 200
-
-
-# ---------------------------------------------------------------------------
 # /v1/uploadCrackFile/<job_task_id>  (new route)
 # ---------------------------------------------------------------------------
 
@@ -2367,50 +2299,6 @@ def test_hashfiles_by_hash_type_user_not_found_returns_403(client, monkeypatch):
     resp = client.get("/v1/hashfiles/hash_type/1000")
     body = _json(resp)
     assert body["status"] == 403
-
-
-@pytest.mark.security
-def test_uploadcrackfile_old_route_exception_during_commit(
-    client, authorized_agent, monkeypatch
-):
-    """POST /v1/uploadCrackFile/<task>/<hash_type> where db.session.commit raises
-    prints the error and continues (lines 1229-1231: the inner try/except).
-
-    The route catches commit exceptions silently (just prints) and still returns
-    status 200, so the exception path is covered even though the record isn't saved.
-
-    We trigger the exception by making hexplain_to_text raise (the inner try
-    block also catches any error from the helper calls, not just commit).
-    """
-    import hashview.api.routes as routes_mod
-    import hashview.utils.utils as utils_mod
-    monkeypatch.setattr(utils_mod, "process_recovered_hash_notifications", lambda: None)
-
-    def raise_hexplain(s):
-        raise ValueError("simulated hexplain error")
-
-    # The route imports hexplain_to_text directly into its namespace, so patch there
-    monkeypatch.setattr(routes_mod, "hexplain_to_text", raise_hexplain)
-
-    hash_val = NTLM_HASH
-    h = Hashes(
-        sub_ciphertext=get_md5_hash(hash_val),
-        ciphertext=hash_val,
-        hash_type=1000,
-        cracked=False,
-    )
-    _db.session.add(h)
-    _db.session.commit()
-
-    client.set_cookie("uuid", authorized_agent.uuid, domain="localhost.test")
-    resp = client.post(
-        "/v1/uploadCrackFile/1/1000",
-        data=json.dumps({"file": f"{hash_val}:password\n"}),
-        content_type="application/json",
-    )
-    # Despite the inner exception, the route always returns 200
-    body = _json(resp)
-    assert body["status"] == 200
 
 
 @pytest.mark.security


### PR DESCRIPTION
The legacy /v1/uploadCrackFile/<task_id>/<hash_type> route is unused: the agent posts only to /v1/uploadCrackFile/<job_task_id> (the two-arg call is commented out in both agent/api/api.py and hashview-agent.py), and no template, JS, or other Python references it.

- routes.py: drop the v1_api_put_jobtask_crackfile_upload handler; remove the dead commented-out one-and-done block in the surviving handler (superseded by update_job_task_status); replace two debug print() statements with current_app.logger.debug(...) and drop a stray commented-out #print.
- openapi.yaml: remove the uploadCrackFileLegacy path -- the spec<->/v1 route parity test (test_openapi_spec.py) requires an exact two-way match.
- test_api_agent_protocol.py: drop the test that only exercised the dead route (the surviving route's crack-marking is covered by test_lucky_and_one_and_done.py) and repoint the agent-only privilege-boundary test to the single-arg route.