### PR TITLE
fix(analytics): decode $HEX[...] before length/strength analysis (#291)

### DIFF
--- a/hashview/analytics/routes.py
+++ b/hashview/analytics/routes.py
@@ -20,6 +20,7 @@ from sqlalchemy import func, select
 from werkzeug.utils import secure_filename
 
 from hashview.models import Customers, Hashes, HashfileHashes, Hashfiles, Jobs, Tasks, db
+from hashview.utils.utils import decode_hex_plain
 
 analytics = Blueprint('analytics', __name__)
 
@@ -293,8 +294,13 @@ def get_analytics():
 
     # ---- one recovered (plaintext, username) corpus query feeds every
     #      plaintext-derived chart below ----
-    corpus = (_scoped_hash_query(customer_id, hashfile_id, cracked=True)
-              .with_entities(Hashes.plaintext, HashfileHashes.username).all())
+    # Decode hashcat's `$HEX[...]` marker once here so every plaintext-derived
+    # chart below (length, strength, char-classes, masks, top passwords) measures
+    # the real password rather than the wrapper. Mirrors Wrapped's _decode_plain.
+    corpus = [(decode_hex_plain(plaintext), username)
+              for plaintext, username in
+              _scoped_hash_query(customer_id, hashfile_id, cracked=True)
+              .with_entities(Hashes.plaintext, HashfileHashes.username).all()]
     total_cracked = len(corpus)
 
     freq = Counter()

--- a/hashview/utils/utils.py
+++ b/hashview/utils/utils.py
@@ -440,6 +440,24 @@ def bytes_to_text(raw):
     except UnicodeDecodeError:
         return '$HEX[' + raw.hex() + ']'
 
+def decode_hex_plain(plaintext):
+    """Inverse of the ``$HEX[<hex>]`` marker produced by bytes_to_text: return the
+    human plaintext so length/character-class analysis reflects the real password
+    rather than the wrapper (``$HEX[4142]`` is 8 chars on the wire but the password
+    is just "AB"). A latin-1 fallback keeps arbitrary binary passwords measurable
+    and displayable. Non-marker text (and None) passes straight through as ''-safe
+    text, so callers can use the result directly."""
+    if plaintext and plaintext.startswith('$HEX[') and plaintext.endswith(']'):
+        try:
+            raw = bytes.fromhex(plaintext[5:-1])
+        except ValueError:
+            return plaintext
+        try:
+            return raw.decode('utf-8')
+        except UnicodeDecodeError:
+            return raw.decode('latin-1')
+    return plaintext or ''
+
 def text_from_field(value):
     """Normalise a str field read from a hashfile (opened with
     ``errors='surrogateescape'``) into storage text: valid UTF-8 stays text;

--- a/hashview/wrapped/routes.py
+++ b/hashview/wrapped/routes.py
@@ -5,6 +5,7 @@ from flask_login import current_user, login_required
 from sqlalchemy import func
 
 from hashview.models import Hashes, Tasks, Users, db
+from hashview.utils.utils import decode_hex_plain
 
 wrapped = Blueprint('wrapped', __name__)
 
@@ -29,24 +30,10 @@ def _rank_of(ordered_ids, user_id):
     return ordered_ids.index(user_id) + 1 if user_id in ordered_ids else None
 
 
-def _decode_plain(plaintext):
-    """Human plaintext used for length checks + display.
-
-    hashcat emits non-UTF-8 plaintexts as ``$HEX[..]``; decode those first so the
-    length reflects the real password rather than the wrapper (``$HEX[4142]`` is
-    8 chars on the wire but the password is just "AB"). A latin-1 fallback keeps
-    binary passwords displayable with a byte-accurate length.
-    """
-    if plaintext and plaintext.startswith('$HEX[') and plaintext.endswith(']'):
-        try:
-            raw = bytes.fromhex(plaintext[5:-1])
-        except ValueError:
-            return plaintext
-        try:
-            return raw.decode('utf-8')
-        except UnicodeDecodeError:
-            return raw.decode('latin-1')
-    return plaintext or ''
+# Human plaintext used for length checks + display: decode hashcat's `$HEX[..]`
+# marker so the length reflects the real password, not the wrapper. Shared with
+# Analytics via hashview.utils.utils.decode_hex_plain.
+_decode_plain = decode_hex_plain
 
 
 @wrapped.route("/wrapped", methods=['GET'])

--- a/tests/unit/test_analytics_view.py
+++ b/tests/unit/test_analytics_view.py
@@ -9,6 +9,8 @@ app from tests/unit/conftest.py.
 
 from datetime import datetime, timedelta
 
+import pytest
+
 from hashview.models import (
     Customers,
     Hashes,
@@ -262,3 +264,55 @@ def test_download_fig8_same_user_pass(app, client):
     resp = client.get(f"/analytics/download/fig8?customer_id={customer_id}&hashfile_id={hashfile_id}")
     assert resp.status_code == 200
     assert resp.headers["Content-Disposition"].startswith("attachment")
+
+
+# ---------------------------------------------------------------------------
+# $HEX[...] cracked passwords — length/strength analytics (issue #291)
+#
+# hashcat stores non-UTF-8 plaintexts as the lossless `$HEX[<hex>]` marker.
+# Analytics must decode that before measuring length, the way Wrapped already
+# does (tests/unit/test_wrapped_view.py). These are xfail until #291 lands.
+# ---------------------------------------------------------------------------
+
+# "pässwörd": 8 real characters, but the $HEX[...] wrapper is 26 chars wide.
+_HEX_PW = "$HEX[" + "pässwörd".encode().hex() + "]"
+
+
+def _seed_single_hex_password():
+    """A scope whose only cracked hash is a $HEX[...] (non-UTF-8) password."""
+    cust = Customers(name="Hex Corp")
+    db.session.add(cust)
+    db.session.commit()
+    hf = Hashfiles(name="hex_dump", customer_id=cust.id, owner_id=1, runtime=60)
+    db.session.add(hf)
+    db.session.commit()
+    h = _hash("hexct", _HEX_PW, True)
+    db.session.add(HashfileHashes(hash_id=h.id, hashfile_id=hf.id, username="bob"))
+    db.session.commit()
+    return cust.id, hf.id
+
+
+@pytest.mark.xfail(reason="#291: analytics counts the $HEX[...] wrapper length", strict=True)
+def test_analytics_hex_length_uses_decoded_length(app, client):
+    """The length-distribution chart must bucket the decoded password length
+    (8 for 'pässwörd'), not the 26-char $HEX[...] wrapper."""
+    user = _admin(); _login(client, user)
+    customer_id, hashfile_id = _seed_single_hex_password()
+    html = client.get(
+        f"/analytics?customer_id={customer_id}&hashfile_id={hashfile_id}"
+    ).get_data(as_text=True)
+    # length_dist renders title="{len} chars: {n}" and a {len} label per bar.
+    assert "8 chars" in html          # decoded length
+    assert "26 chars" not in html     # the $HEX[...] wrapper length
+
+
+@pytest.mark.xfail(reason="#291: analytics counts the $HEX[...] wrapper length", strict=True)
+def test_analytics_hex_not_overscored_as_long_strong(app, client):
+    """An 8-char password must not be rated as if it were 26 chars: the
+    raw $HEX[...] string should never leak into the rendered page."""
+    user = _admin(); _login(client, user)
+    customer_id, hashfile_id = _seed_single_hex_password()
+    html = client.get(
+        f"/analytics?customer_id={customer_id}&hashfile_id={hashfile_id}"
+    ).get_data(as_text=True)
+    assert _HEX_PW not in html        # wrapper must not appear in top passwords/masks

--- a/tests/unit/test_analytics_view.py
+++ b/tests/unit/test_analytics_view.py
@@ -9,8 +9,6 @@ app from tests/unit/conftest.py.
 
 from datetime import datetime, timedelta
 
-import pytest
-
 from hashview.models import (
     Customers,
     Hashes,
@@ -292,7 +290,6 @@ def _seed_single_hex_password():
     return cust.id, hf.id
 
 
-@pytest.mark.xfail(reason="#291: analytics counts the $HEX[...] wrapper length", strict=True)
 def test_analytics_hex_length_uses_decoded_length(app, client):
     """The length-distribution chart must bucket the decoded password length
     (8 for 'pässwörd'), not the 26-char $HEX[...] wrapper."""
@@ -306,7 +303,6 @@ def test_analytics_hex_length_uses_decoded_length(app, client):
     assert "26 chars" not in html     # the $HEX[...] wrapper length
 
 
-@pytest.mark.xfail(reason="#291: analytics counts the $HEX[...] wrapper length", strict=True)
 def test_analytics_hex_not_overscored_as_long_strong(app, client):
     """An 8-char password must not be rated as if it were 26 chars: the
     raw $HEX[...] string should never leak into the rendered page."""

--- a/tests/unit/test_unicode_storage.py
+++ b/tests/unit/test_unicode_storage.py
@@ -47,6 +47,20 @@ def test_hexplain_to_text():
     assert U.hexplain_to_text('not-hex') == 'not-hex'            # defensive fallback
 
 
+@pytest.mark.security
+def test_decode_hex_plain():
+    # Inverse of the $HEX[...] marker, used so length/analytics measure the real
+    # password rather than the wrapper (issue #291).
+    assert U.decode_hex_plain('password') == 'password'           # plain passes through
+    assert U.decode_hex_plain('$HEX[' + 'pässwörd'.encode().hex() + ']') == 'pässwörd'
+    assert len(U.decode_hex_plain('$HEX[70c3a4737377c3b67264]')) == 8   # not 26
+    assert U.decode_hex_plain('$HEX[fffe]') == '\xff\xfe'         # binary -> latin-1 fallback
+    assert U.decode_hex_plain('$HEX[zz]') == '$HEX[zz]'           # bad hex -> unchanged
+    assert U.decode_hex_plain(None) == ''                         # None -> '' (safe for len())
+    # round-trips bytes_to_text for UTF-8 content
+    assert U.decode_hex_plain(U.bytes_to_text('café'.encode())) == 'café'
+
+
 # --------------------------------------------------------------------------
 # hashfile import (the reported crash)
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Closes #291

## Problem

Non-UTF-8 cracked passwords are stored as hashcat's lossless `$HEX[<hex>]` marker (`bytes_to_text`). The **Analytics** dashboard computed password length and every length/character-class-derived statistic directly on that raw string, so the wrapper inflated the numbers:

| Password | Stored | Real length | Analytics length |
|---|---|---|---|
| `pässwörd` | `$HEX[70c3a4737377c3b67264]` | 8 | **26** |
| bytes `\xff\xfe` | `$HEX[fffe]` | 2 | **9** |

Non-UTF-8 cracks were pushed into the "16+" length bucket, over-scored as "strong", and shown as the raw `$HEX[...]` text in top-passwords/masks. **Wrapped** already decoded correctly (`_decode_plain`), so the two pages disagreed.

## Fix

- Promote Wrapped's `_decode_plain` to a shared `decode_hex_plain()` in `hashview/utils/utils.py` — the inverse of `bytes_to_text` (UTF-8, then latin-1 fallback; plain text passes through; `''` for `None`).
- **Analytics** decodes the recovered corpus once at the source, so every chart (length, strength, character classes, masks, top passwords) measures the real password.
- **Wrapped** delegates to the shared helper (behavior unchanged).
- Exports still serve the verbatim `$HEX[...]` (correct for hashcat re-import).

## Tests

- `tests/unit/test_analytics_view.py`: added `$HEX[...]` cases — committed first as strict `xfail` (red, demonstrating the bug), then un-xfailed by the fix.
- `tests/unit/test_unicode_storage.py`: unit test for `decode_hex_plain` (incl. the `pässwörd` 8-vs-26 case), next to the existing `bytes_to_text` tests.
- Full unit suite: **1181 passed**, 0 failures. ruff-clean on all production files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)