### PR TITLE
fix(dashboard): remove dead agent Restart button from fleet modal

### DIFF
--- a/hashview/templates/_dash_fleet.html.j2
+++ b/hashview/templates/_dash_fleet.html.j2
@@ -28,9 +28,7 @@
                             {% if is_down %}<span class="badge red">OFFLINE</span>{% elif working %}<span class="badge amber">CRACKING</span>{% else %}<span class="badge green">ONLINE</span>{% endif %}
                         </span>
                     </div>
-                    {% if is_down %}
-                        <a class="btn btn-sm btn-danger" href="/agents/restart/{{ agent.id }}" role="button">{{ icon('refresh', size=14) }} Restart</a>
-                    {% else %}
+                    {% if not is_down %}
                         <div style="display:flex;justify-content:space-between;font-size:11.5px;font-family:var(--mono);">
                             <span style="color:var(--text-mute);">task</span>
                             <span style="color:{{ 'var(--text)' if working else 'var(--text-dim)' }};white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:150px;">{{ t.task or 'idle' }}</span>


### PR DESCRIPTION
The Agent Fleet modal showed a "Restart" button for any agent past its check-in cutoff, linking to /agents/restart/<id>. That route never existed (no handler, no JS, no script behind it) -- the button was orphaned and would only 404. Remove it.

The offline detection is unchanged: a down agent still gets the red card border, the off status dot, and the OFFLINE badge; per-agent telemetry is shown only while the agent is up.