### PR TITLE
fix(api): create JobNotifications with real columns on /v1/jobs/add

### DIFF
--- a/hashview/api/routes.py
+++ b/hashview/api/routes.py
@@ -536,14 +536,32 @@ def v1_api_post_add_job():
                     db.session.add(job_task)
                     db.session.commit()      
 
-        # job notification
-        job_notification = JobNotifications(
-            job_id=job_entry.id,
-            notify_email=job_data.get('notify_email', False),
-            notify_pushover=job_data.get('notify_pushover', False)
-        )
-        db.session.add(job_notification)
-        db.session.commit()
+        # Job notifications: one row per (job, owner, channel), using the same
+        # method tokens as the web UI ('email'/'push'/'slack'), de-duped the
+        # same way. The old code passed notify_email/notify_pushover kwargs that
+        # don't exist on JobNotifications (its columns are owner_id, job_id,
+        # method) and omitted the required owner_id, so every jobs/add 500'd
+        # here after the job had already been committed. Any notification
+        # failure is now rolled back and logged so it can't undo a created job.
+        try:
+            notify_map = [
+                ('email', job_data.get('notify_email', False)),
+                ('push', job_data.get('notify_pushover', False)),
+                ('slack', job_data.get('notify_slack', False)),
+            ]
+            for method, requested in notify_map:
+                if requested:
+                    exists = JobNotifications.query.filter_by(
+                        job_id=job_entry.id, owner_id=user.id, method=method).first()
+                    if not exists:
+                        db.session.add(JobNotifications(
+                            owner_id=user.id, job_id=job_entry.id, method=method))
+            db.session.commit()
+        except Exception:
+            db.session.rollback()
+            current_app.logger.exception(
+                'API /v1/jobs: job %s created but notification setup failed',
+                job_entry.id)
 
         message = {
             'status': 200,

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,82 @@
+"""Conftest for unit tests.
+
+Overrides the parent (tests/) autouse fixtures ``ensure_setup`` and
+``configure_page``, which require Playwright + a live HTTP server. Unit tests
+here drive Flask's ``test_client`` against an in-memory SQLite app, so those
+e2e-specific fixtures must not run (and must not pull in ``live_server``,
+which ``pytest.skip(...)``s without ``HASHVIEW_E2E_BASE_URL``).
+
+The app is built by hand rather than via ``hashview.create_app`` because on
+this branch ``create_app()`` takes no arguments, hard-loads the MySQL
+``config.conf`` and starts the scheduler — none of which a unit test wants.
+We register only the blueprint under test on a throwaway Flask app bound to a
+single shared in-memory SQLite connection (``StaticPool``).
+
+When Flask isn't installed (e.g. an e2e-only CI venv that only has
+requirements-dev.txt) the ``collect_ignore_glob`` below skips the whole
+tests/unit/ tree at collection time instead of erroring on imports.
+"""
+
+import importlib.util
+
+import pytest
+
+
+if importlib.util.find_spec("flask") is None:
+    collect_ignore_glob = ["test_*.py"]
+
+
+@pytest.fixture(autouse=True)
+def ensure_setup():
+    """Override parent autouse so live_server isn't requested for unit tests."""
+    return
+
+
+@pytest.fixture(autouse=True)
+def configure_page():
+    """Override parent autouse so the Playwright `page` fixture isn't pulled."""
+    return
+
+
+def _build_api_app():
+    # Imported lazily so this module stays importable without Flask (paired
+    # with the ``collect_ignore_glob`` guard above).
+    from flask import Flask
+    from sqlalchemy.pool import StaticPool
+
+    from hashview.models import db
+    from hashview.api.routes import api
+
+    app = Flask(__name__)
+    app.config.update(
+        SQLALCHEMY_DATABASE_URI="sqlite://",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+        # A single shared connection so the in-memory DB survives across the
+        # multiple app contexts a test client request opens.
+        SQLALCHEMY_ENGINE_OPTIONS={
+            "connect_args": {"check_same_thread": False},
+            "poolclass": StaticPool,
+        },
+        SECRET_KEY="unit-test-secret",
+        TESTING=True,
+    )
+    db.init_app(app)
+    app.register_blueprint(api)
+    return app
+
+
+@pytest.fixture()
+def app():
+    from hashview.models import db
+
+    app = _build_api_app()
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()

--- a/tests/unit/test_api_jobs_add_notifications.py
+++ b/tests/unit/test_api_jobs_add_notifications.py
@@ -1,0 +1,115 @@
+"""Regression test for POST /v1/jobs/add notification creation.
+
+Bug: the route built ``JobNotifications(job_id=..., notify_email=...,
+notify_pushover=...)``, but that model only has the columns ``owner_id``,
+``job_id`` and ``method``. The bogus kwargs raised a TypeError which the
+route's ``except`` turned into an HTTP 500 "Failed to add job" — *after* the
+Jobs row had already been committed. So every job created through the API
+reported failure and never got its notifications recorded.
+
+The fix builds one ``JobNotifications`` row per requested channel using the
+real columns (``owner_id``/``method``). These tests assert the endpoint now
+returns 200 and that the expected notification rows exist.
+"""
+
+import json
+
+import pytest
+
+from hashview.models import (
+    db,
+    Customers,
+    HashfileHashes,
+    Hashes,
+    Hashfiles,
+    JobNotifications,
+    Jobs,
+    Tasks,
+    Users,
+)
+
+
+@pytest.fixture()
+def seeded(app):
+    """Seed the minimal object graph so /v1/jobs/add reaches the notification
+    block: an api-keyed user, a customer, a hashfile with one hash, and a
+    cracked hash attributed to a task (so the 'most effective tasks' query is
+    non-empty and the route doesn't bail out early)."""
+    with app.app_context():
+        user = Users(
+            first_name="Api",
+            last_name="User",
+            email_address="api@example.com",
+            password="x",
+            admin=True,
+            api_key="test-api-key",
+        )
+        customer = Customers(name="Acme")
+        db.session.add_all([user, customer])
+        db.session.commit()
+
+        task = Tasks(name="dict", hc_attackmode=0, owner_id=user.id)
+        db.session.add(task)
+        db.session.commit()
+
+        hashfile = Hashfiles(name="hf", customer_id=customer.id, owner_id=user.id)
+        db.session.add(hashfile)
+        db.session.commit()
+
+        cracked = Hashes(
+            sub_ciphertext="abc",
+            ciphertext="deadbeef",
+            hash_type=0,
+            cracked=True,
+            task_id=task.id,
+        )
+        db.session.add(cracked)
+        db.session.commit()
+        db.session.add(HashfileHashes(hash_id=cracked.id, hashfile_id=hashfile.id))
+        db.session.commit()
+
+        return {
+            "api_key": user.api_key,
+            "user_id": user.id,
+            "customer_id": customer.id,
+            "hashfile_id": hashfile.id,
+        }
+
+
+def _post_job(client, seeded, **extra):
+    client.set_cookie("uuid", seeded["api_key"])
+    payload = {
+        "name": "job1",
+        "hashfile_id": seeded["hashfile_id"],
+        "customer_id": seeded["customer_id"],
+    }
+    payload.update(extra)
+    return client.post(
+        "/v1/jobs/add",
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+
+
+def test_jobs_add_with_notifications_returns_200(client, seeded):
+    resp = _post_job(client, seeded, notify_email=True, notify_pushover=True)
+    body = resp.get_json()
+    assert body["status"] == 200, body
+    assert body["msg"] == "Job added"
+
+
+def test_jobs_add_records_requested_channels(client, seeded, app):
+    _post_job(client, seeded, notify_email=True, notify_pushover=True)
+    with app.app_context():
+        rows = JobNotifications.query.all()
+        assert {r.method for r in rows} == {"email", "push"}
+        assert all(r.owner_id == seeded["user_id"] for r in rows)
+
+
+def test_jobs_add_without_notifications_creates_none(client, seeded, app):
+    resp = _post_job(client, seeded)
+    assert resp.get_json()["status"] == 200
+    with app.app_context():
+        assert JobNotifications.query.count() == 0
+        # The job itself must still have been created.
+        assert Jobs.query.count() == 1


### PR DESCRIPTION
## Problem

`POST /v1/jobs/add` constructed `JobNotifications` with `notify_email` / `notify_pushover` kwargs, but that model only has the columns `owner_id`, `job_id`, and `method`. The invalid kwargs raised inside the route's `try/except`, returning HTTP 500 **"Failed to add job"** — *after* the `Jobs` row had already been committed.

Net effect: **every** job created through the API reported failure and recorded no notifications — even when no notification channels were requested, since the bad object was always constructed.

## Fix

Build one `JobNotifications` row per requested channel (`email`/`push`/`slack`) using the real `owner_id`/`method` columns, de-duped per channel, matching the web UI's method tokens. Notification setup is wrapped so a failure rolls back and logs rather than undoing an already-created job. This mirrors the implementation already live on `v0.8.3-dev`.

## Tests

Adds a unit-test harness for `tests/unit/` (a minimal Flask app around the `api` blueprint on in-memory SQLite, overriding the parent Playwright autouse fixtures so unit tests don't require a browser / live server), plus regression tests covering:

- the 200 response on job creation with notifications
- the recorded channels (`{email, push}` with correct `owner_id`)
- the no-notification path (job created, zero notification rows)

Developed test-first: verified all three fail against the original code (HTTP 500, zero rows) before applying the fix, then pass after.

No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)