### PR TITLE
feat(jobs): gate wizard Next until required fields are set

### DIFF
--- a/hashview/jobs/forms.py
+++ b/hashview/jobs/forms.py
@@ -7,6 +7,7 @@ from wtforms import (
 	StringField,
 	SubmitField,
 	TextAreaField,
+	URLField,
 )
 from wtforms.validators import URL, DataRequired, ValidationError
 
@@ -91,5 +92,7 @@ class JobSummaryForm(FlaskForm):
 class JobWebsiteKeywordsForm(FlaskForm):
     """URL to crawl for the (DYNAMIC) Website Keywords wordlist."""
 
-    crawl_url = StringField('Website URL', validators=[DataRequired(), URL(message='Enter a valid URL, e.g. https://example.com')])
+    # URLField renders type="url" so the wizard's client-side Next gating also
+    # enforces URL shape; the URL() validator stays authoritative server-side.
+    crawl_url = URLField('Website URL', validators=[DataRequired(), URL(message='Enter a valid URL, e.g. https://example.com')])
     submit = SubmitField('Next')

--- a/hashview/templates/jobs_add.html.j2
+++ b/hashview/templates/jobs_add.html.j2
@@ -17,6 +17,9 @@
         {
           document.getElementById('new_customer_div').style.display = 'none';
         }
+        // The customer name is only required when adding a new customer. The form's
+        // change listener (hvGateNext) re-checks validity right after this runs.
+        document.getElementById('customer_name').required = (Index.value == 'add_new');
     }
     function updatePriority(v){
         v = parseInt(v, 10);
@@ -41,7 +44,7 @@
 
 {{ wizard_stepper('setup') }}
 
-<form method="POST" action="" enctype="multipart/form-data">
+<form method="POST" action="" enctype="multipart/form-data" id="job_setup_form">
     {{ jobsForm.hidden_tag() }}
 
     <div class="card">
@@ -65,8 +68,8 @@
             </div>
 
             <div class="field" style="display:none" id="new_customer_div">
-                <label class="field-label" for="name">Customer Name <span class="req">*</span></label>
-                <input class="input" id="name" name="customer_name" type="text">
+                <label class="field-label" for="customer_name">Customer Name <span class="req">*</span></label>
+                <input class="input" id="customer_name" name="customer_name" type="text">
             </div>
 
             {% if settings.enabled_job_weights %}
@@ -99,8 +102,14 @@
     <div class="wizard-nav">
         <a class="btn" href="{{ url_for('jobs.jobs_list') }}" role="button">{{ icon('arrowLeft', size=15) }} Cancel</a>
         <span class="spacer"></span>
-        {{ jobsForm.submit(class="btn btn-primary") }}
+        {{ jobsForm.submit(class="btn btn-primary", id="setup_next") }}
     </div>
 </form>
+
+<script>
+    // Gate Next until the job name + customer (and customer name, when adding one)
+    // are filled. showDiv() keeps customer_name's required flag in sync.
+    hvGateNext(document.getElementById('job_setup_form'), document.getElementById('setup_next'));
+</script>
 
 {% endblock content %}

--- a/hashview/templates/jobs_assigned_hashfiles.html.j2
+++ b/hashview/templates/jobs_assigned_hashfiles.html.j2
@@ -31,6 +31,16 @@
     };
     var HV_PASTE_DEFAULT = 'Paste one hash per line…';
     var HV_HAS_EXISTING = {{ 'true' if hashfiles.count() else 'false' }};
+    var HV_DEFAULT_TAB = "{{ default_tab }}";
+
+    // Disable Next until the active tab's required fields are valid. The button
+    // lives outside the forms and targets the active one via its form= attribute.
+    function hvHfGate(){
+        var nb = document.getElementById('hf_next');
+        if (!nb) return;
+        var form = document.getElementById(nb.getAttribute('form'));
+        nb.disabled = form ? !form.checkValidity() : false;
+    }
 
     function hvHashTypeExample(sel){
         var ta = document.getElementById('paste_box');
@@ -54,9 +64,16 @@
         document.getElementById(show ? show : 'hash_type_placeholder').style.display = 'block';
         var vsel = show ? document.getElementById(show).querySelector('select') : null;
         hvHashTypeExample(vsel);
+        // Only the visible hash-type select is required (a required but display:none
+        // select would otherwise block form validity), so Next stays gated until a
+        // hash type is actually chosen for the selected format.
+        ['pwdump_hash_type_div','netntlm_hash_type_div','kerberos_hash_type_div','shadow_hash_type_div','hash_type_div']
+            .forEach(function(id){ var s=document.getElementById(id).querySelector('select'); if(s) s.required=false; });
+        if (vsel) vsel.required = true;
         // --hex-salt applies only to the colon-delimited hash_only / user_hash formats
         var hs = document.getElementById('hex_salt_div');
         if (hs) hs.style.display = (sel.value === 'hash_only' || sel.value === 'user_hash') ? 'flex' : 'none';
+        hvHfGate();
     }
 
     // top-level tab switch: upload / paste / existing
@@ -69,18 +86,26 @@
         ['upload','paste','existing'].forEach(function(t){
             document.getElementById('tab-'+t).classList.toggle('active', t === which);
         });
+        // Only the active tab's content field is required, so a hidden pane's field
+        // never blocks the active form's validity.
         var ta = document.getElementById('paste_box');
         if (ta) ta.required = (which === 'paste');
+        var fi = document.getElementById('hashfile_input');
+        if (fi) fi.required = (which === 'upload');
+        var nm = document.getElementById('name');
+        if (nm) nm.required = (which === 'paste');
         // point the (outside-the-card) Next button at the active form
         var nb = document.getElementById('hf_next');
         if (nb){
             nb.setAttribute('form', existing ? 'hf_form_existing' : 'hf_form');
             nb.style.display = (existing && !HV_HAS_EXISTING) ? 'none' : '';
         }
+        hvHfGate();
     }
     function hvFileChosen(input){
         var n = (input.files && input.files.length) ? input.files[0].name : '';
         document.getElementById('dropzone_name').textContent = n ? ('Selected: ' + n) : '';
+        hvHfGate();
     }
     function hvDrop(e){
         e.preventDefault();
@@ -92,6 +117,16 @@
         }
     }
     function auto_grow(el){ el.style.height='5px'; el.style.height=(el.scrollHeight)+'px'; }
+
+    // Re-gate Next on any field change in either form, and apply the initial tab
+    // state (which sets the per-tab required flags + first gate check) on load.
+    document.addEventListener('DOMContentLoaded', function(){
+        var hf = document.getElementById('hf_form');
+        if (hf){ hf.addEventListener('input', hvHfGate); hf.addEventListener('change', hvHfGate); }
+        var hfe = document.getElementById('hf_form_existing');
+        if (hfe){ hfe.addEventListener('change', hvHfGate); }
+        hvTab(HV_DEFAULT_TAB);
+    });
 </script>
 
 <div class="page-head">

--- a/hashview/templates/jobs_assigned_notifications_hashes.html.j2
+++ b/hashview/templates/jobs_assigned_notifications_hashes.html.j2
@@ -61,7 +61,7 @@
     <div class="wizard-nav">
         <a class="btn" href="{{ url_for('jobs.jobs_assign_notifications', job_id = job.id) }}">{{ icon('arrowLeft', size=15) }} Back</a>
         <span class="spacer"></span>
-        <input type="submit" class="btn btn-primary" value="Submit">
+        <input type="submit" id="alert_submit" class="btn btn-primary" value="Submit">
     </div>
 </form>
 
@@ -90,6 +90,20 @@
         boxes.forEach(function(b){ b.checked = !allChecked; });
         var lbl = document.getElementById('select_all_lbl');
         if (lbl) lbl.textContent = allChecked ? 'Select all' : 'Clear';
+        hvAlertGate();
     }
+
+    // Gate Submit until at least one hash is selected — an alert with no targets
+    // is pointless, so the step requires >=1 checked box.
+    function hvAlertGate(){
+        var btn = document.getElementById('alert_submit');
+        if (!btn) return;
+        btn.disabled = document.querySelectorAll('#hash_options input.hv-check:checked').length === 0;
+    }
+    document.addEventListener('DOMContentLoaded', function(){
+        var tbl = document.getElementById('hash_options');
+        if (tbl) tbl.addEventListener('change', hvAlertGate);   // delegated: any checkbox toggle
+        hvAlertGate();
+    });
 </script>
 {% endblock content %}

--- a/hashview/templates/jobs_assigned_tasks.html.j2
+++ b/hashview/templates/jobs_assigned_tasks.html.j2
@@ -174,7 +174,12 @@
 <div class="wizard-nav" style="margin-top:20px;">
     <a class="btn" href="{{ url_for('jobs.jobs_assign_notifications', job_id = job.id) }}">{{ icon('arrowLeft', size=15) }} Back</a>
     <span class="spacer"></span>
-    <a class="btn btn-primary" href="/jobs/{{job.id}}/website" role="button">Next {{ icon('arrowRight', size=15) }}</a>
+    {# A job needs at least one task to run; gate Next until one is assigned. #}
+    {% if (job_tasks is defined) and job_tasks.count() > 0 %}
+        <a class="btn btn-primary" href="/jobs/{{job.id}}/website" role="button">Next {{ icon('arrowRight', size=15) }}</a>
+    {% else %}
+        <button type="button" class="btn btn-primary" disabled title="Assign at least one task to continue">Next {{ icon('arrowRight', size=15) }}</button>
+    {% endif %}
 </div>
 
 {# ---- DeleteAllTask modal (native <dialog>) ---- #}

--- a/hashview/templates/jobs_website_keywords.html.j2
+++ b/hashview/templates/jobs_website_keywords.html.j2
@@ -10,7 +10,7 @@
 </div>
 {{ wizard_stepper('website', alert_hashes=(alert_hashes if alert_hashes is defined else false), website=true) }}
 
-<form method="POST" action="">
+<form method="POST" action="" id="website_form">
     {{ form.hidden_tag() }}
 
     <div class="card">
@@ -28,8 +28,13 @@
     <div class="wizard-nav">
         <a class="btn" href="{{ url_for('jobs.jobs_list_tasks', job_id=job.id) }}">{{ icon('arrowLeft', size=15) }} Back</a>
         <span class="spacer"></span>
-        {{ form.submit(class="btn btn-primary") }}
+        {{ form.submit(class="btn btn-primary", id="website_next") }}
     </div>
 </form>
+
+<script>
+    // Gate Next until a valid crawl URL is entered (URLField renders type="url").
+    hvGateNext(document.getElementById('website_form'), document.getElementById('website_next'));
+</script>
 
 {% endblock content %}

--- a/hashview/templates/layout.html.j2
+++ b/hashview/templates/layout.html.j2
@@ -225,6 +225,17 @@
             try { localStorage.setItem('hv_sidebar_collapsed', '1'); } catch (e) {}
         }
     }
+
+    // Disable a wizard step's Next/submit button until its form's required fields
+    // are satisfied (native HTML5 constraint validation). Re-checks on every input
+    // /change; server-side validation remains the source of truth.
+    function hvGateNext(form, btn) {
+        if (!form || !btn) return;
+        function sync() { btn.disabled = !form.checkValidity(); }
+        form.addEventListener('input', sync);
+        form.addEventListener('change', sync);
+        sync();
+    }
     </script>
     {% block scripts %}{% endblock %}
 </body>


### PR DESCRIPTION
Each Create Job step's Next button was always clickable; missing required fields only surfaced as a server error after clicking (e.g. step 02 Hashfile: file format chosen but no hash type). Disable Next until the step's required fields are valid. Server-side validation is unchanged and remains the source of truth -- this is a UX layer on top.

- layout: shared hvGateNext(form, btn) helper -- disables the button when form.checkValidity() fails, re-checking on input/change.
- Setup: gate on job name + customer; customer name becomes required only when "Add new customer" is chosen. Also fixes a duplicate id="name" (customer name input is now id="customer_name").
- Hashfile: tab-aware hvHfGate -- only the active tab's fields are required (Upload: format+type+file; Paste: format+type+name+hashes; Use existing: a row is always pre-selected), so a hidden pane never blocks validity and Next stays disabled until format AND type are set.
- Website URL: crawl_url -> WTForms URLField (renders type="url") so Next also requires a valid URL shape; the URL() validator stays server-side.
- Tasks: render Next as a disabled button until >=1 task/group assigned.
- Alert Hashes: Submit disabled until >=1 hash checkbox is selected.

Reuses the existing .btn:disabled styling; no new CSS.