### PR TITLE
fix(validators): accept both $pkzip$ and $pkzip2$ for PKZIP modes

### DIFF
--- a/hashview/utils/hashcat_modes.py
+++ b/hashview/utils/hashcat_modes.py
@@ -7,6 +7,8 @@ spec table used by hashview.utils.utils.validate_hash_only_hashfile. Specs:
   ('hex', N)        -> exactly N hex characters
   ('hexsalt', N)    -> N hex characters, a colon, then a (lenient) salt
   ('prefix', tag)   -> must start with the literal magic tag (e.g. '$krb5tgs$')
+  ('prefixes', tags)-> must start with one of several literal magic tags (e.g. PKZIP's
+                      '$pkzip$'/'$pkzip2$', both of which hashcat accepts)
   ('litprefix', t)  -> must start with the literal uppercase token (e.g. 'SCRYPT')
 Only fixed-shape parts are constrained, so legitimate hashes are not rejected.
 """
@@ -661,11 +663,11 @@ HASH_ONLY_AUTO_RULES = {
     '16801': ('hexsalt', 32),
     '16900': ('prefix', '$ansible$'),
     '17010': ('prefix', '$gpg$'),
-    '17200': ('prefix', '$pkzip2$'),
-    '17210': ('prefix', '$pkzip2$'),
-    '17220': ('prefix', '$pkzip2$'),
-    '17225': ('prefix', '$pkzip2$'),
-    '17230': ('prefix', '$pkzip2$'),
+    '17200': ('prefixes', ('$pkzip$', '$pkzip2$')),
+    '17210': ('prefixes', ('$pkzip$', '$pkzip2$')),
+    '17220': ('prefixes', ('$pkzip$', '$pkzip2$')),
+    '17225': ('prefixes', ('$pkzip$', '$pkzip2$')),
+    '17230': ('prefixes', ('$pkzip$', '$pkzip2$')),
     '17300': ('hex', 56),
     '17400': ('hex', 64),
     '17500': ('hex', 96),

--- a/hashview/utils/utils.py
+++ b/hashview/utils/utils.py
@@ -1152,6 +1152,12 @@ def _build_auto_matcher(spec):
         rx = re.compile(r'[0-9a-fA-F]{%d}:.+' % spec[1])
         return (lambda s: rx.match(s) is not None,
                 '%d hex characters, a colon, then a salt' % spec[1])
+    if kind == 'prefixes':
+        # Several acceptable magic tags (str.startswith accepts a tuple). Used by
+        # PKZIP, where hashcat accepts both the legacy '$pkzip$' and '$pkzip2$'.
+        prefixes = tuple(spec[1])
+        return (lambda s: s.startswith(prefixes),
+                'a hash beginning with ' + ' or '.join("'%s'" % p for p in prefixes))
     # 'prefix' / 'litprefix'
     prefix = spec[1]
     return (lambda s: s.startswith(prefix), f"a hash beginning with '{prefix}'")

--- a/tests/unit/test_hashfile_validators.py
+++ b/tests/unit/test_hashfile_validators.py
@@ -186,6 +186,20 @@ def test_hash_only_invalid():
     _bad(validate_hash_only_hashfile, ['8743b52063cd84097a65d1633f5c74f5'], '10')      # md5+salt needs :salt
 
 
+def test_hash_only_pkzip_accepts_both_tags():
+    # hashcat's --identify maps BOTH the legacy '$pkzip$' and the '$pkzip2$' tag
+    # to the PKZIP modes (its example hash uses '$pkzip2$'), so accept either for
+    # every PKZIP mode. (Previously the rule was '$pkzip2$'-only, rejecting valid
+    # '$pkzip$' hashes.)
+    pkzip = ('$pkzip$8*1*1*0*0*19*9635*93c0ece4f264048e2af711ba68e132833ad76f985a8a2a9658'
+             '*$/pkzip$')
+    pkzip2 = '$pkzip2$3*1*1*0*0*24*3e2c*3ef8*0619e9d17ff3f994*$/pkzip2$'
+    for htype in ('17200', '17210', '17220', '17225', '17230'):
+        _ok(validate_hash_only_hashfile, [pkzip], htype)
+        _ok(validate_hash_only_hashfile, [pkzip2], htype)
+    _bad(validate_hash_only_hashfile, ['$notpkzip$1*2*3'], '17225')   # other magic still rejected
+
+
 def test_hash_only_unknown_type_is_lenient():
     # a type not in the table is accepted (cannot be safely constrained)
     _ok(validate_hash_only_hashfile, ['anything-goes-here'], '31500')


### PR DESCRIPTION
hashcat's --identify maps both the legacy `$pkzip$` and the `$pkzip2$` tag to the PKZIP modes (17200/17210/17220/17225/17230), but the hashfile-import validator's per-mode rule was `$pkzip2$`-only — so a valid `$pkzip$...$/pkzip$` hash that hashcat accepts was rejected as "invalid hash for the selected type".

Add a 'prefixes' spec type (str.startswith accepts a tuple of tags) and key the five PKZIP modes to ('$pkzip$', '$pkzip2$'). Adds a regression test.