### PR TITLE
feat(jobs): per-hashfile --hex-salt option for salted hashes

### DIFF
--- a/hashview/jobs/forms.py
+++ b/hashview/jobs/forms.py
@@ -63,6 +63,9 @@ class JobsNewHashFileForm(FlaskForm):
 
     hashfilehashes = TextAreaField('Hashes')
     hashfile = FileField('Upload Hashfile')
+    # Only meaningful for the colon-delimited hash_only / user_hash formats; the
+    # template shows the toggle only for those and the route ignores it otherwise.
+    hex_salt = BooleanField('Salts are hex-encoded')
     submit = SubmitField('Next')
 
 class JobsNotificationsForm(FlaskForm):

--- a/hashview/jobs/routes.py
+++ b/hashview/jobs/routes.py
@@ -47,6 +47,7 @@ from hashview.utils.utils import (
     save_file,
     try_commit,
     validate_hash_only_hashfile,
+    validate_hex_salt,
     validate_kerberos_hashfile,
     validate_netntlm_hashfile,
     validate_pwdump_hashfile,
@@ -352,6 +353,16 @@ def jobs_assigned_hashfile(job_id):
                 else:
                     has_problem = 'Invalid File Format'
 
+                # --hex-salt: when the user marked this hashfile's salts as
+                # hex-encoded, verify every salted line actually carries a hex
+                # salt. Only hash_only / user_hash carry a colon-delimited salt
+                # hashcat's --hex-salt applies to; validate_hex_salt no-ops for
+                # unsalted modes.
+                if not has_problem and jobs_new_hashfile_form.hex_salt.data \
+                        and jobs_new_hashfile_form.file_type.data in ('hash_only', 'user_hash'):
+                    has_problem = validate_hex_salt(
+                        hashfile_path, jobs_new_hashfile_form.file_type.data, hash_type)
+
                 if has_problem:
                     if is_ajax:
                         return jsonify({'status': 'error', 'msg': has_problem}), 400
@@ -359,6 +370,11 @@ def jobs_assigned_hashfile(job_id):
                     return redirect(url_for('jobs.jobs_assigned_hashfile', job_id=job_id))
                 else:
                     hashfile = Hashfiles(name=hashfile_name, customer_id=job.customer_id, owner_id=current_user.id)
+                    # Only honor --hex-salt for the two formats that carry a
+                    # colon-delimited salt, even if a crafted POST sets it for
+                    # another format (the UI only shows the toggle for these).
+                    hashfile.hex_salt = bool(jobs_new_hashfile_form.hex_salt.data) and \
+                        jobs_new_hashfile_form.file_type.data in ('hash_only', 'user_hash')
                     db.session.add(hashfile)
                     db.session.commit()
 

--- a/hashview/models.py
+++ b/hashview/models.py
@@ -222,6 +222,10 @@ class Hashfiles(db.Model):
     runtime = db.Column(db.Integer, default=0)
     customer_id = db.Column(db.Integer, nullable=False)
     owner_id = db.Column(db.Integer, nullable=False)
+    # The supplied hashes' salts are hex-encoded -> hashcat needs --hex-salt; only
+    # meaningful for the colon-delimited hash_only / user_hash formats (see
+    # build_hashcat_command + validate_hex_salt).
+    hex_salt = db.Column(db.Boolean, nullable=False, default=False)
 
 class HashfileHashes(db.Model):
     """Class object to represent HashfileHashes"""

--- a/hashview/static/css/phosphor-app.css
+++ b/hashview/static/css/phosphor-app.css
@@ -288,6 +288,30 @@ details.job-card[open] > summary .chev { transform: rotate(90deg); }
 .dropzone.drag { border-color: var(--primary); background: rgba(var(--primary-rgb), 0.07); box-shadow: inset 0 0 18px rgba(var(--primary-rgb), 0.08); }
 .dropzone .ico { color: var(--text-mute); }
 .dropzone.drag .ico { color: var(--primary); }
+
+/* --hex-salt opt-in box: a slightly-lighter panel that lifts the toggle off the
+   card, and illuminates to the phosphor amber when the switch is enabled (mirrors
+   the .switch checked state). :has() drives the lit state off the checkbox — the
+   same pattern as .notif-row / the selectable table rows. --glow respects the
+   user's data-glow preference (becomes none when glow is off, leaving border+fill
+   to still signal "enabled"). Layout (display:flex) is toggled inline by the JS. */
+.hex-salt-box {
+  align-items: center;
+  gap: 12px;
+  margin-top: 20px;
+  max-width: 680px;
+  padding: 14px 16px;
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  transition: border-color .15s, background .15s, box-shadow .15s;
+}
+.hex-salt-box:has(input:checked) {
+  border-color: var(--primary-deep);
+  background: rgba(var(--primary-rgb), 0.06);
+  box-shadow: var(--glow);
+}
+
 .sel-box {
   width: 16px; height: 16px;
   border-radius: 4px;

--- a/hashview/templates/jobs_assigned_hashfiles.html.j2
+++ b/hashview/templates/jobs_assigned_hashfiles.html.j2
@@ -54,6 +54,9 @@
         document.getElementById(show ? show : 'hash_type_placeholder').style.display = 'block';
         var vsel = show ? document.getElementById(show).querySelector('select') : null;
         hvHashTypeExample(vsel);
+        // --hex-salt applies only to the colon-delimited hash_only / user_hash formats
+        var hs = document.getElementById('hex_salt_div');
+        if (hs) hs.style.display = (sel.value === 'hash_only' || sel.value === 'user_hash') ? 'flex' : 'none';
     }
 
     // top-level tab switch: upload / paste / existing
@@ -133,6 +136,18 @@
                         <div id="kerberos_hash_type_div" style="display:none;">{{ jobsNewHashFileForm.kerberos_hash_type(class="select", onchange="hvHashTypeExample(this)") }}</div>
                         <div id="shadow_hash_type_div" style="display:none;">{{ jobsNewHashFileForm.shadow_hash_type(class="select", onchange="hvHashTypeExample(this)") }}</div>
                         <div id="hash_type_div" style="display:none;">{{ jobsNewHashFileForm.hash_type(class="select", onchange="hvHashTypeExample(this)") }}</div>
+                    </div>
+                </div>
+
+                {# --hex-salt: only the colon-delimited hash_only / user_hash formats carry a
+                   separate salt hashcat can treat as hex; showHashTypeSelected() shows this only for those.
+                   .hex-salt-box (phosphor-app.css) is the lighter panel that lifts it off the card and
+                   illuminates when enabled; JS only flips display:none<->flex, leaving the box style. #}
+                <div id="hex_salt_div" class="hex-salt-box" style="display:none;">
+                    <label class="switch">{{ jobsNewHashFileForm.hex_salt(role="switch") }}<span class="track"></span></label>
+                    <div style="flex:1; min-width:0;">
+                        <div style="color:var(--text);">Salts are hex-encoded <code style="color:var(--text-mute); font-size:11.5px; margin-left:4px;">--hex-salt</code></div>
+                        <div class="field-hint" style="margin-top:3px;">Enable when this hashfile's salts are stored as hexadecimal. Passed to hashcat so salted modes parse the salt correctly.</div>
                     </div>
                 </div>
 

--- a/hashview/utils/utils.py
+++ b/hashview/utils/utils.py
@@ -871,6 +871,14 @@ def build_hashcat_command(job_id, task_id, chunk=None, job_task_id=None):
     if attackmode == 0 and isinstance(task.rule_id, int) and task.loopback and not is_chunk_slice:
         cmd += ' --loopback'
 
+    # --hex-salt: the hashfile was marked as carrying hex-encoded salts. Gated on
+    # a salted mode so we never pass it to an unsalted mode (hashcat would reject
+    # it); the upload route only sets hex_salt for the hash_only / user_hash
+    # formats, whose ciphertext keeps the colon-delimited salt hashcat parses.
+    hashfile = Hashfiles.query.get(job.hashfile_id)
+    if hashfile and hashfile.hex_salt and hash_type_uses_salt(hash_type):
+        cmd += ' --hex-salt'
+
     # Dictionary with optional rules
     if attackmode == 0:
         if isinstance(task.rule_id, int):
@@ -1511,6 +1519,57 @@ def validate_hash_only_hashfile(hashfile_path, hash_type):
         if not ok:
             return ('Error line ' + str(line_no) + ' is not a valid hash for the selected '
                     'type — expected ' + expected + '.')
+        return None
+
+    return _validate_hashfile(hashfile_path, check)
+
+
+# Modes whose hash is supplied as a colon-delimited "<hash>:<salt>" (or
+# "<salt>:<hash>") pair -- the only modes for which hashcat's --hex-salt is
+# meaningful. Derived from the existing rule sources so the set can't drift:
+# the hexsalt auto-rules (hashcat_modes) plus the curated rules whose regex
+# carries a salt colon. A few fixed-structure multi-field colon formats are
+# excluded because the text after the first colon isn't a free salt (Juniper's
+# numeric salt, SipHash's "<hex>:2:4:<hex>", DES's "<hex>:<hex>").
+_SALTED_HASH_MODE_EXCLUDE = frozenset({'22', '10100', '14000'})
+_SALTED_HASH_MODES = frozenset(
+    {mode for mode, spec in HASH_ONLY_AUTO_RULES.items() if spec[0] == 'hexsalt'}
+    | {mode for mode, (rx, _desc) in _HASH_ONLY_RULES.items() if ':' in rx.pattern}
+) - _SALTED_HASH_MODE_EXCLUDE
+
+
+def hash_type_uses_salt(hash_type):
+    """True when the hashcat mode supplies its salt as a separate colon-delimited
+    field (so --hex-salt applies). Unsalted modes (NTLM, raw MD5, ...) have no
+    salt to check, so the --hex-salt validation + flag are gated on this."""
+    return str(hash_type) in _SALTED_HASH_MODES
+
+
+_HEX_SALT_RE = re.compile(r'^[0-9a-fA-F]+$')
+
+
+def validate_hex_salt(hashfile_path, file_type, hash_type):
+    """When the --hex-salt option is set, verify every line carries a hex salt.
+
+    Salt position is format-dependent: ``hash_only`` is ``<hash>:<salt>`` (salt
+    after the 1st ':'); ``user_hash`` is ``<user>:<hash>:<salt>`` (salt after the
+    2nd ':', since import splits the username off the first colon). No-ops
+    (returns False) for modes that don't use a salt — there's nothing to check.
+    Returns an error string on the first offending line, else False (matching the
+    sibling validate_*_hashfile contract)."""
+    if not hash_type_uses_salt(hash_type):
+        return False
+    salt_index = 2 if file_type == 'user_hash' else 1
+
+    def check(line, line_no):
+        parts = line.split(':')
+        if len(parts) <= salt_index or parts[salt_index] == '':
+            return ('Error line ' + str(line_no) + ': --hex-salt is set but no salt '
+                    'was found (expected <hash>:<salt>).')
+        salt = ':'.join(parts[salt_index:])     # keep any further colons as part of the salt
+        if not _HEX_SALT_RE.match(salt):
+            return ('Error line ' + str(line_no) + ': salt ' + repr(salt) + ' is not hex '
+                    '(only 0-9 a-f allowed when --hex-salt is set).')
         return None
 
     return _validate_hashfile(hashfile_path, check)

--- a/migrations/versions/a3f7c1e29b84_add_hashfile_hex_salt.py
+++ b/migrations/versions/a3f7c1e29b84_add_hashfile_hex_salt.py
@@ -1,0 +1,34 @@
+"""add hashfile hex_salt option
+
+Revision ID: a3f7c1e29b84
+Revises: dae1c3ac81e6
+Create Date: 2026-06-26 00:00:00.000000
+
+Adds ``hashfiles.hex_salt`` -- a per-hashfile flag marking that the supplied
+hashes' salts are hex-encoded. When set, the job-creation import validates that
+each salted line carries a hex salt and ``build_hashcat_command`` appends
+``--hex-salt`` (only for the colon-delimited hash_only / user_hash formats).
+
+NOT NULL with a ``server_default`` of 0 so existing hashfile rows backfill to
+"plain salts"; fresh rows rely on the model ``default=False``.
+``batch_alter_table`` keeps this SQLite-safe for the migration-smoke test.
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'a3f7c1e29b84'
+down_revision = 'dae1c3ac81e6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('hashfiles') as batch_op:
+        batch_op.add_column(sa.Column('hex_salt', sa.Boolean(), nullable=False, server_default=sa.text('0')))
+
+
+def downgrade():
+    with op.batch_alter_table('hashfiles') as batch_op:
+        batch_op.drop_column('hex_salt')

--- a/tests/unit/test_hashcat_loopback_potfile.py
+++ b/tests/unit/test_hashcat_loopback_potfile.py
@@ -24,6 +24,7 @@ import pytest
 from hashview.models import (
     Hashes,
     HashfileHashes,
+    Hashfiles,
     Jobs,
     Rules,
     Tasks,
@@ -251,6 +252,55 @@ def test_chunk_temp_files_keyed_on_job_task_id(app):
     assert ("control/outfiles/hc_cracked_%d_202.txt" % job.id) in c2
     assert ("control/hashes/hashfile_%d_101.txt" % job.id) in c1
     assert ("control/outfiles/hc_potfile_%d_202.pot" % job.id) in c2
+
+
+# ---------------------------------------------------------------------------
+# --hex-salt: emitted only for a hex_salt hashfile on a salted mode
+# ---------------------------------------------------------------------------
+
+
+def _build_hex(user, *, hex_salt, hash_type, ciphertext="abcd:cafe"):
+    """Build a job whose hashfile carries the given hex_salt flag + hash mode and
+    return its hashcat command (straight dict mode, no rule)."""
+    hf = Hashfiles(name="hf", customer_id=1, owner_id=user.id, hex_salt=hex_salt)
+    db.session.add(hf)
+    db.session.commit()
+    hsh = Hashes(sub_ciphertext="0" * 8, ciphertext=ciphertext, hash_type=hash_type, cracked=False)
+    db.session.add(hsh)
+    db.session.commit()
+    db.session.add(HashfileHashes(hash_id=hsh.id, hashfile_id=hf.id))
+    job = Jobs(name="j", status="Queued", hashfile_id=hf.id, customer_id=1, owner_id=user.id)
+    db.session.add(job)
+    wl = _wordlist(user)
+    task = Tasks(name="t", hc_attackmode=0, owner_id=user.id,
+                 wl_id=wl.id, rule_id=None, hc_mask=None, loopback=False)
+    db.session.add(task)
+    db.session.commit()
+    return build_hashcat_command(job.id, task.id)
+
+
+@pytest.mark.security
+def test_hex_salt_emitted_for_salted_mode(app):
+    user = _make_user()
+    cmd = _build_hex(user, hex_salt=True, hash_type=10)     # md5($pass.$salt) -> salted
+    assert " --hex-salt" in cmd
+    assert " -m 10" in cmd
+
+
+@pytest.mark.security
+def test_hex_salt_omitted_when_flag_off(app):
+    user = _make_user()
+    cmd = _build_hex(user, hex_salt=False, hash_type=10)
+    assert "--hex-salt" not in cmd
+
+
+@pytest.mark.security
+def test_hex_salt_omitted_for_unsalted_mode(app):
+    """Flag on, but an unsalted mode (NTLM) has no salt -> hashcat would reject
+    --hex-salt, so it must be suppressed."""
+    user = _make_user()
+    cmd = _build_hex(user, hex_salt=True, hash_type=1000, ciphertext="b" * 32)
+    assert "--hex-salt" not in cmd
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_hashfile_validators.py
+++ b/tests/unit/test_hashfile_validators.py
@@ -13,8 +13,14 @@ import tempfile
 import pytest
 
 from hashview.utils.utils import (
-    validate_pwdump_hashfile, validate_netntlm_hashfile, validate_kerberos_hashfile,
-    validate_shadow_hashfile, validate_hash_only_hashfile, validate_user_hash_hashfile,
+    hash_type_uses_salt,
+    validate_hash_only_hashfile,
+    validate_hex_salt,
+    validate_kerberos_hashfile,
+    validate_netntlm_hashfile,
+    validate_pwdump_hashfile,
+    validate_shadow_hashfile,
+    validate_user_hash_hashfile,
 )
 
 
@@ -302,8 +308,11 @@ def test_hash_only_auto_table_modes():
 
 def test_form_choices_complete_and_lm_excluded():
     from hashview.utils.hashcat_modes import (
-        HASH_TYPE_CHOICES, KERBEROS_HASH_TYPE_CHOICES,
-        NETNTLM_HASH_TYPE_CHOICES, SHADOW_HASH_TYPE_CHOICES)
+        HASH_TYPE_CHOICES,
+        KERBEROS_HASH_TYPE_CHOICES,
+        NETNTLM_HASH_TYPE_CHOICES,
+        SHADOW_HASH_TYPE_CHOICES,
+    )
 
     def vals(choices):
         return [v for v, _ in choices if v]
@@ -318,3 +327,51 @@ def test_form_choices_complete_and_lm_excluded():
     assert vals(KERBEROS_HASH_TYPE_CHOICES) == ['7500', '13100', '18200', '19600', '19700', '19800', '19900', '28800', '28900']
     assert vals(NETNTLM_HASH_TYPE_CHOICES) == ['5500', '5600', '27000', '27100']
     assert vals(SHADOW_HASH_TYPE_CHOICES) == ['500', '1500', '1800', '3200', '7400', '12400', '15100']
+
+
+# ---------------------------------------------------------------------------
+# --hex-salt (hash_type_uses_salt + validate_hex_salt)
+# ---------------------------------------------------------------------------
+
+def test_hash_type_uses_salt():
+    # generic colon-delimited salted modes -> True
+    for salted in ('10', '20', '110', '1410', '1710', '11', '2811', '1100'):
+        assert hash_type_uses_salt(salted) is True, salted
+    # an auto-derived hexsalt mode -> True
+    assert hash_type_uses_salt('3100') is True
+    # unsalted raw modes -> False
+    for plain in ('0', '100', '1000', '1700', '900'):
+        assert hash_type_uses_salt(plain) is False, plain
+    # fixed-structure multi-field colon modes are excluded
+    for excluded in ('22', '10100', '14000'):
+        assert hash_type_uses_salt(excluded) is False, excluded
+    # accepts int too (str-normalised internally)
+    assert hash_type_uses_salt(10) is True
+
+
+def test_validate_hex_salt_hash_only():
+    md5 = 'a' * 32
+    # valid hex salt after the first colon
+    _ok(validate_hex_salt, [md5 + ':deadbeef', md5 + ':0123456789abcdef'], 'hash_only', '10')
+    # salt with non-hex characters
+    _bad(validate_hex_salt, [md5 + ':xyz123'], 'hash_only', '10')
+    # no salt at all (no colon)
+    _bad(validate_hex_salt, [md5], 'hash_only', '10')
+    # colon present but empty salt
+    _bad(validate_hex_salt, [md5 + ':'], 'hash_only', '10')
+
+
+def test_validate_hex_salt_user_hash():
+    md5 = 'b' * 32
+    # user:hash:salt -> salt after the 2nd colon
+    _ok(validate_hex_salt, ['alice:' + md5 + ':cafe', 'bob:' + md5 + ':00ff'], 'user_hash', '10')
+    # non-hex salt
+    _bad(validate_hex_salt, ['alice:' + md5 + ':nothex'], 'user_hash', '10')
+    # only user:hash, no salt field
+    _bad(validate_hex_salt, ['alice:' + md5], 'user_hash', '10')
+
+
+def test_validate_hex_salt_noop_for_unsalted_mode():
+    # unsalted mode -> nothing to validate, returns False even with junk "salts"
+    ntlm = 'c' * 32
+    _ok(validate_hex_salt, [ntlm, ntlm + ':whatever'], 'hash_only', '1000')


### PR DESCRIPTION
Add a "Salts are hex-encoded" toggle to Create Job step 02 (Hashfile) so users can mark a hashfile whose salts are hex-encoded rather than plain ASCII, and have hashcat parse them correctly.

- models: Hashfiles.hex_salt boolean (+ migration a3f7c1e29b84, server default 0 so existing rows backfill to "plain salts").
- form/UI: hex_salt BooleanField + a .hex-salt-box panel that only shows for the colon-delimited hash_only / user_hash formats and illuminates to the phosphor amber when enabled.
- import: validate_hex_salt() errors when --hex-salt is set but a line carries no salt, or the salt isn't hex; gated by hash_type_uses_salt() (derived from the existing rule tables) so unsalted modes are skipped. Salt position is format-aware (after the 1st colon for hash_only, the 2nd for user_hash). The route only persists the flag for those two formats even on a crafted POST.
- build_hashcat_command: appends --hex-salt only when the hashfile flag is set AND the mode is salted, so it is never passed to a mode hashcat would reject.
- tests: validator + command-builder coverage for the new behavior.