### PR TITLE
feat(jobs): dedupe non-dynamic tasks + card-style drag-reorder task q…

### DIFF
--- a/hashview/jobs/routes.py
+++ b/hashview/jobs/routes.py
@@ -43,6 +43,7 @@ from hashview.models import (
 from hashview.utils.audit import log_event
 from hashview.utils.utils import (
     build_job_task_commands,
+    dynamic_wordlist_ids,
     import_hashfilehashes,
     save_file,
     try_commit,
@@ -482,14 +483,39 @@ def jobs_list_tasks(job_id):
     job_tasks = JobTasks.query.filter_by(job_id=job_id)
     task_groups = TaskGroups.query.all()
     wordlists = Wordlists.query.all()
-    # Right now we're doing nested loops in the template, this could probably be solved with a left/join select
+
+    # Tasks offered in the "Add Task" dropdown: a task drops out once it's
+    # assigned UNLESS it uses a dynamic wordlist (those may be added more than
+    # once). Mirrors jobs_assign_task's wl_id-based static/dynamic check so a job
+    # can't be configured with two of the same non-dynamic task.
+    dynamic_wl_ids = dynamic_wordlist_ids()
+    assigned_task_ids = {jt.task_id for jt in job_tasks}
+    assignable_tasks = [t for t in tasks
+                        if t.id not in assigned_task_ids or t.wl_id in dynamic_wl_ids]
+
+    # Per-task display metadata for the queue cards (keyed by task id; duplicate
+    # dynamic-task rows share the same task id, so one entry serves all its rows).
+    wl_names = {w.id: w.name for w in wordlists}
+    task_meta = {}
+    for t in tasks:
+        if t.hc_attackmode == 0:
+            label = 'Dict + Rule' if t.rule_id else 'Dictionary'
+        elif t.hc_attackmode == 1:
+            label = 'Combination'
+        elif t.hc_attackmode == 3:
+            label = 'Brute-force'
+        elif t.hc_attackmode in (6, 7):
+            label = 'Hybrid'
+        else:
+            label = 'Task'
+        task_meta[t.id] = {'name': t.name, 'type': label, 'wordlist': wl_names.get(t.wl_id)}
 
     # Does this job have per-hash alerts? Drives the conditional "Alert Hashes" wizard step.
     alert_hashes = False
     if job.hashfile_id:
         alert_hashes = db.session.query(HashNotifications).join(HashfileHashes, HashNotifications.hash_id == HashfileHashes.hash_id).filter(HashfileHashes.hashfile_id == job.hashfile_id).first() is not None
 
-    return render_template('jobs_assigned_tasks.html.j2', title='Jobs Assigned Tasks', job=job, tasks=tasks, job_tasks=job_tasks, task_groups=task_groups, wordlists=wordlists, alert_hashes=alert_hashes, website=_job_uses_website_keywords(job_id))
+    return render_template('jobs_assigned_tasks.html.j2', title='Jobs Assigned Tasks', job=job, tasks=tasks, job_tasks=job_tasks, assignable_tasks=assignable_tasks, task_meta=task_meta, task_groups=task_groups, wordlists=wordlists, alert_hashes=alert_hashes, website=_job_uses_website_keywords(job_id))
 
 @jobs.route("/jobs/<int:job_id>/assign_task/<int:task_id>", methods=['POST'])
 @login_required
@@ -502,25 +528,19 @@ def jobs_assign_task(job_id, task_id):
         flash('Security check failed (invalid or missing CSRF token).', 'danger')
         return redirect("/jobs/" + str(job_id) + "/tasks")
 
-    # Someone smarter than me can turn this into a single DB Query
+    # A task may be assigned more than once ONLY when it uses a dynamic wordlist.
+    # Check for a dynamic wordlist explicitly (not "anything that isn't static") so
+    # a missing wordlist or odd `type` casing can't slip a duplicate through — this
+    # matches the Add-Task dropdown's dynamic_wordlist_ids() filter.
+    task = Tasks.query.get(task_id)
+    wordlist = Wordlists.query.get(task.wl_id) if task else None
+    is_dynamic = wordlist is not None and wordlist.type == 'dynamic'
     jobtask_exists = JobTasks.query.filter_by(job_id=job_id, task_id=task_id).first()
-    wordlist = Wordlists.query.get(Tasks.query.get(task_id).wl_id)
-    # hc_attackmode = Tasks.query.get(task_id).hc_attackmode
-    
-    if jobtask_exists:
-        #if hc_attackmode == '0' or hc_attackmode == '1' or hc_attackmode == '6' or hc_attackmode == '7':
-        if wordlist:
-            if wordlist.type == 'static':
-                flash('Task already assigned to the job.', 'warning')
-            else:
-                job_task = JobTasks(job_id=job_id, task_id=task_id, status='Not Started')
-                db.session.add(job_task)
-                db.session.commit() 
-        else:
-            flash('Task already assigned to the job.', 'warning')
+
+    if jobtask_exists and not is_dynamic:
+        flash('That task is already assigned. Only tasks using a dynamic wordlist can be added more than once.', 'warning')
     else:
-        job_task = JobTasks(job_id=job_id, task_id=task_id, status='Not Started')
-        db.session.add(job_task)
+        db.session.add(JobTasks(job_id=job_id, task_id=task_id, status='Not Started'))
         db.session.commit()
 
     return redirect("/jobs/"+str(job_id)+"/tasks")
@@ -537,29 +557,17 @@ def jobs_assign_task_group(job_id, task_group_id):
     task_group = TaskGroups.query.get(task_group_id)
 
     for task_group_entry in json.loads(task_group.tasks):
-        # Check if task.hc_attackmode = 0, 1, 6, or 7. If so allow duplicates
+        # As in jobs_assign_task: only a dynamic-wordlist task may be added again;
+        # an already-assigned non-dynamic task in the group is skipped.
+        task = Tasks.query.get(task_group_entry)
+        wordlist = Wordlists.query.get(task.wl_id) if task else None
+        is_dynamic = wordlist is not None and wordlist.type == 'dynamic'
         jobtask_exists = JobTasks.query.filter_by(job_id=job_id, task_id=task_group_entry).first()
-        wordlist = Wordlists.query.get(Tasks.query.get(task_group_entry).wl_id)
 
-        if jobtask_exists:
-            if wordlist:
-                if wordlist.type == 'static':
-                    continue
-                else:
-                    job_task = JobTasks(job_id=job_id, task_id=task_group_entry, status='Not Started')
-                    db.session.add(job_task)
-                    db.session.commit()
-            else:
-                continue
-        else:
-            job_task = JobTasks(job_id=job_id, task_id=task_group_entry, status='Not Started')
-            db.session.add(job_task)
-            db.session.commit()
-
-
-        # job_task = JobTasks(job_id=job_id, task_id=task_group_entry, status='Not Started')
-        # db.session.add(job_task)
-        # db.session.commit()
+        if jobtask_exists and not is_dynamic:
+            continue
+        db.session.add(JobTasks(job_id=job_id, task_id=task_group_entry, status='Not Started'))
+        db.session.commit()
 
     return redirect("/jobs/" + str(job_id) + "/tasks")
 
@@ -602,85 +610,39 @@ def jobs_assign_lucky_task_group(job_id):
         flash('Successfully Added Top 10 Tasks', 'success')
     return redirect("/jobs/" + str(job_id) + "/tasks")
 
-@jobs.route("/jobs/<int:job_id>/move_task_up/<int:task_id>", methods=['POST'])
+@jobs.route("/jobs/<int:job_id>/reorder_tasks", methods=['POST'])
 @login_required
-def jobs_move_task_up(job_id, task_id):
-    """Function to move assigned task up on task list for job"""
+def jobs_reorder_tasks(job_id):
+    """Reorder a job's task queue from a drag-and-drop submission.
+
+    ``order`` is the new task-id sequence (comma-joined, one entry per queue row;
+    duplicates are allowed for dynamic-wordlist tasks). The submission must be a
+    permutation of the job's current rows (multiset equality) — otherwise it's a
+    stale/tampered page and is rejected. Rebuilds the queue by deleting and
+    recreating the rows in the new order, the same delete-and-recreate the old
+    move-up/down arrows used (order is JobTasks insertion order)."""
 
     if not FlaskForm().validate_on_submit():
         flash('Security check failed (invalid or missing CSRF token).', 'danger')
         return redirect("/jobs/" + str(job_id) + "/tasks")
 
-    job_tasks = JobTasks.query.filter_by(job_id=job_id).all()
+    current = [jt.task_id for jt in JobTasks.query.filter_by(job_id=job_id).all()]
+    try:
+        submitted = [int(x) for x in request.form.get('order', '').split(',') if x != '']
+    except ValueError:
+        submitted = []
 
-    # We create an array of all related jobtasks, remove existing jobtasks, re-arrange, and create new jobtasks (this way we dont have to worry about non-contigous jobtasks ids)
-    temp_jobtasks = []
-    new_jobtasks = []
-
-    for entry in job_tasks:
-        temp_jobtasks.append(str(entry.task_id))
-
-    if temp_jobtasks[0] == str(task_id):
-        flash('Task is already at the top', 'warning')
-        return redirect("/jobs/"+str(job_id)+"/tasks")
-
-    element_index = temp_jobtasks.index(str(task_id))
-    temp_value = temp_jobtasks[element_index - 1]
-    temp_jobtasks[element_index - 1] = str(task_id)
-    temp_jobtasks[element_index] = str(temp_value)
-
-    new_jobtasks = temp_jobtasks
-
-    JobTasks.query.filter_by(job_id=job_id).delete()
-    db.session.commit()
-
-    for entry in new_jobtasks:
-        job_task = JobTasks(job_id=job_id, task_id=entry, status='Not Started')
-        db.session.add(job_task)
-        db.session.commit()
-
-    return redirect("/jobs/"+str(job_id)+"/tasks")
-
-@jobs.route("/jobs/<int:job_id>/move_task_down/<int:task_id>", methods=['POST'])
-@login_required
-def jobs_move_task_down(job_id, task_id):
-    """Function to move assigned task down on task list for job"""
-
-    if not FlaskForm().validate_on_submit():
-        flash('Security check failed (invalid or missing CSRF token).', 'danger')
+    if sorted(submitted) != sorted(current):
+        flash('Task order was out of date; nothing changed. Please try again.', 'danger')
         return redirect("/jobs/" + str(job_id) + "/tasks")
 
-    job_tasks = JobTasks.query.filter_by(job_id=job_id).all()
-
-    # We create an array of all related jobtasks, remove existing jobtasks, re-arrange, and create new jobtasks (this way we dont have to worry about non-contigous jobtasks ids)
-    temp_jobtasks = []
-    new_jobtasks = []
-
-    for entry in job_tasks:
-        temp_jobtasks.append(str(entry.task_id))
-
-    if temp_jobtasks[-1] == str(task_id):
-        flash('Task is already at the bottom', 'warning')
-        return redirect("/jobs/"+str(job_id)+"/tasks")
-
-    for index in range(len(temp_jobtasks)):
-        if int(index+1) <= len(temp_jobtasks):
-            if  temp_jobtasks[int(index)] == str(task_id):
-                new_jobtasks.append(temp_jobtasks[int(index+1)])
-                new_jobtasks.append(str(task_id))
-                del temp_jobtasks[int(index+1)]
-            else:
-                new_jobtasks.append(temp_jobtasks[int(index)])
-
     JobTasks.query.filter_by(job_id=job_id).delete()
     db.session.commit()
+    for task_id in submitted:
+        db.session.add(JobTasks(job_id=job_id, task_id=task_id, status='Not Started'))
+    db.session.commit()
 
-    for entry in new_jobtasks:
-        job_task = JobTasks(job_id=job_id, task_id=entry, status='Not Started')
-        db.session.add(job_task)
-        db.session.commit()
-
-    return redirect("/jobs/"+str(job_id)+"/tasks")
+    return redirect("/jobs/" + str(job_id) + "/tasks")
 
 @jobs.route("/jobs/<int:job_id>/remove_task/<int:task_id>", methods=['POST'])
 @login_required

--- a/hashview/templates/jobs_assigned_tasks.html.j2
+++ b/hashview/templates/jobs_assigned_tasks.html.j2
@@ -32,34 +32,16 @@
                     </summary>
                     <div class="card" style="margin-top:8px; max-height:300px; overflow-y:auto;">
                         <div class="card-body" style="padding:6px;">
-                            {% set any_task = namespace(value=0) %}
-                            {% for task in tasks %}
-                                {% set already_assigned = namespace(value=0) %}
-                                {% for job_task in job_tasks %}
-                                    {% if job_task.task_id == task.id %}
-                                        {% if task.hc_attackmode == 0 or task.hc_attackmode == 1 or task.hc_attackmode == 6 or task.hc_attackmode == 7 %}
-                                            {% for wordlist in wordlists %}
-                                                {% if wordlist.id == task.wordlist_id and wordlist.type == 'static' %}
-                                                    {% set already_assigned.value = 1 %}
-                                                {% endif %}
-                                            {% endfor %}
-                                        {% else %}
-                                            {% set already_assigned.value = 1 %}
-                                        {% endif %}
-                                    {% endif %}
-                                {% endfor %}
-                                {% if already_assigned.value == 0 %}
-                                    {% set any_task.value = 1 %}
-                                    <!-- TODO: filter out tasks already assigned to the job -->
-                                    <form method="POST" action="/jobs/{{job.id}}/assign_task/{{task.id}}">
-                                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                                        <button type="submit" class="btn btn-ghost btn-block" style="justify-content:flex-start;">{{ icon('task', size=14) }} {{task.name}}</button>
-                                    </form>
-                                {% endif %}
-                            {% endfor %}
-                            {% if any_task.value == 0 %}
+                            {# assignable_tasks (computed in the route): an assigned task drops out
+                               unless it uses a dynamic wordlist, so a non-dynamic task can't be added twice. #}
+                            {% for task in assignable_tasks %}
+                                <form method="POST" action="/jobs/{{job.id}}/assign_task/{{task.id}}">
+                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                    <button type="submit" class="btn btn-ghost btn-block" style="justify-content:flex-start;">{{ icon('task', size=14) }} {{task.name}}</button>
+                                </form>
+                            {% else %}
                                 <div class="page-sub" style="padding:8px 10px;">No tasks available.</div>
-                            {% endif %}
+                            {% endfor %}
                         </div>
                     </div>
                 </details>
@@ -97,79 +79,138 @@
     {# ============ Task Queue ============ #}
     <div class="card">
         <div class="card-head">
-            {{ icon('list', size=16) }}
+            <span class="dot-led {% if (job_tasks is defined) and job_tasks.count() > 0 %}on{% else %}idle{% endif %}"></span>
             <h3>Task Queue</h3>
             {% if (job_tasks is defined) and job_tasks.count() > 0 %}
-                <button type="button" id="remove_all" class="btn btn-danger btn-sm" style="margin-left:auto;" title="Remove all assigned tasks for this Job" onclick="document.getElementById('deleteModal').showModal()">{{ icon('trash', size=14) }} Remove All</button>
+                <a href="#" id="clear_all" style="margin-left:auto; color:var(--text-mute); font-size:12px; font-family:var(--mono);" title="Remove all assigned tasks for this job" onclick="document.getElementById('deleteModal').showModal(); return false;">clear all</a>
             {% endif %}
         </div>
         <div class="card-body" style="padding:0;">
-            <table class="tbl">
-                <thead>
-                    <tr>
-                        <th>Task Name</th>
-                        <th>Type</th>
-                        <th class="center">Control</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for job_task in job_tasks %}
-                        <tr>
-                            <td style="font-weight:500;">
-                                {% for task in tasks %}
-                                    {% if task.id == job_task.task_id %}
-                                        {{task.name}}
-                                    {% endif %}
-                                {% endfor %}
-                            </td>
-                            <td style="color:var(--text-dim);">
-                                {% for task in tasks %}
-                                    {% if task.id == job_task.task_id %}
-                                        {% if task.hc_attackmode == 0 %}
-                                            Straight (Wordlist + Rules)
-                                        {% elif task.hc_attackmode == 1 %}
-                                            Combination (Wordlist1, Rule1, Wordlist2, Rule2)
-                                        {% elif task.hc_attackmode == 3 %}
-                                            Brute-force (Maskmode)
-                                        {% elif task.hc_attackmode == 6 %}
-                                            Hybrid (Wordlist + Mask)
-                                        {% elif task.hc_attackmode == 7 %}
-                                            Hybrid (Mask + wordlist)
-                                        {% else %}
-                                            UNDEF?
-                                        {% endif %}
-                                    {% endif %}
-                                {% endfor %}
-                            </td>
-                            <td class="center">
-                                <div style="display:flex; gap:4px; justify-content:center;">
-                                    <form method="POST" action="/jobs/{{job.id}}/move_task_up/{{job_task.task_id}}" style="display:contents">
-                                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                                        <button type="submit" class="icon-btn" title="Move Up">{{ icon('arrowUp', size=15) }}</button>
-                                    </form>
-                                    <form method="POST" action="/jobs/{{job.id}}/move_task_down/{{job_task.task_id}}" style="display:contents">
-                                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                                        <button type="submit" class="icon-btn" title="Move Down">{{ icon('arrowDown', size=15) }}</button>
-                                    </form>
-                                    <form method="POST" action="/jobs/{{job.id}}/remove_task/{{job_task.task_id}}" style="display:contents">
-                                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                                        <button type="submit" class="icon-btn act-del" title="Delete">{{ icon('trash', size=15) }}</button>
-                                    </form>
-                                </div>
-                            </td>
-                        </tr>
-                    {% else %}
-                        <tr>
-                            <td colspan="3" style="text-align:center; padding:32px 16px; color:var(--text-dim);">
-                                No tasks assigned yet. Add some from the library.
-                            </td>
-                        </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
+            {# Drag a card to reorder; siblings slide out of the way (FLIP). On drop
+               the new task-id order is posted to jobs_reorder_tasks (POST+redirect). #}
+            <form id="reorder-form" method="POST" action="/jobs/{{job.id}}/reorder_tasks">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <input type="hidden" name="order" id="reorder-order">
+            </form>
+            <div id="task-queue">
+                {% for job_task in job_tasks %}
+                    {% set m = task_meta.get(job_task.task_id) if task_meta is defined else none %}
+                    <div class="tq-item" draggable="true" data-task-id="{{ job_task.task_id }}">
+                        <span class="tq-index">{{ '%02d' % loop.index }}</span>
+                        <span class="tq-grip" title="Drag to reorder">{{ icon('drag', size=16) }}</span>
+                        <div class="tq-body">
+                            <div class="tq-name">{{ m.name if m else 'Unknown task' }}</div>
+                            <div class="tq-sub">{{ m.type if m else 'Task' }}{% if m and m.wordlist %} · {{ m.wordlist }}{% endif %}</div>
+                        </div>
+                        <div class="tq-controls">
+                            <form method="POST" action="/jobs/{{job.id}}/remove_task/{{job_task.task_id}}" style="display:contents">
+                                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                                <button type="submit" class="icon-btn act-del" title="Remove task">{{ icon('trash', size=15) }}</button>
+                            </form>
+                        </div>
+                    </div>
+                {% else %}
+                    <div class="tq-empty">No tasks assigned yet. Add some from the library.</div>
+                {% endfor %}
+            </div>
         </div>
     </div>
 </div>
+
+<style>
+    #task-queue { display: flex; flex-direction: column; gap: 12px; padding: 16px; }
+    .tq-item {
+        display: flex; align-items: center; gap: 14px; padding: 14px 16px;
+        border: 1px solid var(--border); border-radius: var(--radius-lg);
+        background: var(--surface-2);
+        transition: transform .18s ease, opacity .15s ease, border-color .15s ease;
+    }
+    .tq-item:hover { border-color: var(--border-bright); }
+    .tq-item.tq-dragging { opacity: 0.4; }
+    .tq-index { font-family: var(--mono); color: var(--primary); font-size: 13px; min-width: 22px; text-align: right; }
+    .tq-grip { color: var(--text-mute); cursor: grab; display: inline-flex; }
+    .tq-item:hover .tq-grip { color: var(--text-dim); }
+    .tq-item.tq-dragging .tq-grip { cursor: grabbing; }
+    .tq-body { flex: 1; min-width: 0; }
+    .tq-name { color: var(--text); font-family: var(--mono); font-size: 14px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .tq-sub { color: var(--text-mute); font-family: var(--mono); font-size: 11.5px; margin-top: 3px; }
+    .tq-controls { display: flex; gap: 6px; flex: none; }
+    .tq-empty { padding: 32px 16px; text-align: center; color: var(--text-dim); }
+</style>
+<script>
+    // Drag-to-reorder the task queue. While dragging, siblings animate out of the
+    // way (FLIP: measure -> reorder -> invert -> play). On drop, the new task-id
+    // order is submitted to jobs_reorder_tasks (the server rebuilds the order).
+    (function () {
+        var list = document.getElementById('task-queue');
+        if (!list) return;
+        var dragEl = null;
+
+        function itemAfter(y) {
+            var items = Array.prototype.slice.call(
+                list.querySelectorAll('.tq-item:not(.tq-dragging)'));
+            var best = { offset: -Infinity, el: null };
+            items.forEach(function (el) {
+                var box = el.getBoundingClientRect();
+                var offset = y - box.top - box.height / 2;
+                if (offset < 0 && offset > best.offset) best = { offset: offset, el: el };
+            });
+            return best.el;
+        }
+
+        // Animate the move: record current tops, run the DOM reorder, then slide
+        // each shifted sibling from its old position to its new one.
+        function flipReorder(reorder) {
+            var items = Array.prototype.slice.call(list.querySelectorAll('.tq-item'));
+            var firstTop = items.map(function (el) { return el.getBoundingClientRect().top; });
+            reorder();
+            items.forEach(function (el, i) {
+                if (el === dragEl) return;
+                var dy = firstTop[i] - el.getBoundingClientRect().top;
+                if (!dy) return;
+                el.style.transition = 'none';
+                el.style.transform = 'translateY(' + dy + 'px)';
+                requestAnimationFrame(function () {
+                    el.style.transition = '';
+                    el.style.transform = '';
+                });
+            });
+        }
+
+        list.addEventListener('dragstart', function (e) {
+            dragEl = e.target.closest('.tq-item');
+            if (!dragEl) return;
+            e.dataTransfer.effectAllowed = 'move';
+            try { e.dataTransfer.setData('text/plain', ''); } catch (_) {}
+            // defer so the drag image captures the full-opacity card, then fade it
+            setTimeout(function () { if (dragEl) dragEl.classList.add('tq-dragging'); }, 0);
+        });
+        list.addEventListener('dragend', function () {
+            if (dragEl) dragEl.classList.remove('tq-dragging');
+            dragEl = null;
+        });
+        list.addEventListener('dragover', function (e) {
+            if (!dragEl) return;
+            e.preventDefault();
+            var after = itemAfter(e.clientY);
+            if (after === dragEl) return;
+            if (after == null) {
+                if (list.lastElementChild !== dragEl) flipReorder(function () { list.appendChild(dragEl); });
+            } else if (dragEl.nextElementSibling !== after) {
+                flipReorder(function () { list.insertBefore(dragEl, after); });
+            }
+        });
+        list.addEventListener('drop', function (e) {
+            e.preventDefault();
+            if (!dragEl) return;
+            var ids = Array.prototype.map.call(
+                list.querySelectorAll('.tq-item[data-task-id]'),
+                function (el) { return el.getAttribute('data-task-id'); });
+            document.getElementById('reorder-order').value = ids.join(',');
+            document.getElementById('reorder-form').submit();
+        });
+    })();
+</script>
 
 <div class="wizard-nav" style="margin-top:20px;">
     <a class="btn" href="{{ url_for('jobs.jobs_assign_notifications', job_id = job.id) }}">{{ icon('arrowLeft', size=15) }} Back</a>

--- a/tests/unit/test_jobs_routes.py
+++ b/tests/unit/test_jobs_routes.py
@@ -187,7 +187,7 @@ def _ordered_task_ids(job):
             JobTasks.query.filter_by(job_id=job.id).order_by(JobTasks.id).all()]
 
 
-def test_jobs_move_task_up_swaps_order(app, client):
+def test_jobs_reorder_tasks_swaps_order(app, client):
     admin = make_admin()
     login(client, admin)
     cust = make_customer()
@@ -196,12 +196,13 @@ def test_jobs_move_task_up_swaps_order(app, client):
     _assign(job, t1)
     _assign(job, t2)
     assert _ordered_task_ids(job) == [t1.id, t2.id]
-    resp = client.post(f"/jobs/{job.id}/move_task_up/{t2.id}", follow_redirects=False)
+    resp = client.post(f"/jobs/{job.id}/reorder_tasks",
+                       data={"order": f"{t2.id},{t1.id}"}, follow_redirects=False)
     assert resp.status_code in (301, 302)
     assert _ordered_task_ids(job) == [t2.id, t1.id]
 
 
-def test_jobs_move_task_up_top_is_noop(app, client):
+def test_jobs_reorder_tasks_bad_order_is_noop(app, client):
     admin = make_admin()
     login(client, admin)
     cust = make_customer()
@@ -209,21 +210,10 @@ def test_jobs_move_task_up_top_is_noop(app, client):
     t1, t2 = _task(admin, name="first"), _task(admin, name="second")
     _assign(job, t1)
     _assign(job, t2)
-    client.post(f"/jobs/{job.id}/move_task_up/{t1.id}", follow_redirects=False)
+    # not a permutation of the job's rows -> rejected, order unchanged
+    client.post(f"/jobs/{job.id}/reorder_tasks",
+                data={"order": f"{t1.id}"}, follow_redirects=False)
     assert _ordered_task_ids(job) == [t1.id, t2.id]
-
-
-def test_jobs_move_task_down_swaps_order(app, client):
-    admin = make_admin()
-    login(client, admin)
-    cust = make_customer()
-    job = _job(admin, cust)
-    t1, t2 = _task(admin, name="first"), _task(admin, name="second")
-    _assign(job, t1)
-    _assign(job, t2)
-    resp = client.post(f"/jobs/{job.id}/move_task_down/{t1.id}", follow_redirects=False)
-    assert resp.status_code in (301, 302)
-    assert _ordered_task_ids(job) == [t2.id, t1.id]
 
 
 def test_jobs_remove_all_tasks_clears(app, client):

--- a/tests/unit/test_jobs_routes_branches.py
+++ b/tests/unit/test_jobs_routes_branches.py
@@ -641,10 +641,10 @@ def test_jobs_assign_task_duplicate_with_no_wordlist_flashes(app, client):
     db.session.commit()
     _login(client, user)
 
-    # Assign again — should flash "Task already assigned"
+    # Assign again — should be rejected (no dynamic wordlist) and flash a warning
     resp = client.post(f"/jobs/{job.id}/assign_task/{task.id}",
                        follow_redirects=True)
-    assert b"Task already assigned to the job." in resp.data
+    assert b"already assigned" in resp.data
     assert JobTasks.query.filter_by(job_id=job.id, task_id=task.id).count() == 1
 
 
@@ -838,11 +838,11 @@ def test_jobs_notifications_hash_slack_redirects_to_hashes(app, client):
 
 
 # ---------------------------------------------------------------------------
-# jobs_move_task_down with 3 tasks — hits the else branch (line 624)
+# jobs_reorder_tasks — reorder a 3-task queue to an arbitrary permutation
 # ---------------------------------------------------------------------------
 
-def test_jobs_move_task_down_three_tasks_else_branch(app, client):
-    """Moving task_1 down in a 3-task list exercises the else-append branch."""
+def test_jobs_reorder_tasks_three_tasks(app, client):
+    """Reorder a 3-task queue to [t2, t1, t3] via the drag-drop reorder route."""
     user = _nonadmin()
     customer = _make_customer()
     job = _make_job(user.id, customer.id)
@@ -856,9 +856,8 @@ def test_jobs_move_task_down_three_tasks_else_branch(app, client):
     db.session.commit()
     _login(client, user)
 
-    # Move t1 down: order should become [t2, t1, t3]
-    resp = client.post(f"/jobs/{job.id}/move_task_down/{t1.id}",
-                       follow_redirects=False)
+    resp = client.post(f"/jobs/{job.id}/reorder_tasks",
+                       data={"order": f"{t2.id},{t1.id},{t3.id}"}, follow_redirects=False)
     assert resp.status_code in (301, 302)
     order = [jt.task_id for jt in
              JobTasks.query.filter_by(job_id=job.id).order_by(JobTasks.id).all()]

--- a/tests/unit/test_jobs_routes_guards.py
+++ b/tests/unit/test_jobs_routes_guards.py
@@ -135,7 +135,8 @@ def test_jobs_assign_duplicate_static_wordlist_task_rejected(app, client):
     client.post(f"/jobs/{job.id}/assign_task/{task.id}")
     resp = client.post(f"/jobs/{job.id}/assign_task/{task.id}",
                       follow_redirects=True)
-    assert b"Task already assigned to the job." in resp.data
+    assert b"already assigned" in resp.data
+    assert JobTasks.query.filter_by(job_id=job.id, task_id=task.id).count() == 1  # no dupe
     assert JobTasks.query.filter_by(job_id=job.id, task_id=task.id).count() == 1
 
 
@@ -348,7 +349,7 @@ def test_jobs_assign_task_group_assigns_all_and_skips_static_dupes(app, client):
     assert JobTasks.query.filter_by(job_id=job.id).count() == 2
 
 
-# ------------------------------------------------- jobs_move_task_up / _down
+# ------------------------------------------------------- jobs_reorder_tasks
 
 def _job_with_two_tasks(user):
     customer = _make_customer()
@@ -367,48 +368,71 @@ def _task_order(job_id):
             JobTasks.query.filter_by(job_id=job_id).order_by(JobTasks.id).all()]
 
 
-def test_jobs_move_task_up_swaps_order(app, client):
+def test_jobs_reorder_tasks_reorders(app, client):
     user = _nonadmin()
     job, t1, t2 = _job_with_two_tasks(user)
     _login(client, user)
 
-    resp = client.post(f"/jobs/{job.id}/move_task_up/{t2.id}",
-                      follow_redirects=False)
+    resp = client.post(f"/jobs/{job.id}/reorder_tasks",
+                       data={"order": f"{t2.id},{t1.id}"}, follow_redirects=False)
     assert resp.status_code in (301, 302)
     assert _task_order(job.id) == [t2.id, t1.id]
 
 
-def test_jobs_move_task_up_already_top_warns(app, client):
+def test_jobs_reorder_tasks_rejects_non_permutation(app, client):
+    """A submitted order that isn't a permutation of the job's rows (stale page /
+    tampering) is rejected and the queue is left unchanged."""
     user = _nonadmin()
     job, t1, t2 = _job_with_two_tasks(user)
     _login(client, user)
 
-    resp = client.post(f"/jobs/{job.id}/move_task_up/{t1.id}",
-                      follow_redirects=True)
-    assert b"already at the top" in resp.data
+    resp = client.post(f"/jobs/{job.id}/reorder_tasks",
+                       data={"order": f"{t1.id},999999"}, follow_redirects=True)
+    assert b"out of date" in resp.data
     assert _task_order(job.id) == [t1.id, t2.id]  # unchanged
 
 
-def test_jobs_move_task_down_swaps_order(app, client):
+def test_add_task_dropdown_drops_assigned_static_keeps_dynamic(app, client):
+    """The Add-Task dropdown removes an assigned task unless it uses a dynamic
+    wordlist (so a non-dynamic task can't be added twice). The assign_task form
+    only appears in the dropdown, so its presence/absence is the signal."""
     user = _nonadmin()
-    job, t1, t2 = _job_with_two_tasks(user)
+    customer = _make_customer()
+    job = _make_job(user.id, customer.id)
+    static_wl = _make_wordlist(user.id, name="static-wl", wl_type="static")
+    dynamic_wl = _make_wordlist(user.id, name="dyn-wl", wl_type="dynamic")
+    t_static = _make_task(user.id, static_wl.id, name="static-task")
+    t_dynamic = _make_task(user.id, dynamic_wl.id, name="dynamic-task")
+    t_unassigned = _make_task(user.id, static_wl.id, name="unassigned-task")
+    # assign the static + dynamic tasks; leave t_unassigned off the job
+    db.session.add(JobTasks(job_id=job.id, task_id=t_static.id, status="Not Started"))
+    db.session.add(JobTasks(job_id=job.id, task_id=t_dynamic.id, status="Not Started"))
+    db.session.commit()
     _login(client, user)
 
-    resp = client.post(f"/jobs/{job.id}/move_task_down/{t1.id}",
-                      follow_redirects=False)
-    assert resp.status_code in (301, 302)
-    assert _task_order(job.id) == [t2.id, t1.id]
+    html = client.get(f"/jobs/{job.id}/tasks").get_data(as_text=True)
+    assert f"/assign_task/{t_static.id}" not in html       # assigned + static -> dropped
+    assert f"/assign_task/{t_dynamic.id}" in html          # assigned + dynamic -> stays
+    assert f"/assign_task/{t_unassigned.id}" in html       # unassigned -> shown
 
 
-def test_jobs_move_task_down_already_bottom_warns(app, client):
+def test_task_queue_renders_cards_with_meta(app, client):
+    """The queue renders draggable .tq-item cards with the task name + a
+    type-and-wordlist subtitle (mode-0 no-rule task -> 'Dictionary')."""
     user = _nonadmin()
-    job, t1, t2 = _job_with_two_tasks(user)
+    customer = _make_customer()
+    job = _make_job(user.id, customer.id)
+    wl = _make_wordlist(user.id, name="rockyou", wl_type="static")
+    t = _make_task(user.id, wl.id, name="rockyou-dict")   # hc_attackmode 0, rule_id None
+    db.session.add(JobTasks(job_id=job.id, task_id=t.id, status="Not Started"))
+    db.session.commit()
     _login(client, user)
 
-    resp = client.post(f"/jobs/{job.id}/move_task_down/{t2.id}",
-                      follow_redirects=True)
-    assert b"already at the bottom" in resp.data
-    assert _task_order(job.id) == [t1.id, t2.id]  # unchanged
+    html = client.get(f"/jobs/{job.id}/tasks").get_data(as_text=True)
+    assert 'class="tq-item"' in html and 'draggable="true"' in html
+    assert "rockyou-dict" in html        # task name
+    assert "Dictionary" in html          # type label (mode 0, no rule)
+    assert "rockyou" in html             # wordlist name in the subtitle
 
 
 # ---------------------------------------------------- notifications wizard step


### PR DESCRIPTION
…ueue

Job-wizard "assign tasks" step:
- Add-Task dropdown now only offers a task once it's assigned if it uses a dynamic wordlist (route-computed assignable_tasks via dynamic_wordlist_ids; the old filter tested a non-existent task.wordlist_id field). Hardened jobs_assign_task / jobs_assign_task_group to allow a duplicate ONLY for an explicitly-dynamic wordlist (was "anything not 'static'", which let odd type casing through) — frontend and backend now share one rule.
- Task queue is rendered as bordered, rounded cards with spacing (index, grip, name, type·wordlist subtitle, remove), replacing the table.
- Drag-to-reorder with a FLIP slide animation (siblings glide out of the way to show the drop slot); removed the up/down arrows + jobs_move_task_up/down in a prior commit, reorder persists via jobs_reorder_tasks.