### PR TITLE
feat(api): add GET /v1/hashfiles/hash_type/<hash_type>

### DIFF
--- a/hashview/api/routes.py
+++ b/hashview/api/routes.py
@@ -803,6 +803,64 @@ def v1_api_get_hashfile(hashfile_id):
 
     return send_from_directory('control/tmp/', random_hex)
 
+# List hashfiles that contain hashes of a given hash_type, with per-file
+# total/cracked counts scoped to that type. Lets API clients pick a hashfile
+# to build a job against without hardcoding an ID.
+@api.route('/v1/hashfiles/hash_type/<int:hash_type>', methods=['GET'])
+def v1_api_get_hashfiles_by_hash_type(hash_type):
+    if not is_authorized(user=True, agent=False, request=request):
+        return redirect("/v1/not_authorized")
+
+    uuid = request.cookies.get('uuid')
+    user = Users.query.filter_by(api_key=uuid).first()
+    if not user:
+        return jsonify({
+            'status': 403,
+            'type': 'Error',
+            'msg': 'User not found'
+        })
+
+    # hash_type lives on Hashes (per-hash), not on Hashfiles: a file can hold
+    # mixed types, so match via the HashfileHashes junction and scope the
+    # counts to THIS hash_type within each file.
+    matching_ids = [row[0] for row in
+                    db.session.query(HashfileHashes.hashfile_id)
+                    .join(Hashes, Hashes.id == HashfileHashes.hash_id)
+                    .filter(Hashes.hash_type == hash_type)
+                    .distinct().all()]
+
+    results = []
+    for hashfile_id in matching_ids:
+        hashfile = Hashfiles.query.get(hashfile_id)
+        if hashfile is None:
+            continue
+        base = db.session.query(Hashes.id) \
+            .join(HashfileHashes, HashfileHashes.hash_id == Hashes.id) \
+            .filter(HashfileHashes.hashfile_id == hashfile_id) \
+            .filter(Hashes.hash_type == hash_type)
+        total = base.count()
+        cracked = base.filter(Hashes.cracked == '1').count()
+        results.append({
+            'id': hashfile.id,
+            'name': hashfile.name,
+            'customer_id': hashfile.customer_id,
+            'owner_id': hashfile.owner_id,
+            'uploaded_at': hashfile.uploaded_at.isoformat() if hashfile.uploaded_at else None,
+            'hash_type': hash_type,
+            'total_hashes': total,
+            'cracked_hashes': cracked,
+        })
+
+    # Structured list (not AlchemyEncoder) because the count fields are
+    # derived, not model columns. An empty list with status 200 is the valid
+    # "no hashfiles of this type" answer.
+    message = {
+        'status': 200,
+        'type': 'message',
+        'hashfiles': results
+    }
+    return jsonify(message)
+
 # Upload Cracked Hashes
 # old and probably unused
 @api.route('/v1/uploadCrackFile/<int:task_id>/<int:hash_type>', methods=['POST'])

--- a/tests/unit/test_api_hashfiles_by_hash_type.py
+++ b/tests/unit/test_api_hashfiles_by_hash_type.py
@@ -1,0 +1,93 @@
+"""Tests for GET /v1/hashfiles/hash_type/<hash_type>.
+
+Backported from v0.8.3-dev. API clients use this endpoint to discover which
+hashfiles hold hashes of a given hash_type (with total/cracked counts) so they
+can pick one to build a job against instead of hardcoding an ID. main lacked
+the endpoint, so those clients 404'd and fell back to manual ID entry.
+"""
+
+import json
+
+import pytest
+
+from hashview.models import (
+    db,
+    Customers,
+    HashfileHashes,
+    Hashes,
+    Hashfiles,
+    Users,
+)
+
+
+@pytest.fixture()
+def seeded(app):
+    """Two hashfiles: one holds NTLM (type 1000) hashes (one cracked, one not),
+    the other holds only an md5 (type 0) hash. Lets us assert filtering and the
+    per-type total/cracked counts."""
+    with app.app_context():
+        user = Users(
+            first_name="Api",
+            last_name="User",
+            email_address="api@example.com",
+            password="x",
+            admin=True,
+            api_key="test-api-key",
+        )
+        customer = Customers(name="Acme")
+        db.session.add_all([user, customer])
+        db.session.commit()
+
+        ntlm_file = Hashfiles(name="ntlm", customer_id=customer.id, owner_id=user.id)
+        md5_file = Hashfiles(name="md5", customer_id=customer.id, owner_id=user.id)
+        db.session.add_all([ntlm_file, md5_file])
+        db.session.commit()
+
+        h1 = Hashes(sub_ciphertext="a", ciphertext="aa", hash_type=1000, cracked=True)
+        h2 = Hashes(sub_ciphertext="b", ciphertext="bb", hash_type=1000, cracked=False)
+        h3 = Hashes(sub_ciphertext="c", ciphertext="cc", hash_type=0, cracked=False)
+        db.session.add_all([h1, h2, h3])
+        db.session.commit()
+        db.session.add_all([
+            HashfileHashes(hash_id=h1.id, hashfile_id=ntlm_file.id),
+            HashfileHashes(hash_id=h2.id, hashfile_id=ntlm_file.id),
+            HashfileHashes(hash_id=h3.id, hashfile_id=md5_file.id),
+        ])
+        db.session.commit()
+
+        return {
+            "api_key": user.api_key,
+            "customer_id": customer.id,
+            "ntlm_file_id": ntlm_file.id,
+            "md5_file_id": md5_file.id,
+        }
+
+
+def test_lists_only_hashfiles_of_that_type_with_counts(client, seeded):
+    client.set_cookie("uuid", seeded["api_key"])
+    resp = client.get("/v1/hashfiles/hash_type/1000")
+    body = resp.get_json()
+    assert body["status"] == 200, body
+    files = body["hashfiles"]
+    assert len(files) == 1
+    entry = files[0]
+    assert entry["id"] == seeded["ntlm_file_id"]
+    assert entry["name"] == "ntlm"
+    assert entry["hash_type"] == 1000
+    assert entry["total_hashes"] == 2
+    assert entry["cracked_hashes"] == 1
+
+
+def test_returns_empty_list_for_type_with_no_hashfiles(client, seeded):
+    client.set_cookie("uuid", seeded["api_key"])
+    resp = client.get("/v1/hashfiles/hash_type/9999")
+    body = resp.get_json()
+    assert body["status"] == 200
+    assert body["hashfiles"] == []
+
+
+def test_requires_authorization(client):
+    # No auth cookie -> redirect to the not_authorized route.
+    resp = client.get("/v1/hashfiles/hash_type/1000")
+    assert resp.status_code in (301, 302)
+    assert "/v1/not_authorized" in resp.headers["Location"]


### PR DESCRIPTION
## Problem

API clients (e.g. the interactive job-creation helper) call `GET /v1/hashfiles/hash_type/<hash_type>` to discover which hashfiles hold hashes of a given type before building a job. `main` lacks this endpoint, so those clients 404 and fall back to *"look up the hashfile ID in the web UI and enter it below."*

The endpoint already exists on `v0.8.3-dev`; this backports it to `main`.

## Endpoint

`GET /v1/hashfiles/hash_type/<int:hash_type>` — user-authenticated. Returns the hashfiles containing at least one hash of `hash_type`, each with `total_hashes` / `cracked_hashes` counts **scoped to that type**:

```json
{"status": 200, "type": "message", "hashfiles": [
  {"id": 1, "name": "ntlm", "customer_id": 1, "owner_id": 1,
   "uploaded_at": "...", "hash_type": 1000,
   "total_hashes": 2, "cracked_hashes": 1}
]}
```

`hash_type` lives on `Hashes` (a file can hold mixed types), so matching goes through the `HashfileHashes` junction and counts are scoped per type. An empty list with `status: 200` is the valid "none of this type" answer.

## Tests

Regression tests (TDD — verified failing with 404 before the route existed, passing after):
- lists only hashfiles of the requested type, with correct total/cracked counts
- returns an empty list for a type with no hashfiles
- unauthenticated request redirects to `/v1/not_authorized`

Full `tests/unit/` suite: 6 passed. No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)