### PR TITLE
fix(api): make NTLM cracked-hash import actually work

### DIFF
--- a/hashview/api/routes.py
+++ b/hashview/api/routes.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, jsonify, redirect, request, send_from_directory, current_app, url_for
 from hashview.models import Agents, JobTasks, Tasks, Wordlists, Rules, Jobs, Hashes, Hashfiles, HashfileHashes, Users, HashNotifications, Settings, JobNotifications, Customers
-from hashview.utils.utils import get_md5_hash, get_linecount, get_filehash, update_dynamic_wordlist, update_job_task_status, import_hashfilehashes, validate_pwdump_hashfile, validate_netntlm_hashfile, validate_kerberos_hashfile, validate_shadow_hashfile, validate_user_hash_hashfile, validate_hash_only_hashfile, send_email, send_pushover, notify_admins, build_hashcat_command
+from hashview.utils.utils import get_md5_hash, get_linecount, get_filehash, update_dynamic_wordlist, update_job_task_status, import_hashfilehashes, validate_pwdump_hashfile, validate_netntlm_hashfile, validate_kerberos_hashfile, validate_shadow_hashfile, validate_user_hash_hashfile, validate_hash_only_hashfile, send_email, send_pushover, notify_admins, build_hashcat_command, ntlm_hash_hex
 from hashview.models import db
 from sqlalchemy.ext.declarative import DeclarativeMeta
 from sqlalchemy import func
@@ -1169,8 +1169,11 @@ def v1_api_hashes_import(hash_type):
     if not is_authorized(user=True, agent=False, request=request):
         return redirect("/vi/not_authorized")    
     
-    if hash_type == '1000':
-    
+    # The route converter yields an int; comparing to the string '1000' made
+    # this branch unreachable (every request fell through to 'Unsupported
+    # Hashtype'), so NTLM import silently did nothing. Compare as int.
+    if hash_type == 1000:
+
         # Expect raw plain‑text body (Content‑Type: text/plain)
         raw_content = request.get_data(as_text=True)
         if not raw_content:
@@ -1211,15 +1214,18 @@ def v1_api_hashes_import(hash_type):
         try:
             with open(file_path, 'r') as f:
                 for line in f:
-                    ciphertext = line.split(':')[0]
-                    plaintext = line.split(':')[1:]
+                    line = line.rstrip('\r\n')
+                    if not line:
+                        continue
+                    parts = line.split(':')
+                    ciphertext = parts[0]
+                    # everything after the first ':' is the plaintext (it may
+                    # itself contain ':')
+                    plaintext = ':'.join(parts[1:])
 
-                    # encipher plaintext and compare cipher text
-                    pw_bytes = plaintext.encode('utf-16le')
-                    md4_hasher = hashlib.new('md4', pw_bytes)
-                    digest = md4_hasher.digest()
-
-                    if ciphertext == binascii.hexlify(digest).decode('ascii').upper():
+                    # NTLM = MD4(UTF-16LE(pw)); ntlm_hash_hex falls back to a
+                    # pure-Python MD4 where OpenSSL 3.x drops md4 from hashlib.
+                    if ciphertext == ntlm_hash_hex(plaintext):
                         # valid hash:plaintext
                         record = Hashes.query.filter_by(hash_type=hash_type, sub_ciphertext=get_md5_hash(ciphertext), cracked='0').first()
                         if record:

--- a/hashview/utils/utils.py
+++ b/hashview/utils/utils.py
@@ -3,6 +3,8 @@ import os
 import secrets
 import hashlib
 import re
+import struct
+import binascii
 import _md5
 import requests
 from datetime import datetime
@@ -105,6 +107,70 @@ def get_md5_hash(string):
 
     m = _md5.md5(string.encode('utf-8'))
     return m.hexdigest()
+
+def _md4_pure(data):
+    """Pure-Python MD4 (RFC 1320). Returns the 16-byte digest.
+
+    Fallback for systems whose OpenSSL 3.x build ships MD4 only in the
+    (disabled-by-default) legacy provider, where hashlib.new('md4') raises
+    ValueError. Used to verify NTLM plaintexts one line at a time — not a
+    hot path, so pure Python is fine.
+    """
+    def lrot(x, n):
+        x &= 0xFFFFFFFF
+        return ((x << n) | (x >> (32 - n))) & 0xFFFFFFFF
+
+    msg = bytearray(data)
+    bit_len = (8 * len(msg)) & 0xFFFFFFFFFFFFFFFF
+    msg.append(0x80)
+    while len(msg) % 64 != 56:
+        msg.append(0)
+    msg += struct.pack('<Q', bit_len)
+
+    A, B, C, D = 0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476
+    for off in range(0, len(msg), 64):
+        X = struct.unpack('<16I', msg[off:off + 64])
+        a, b, c, d = A, B, C, D
+        # Round 1: F = (b & c) | (~b & d)
+        for i in (0, 4, 8, 12):
+            a = lrot(a + ((b & c) | (~b & d)) + X[i], 3)
+            d = lrot(d + ((a & b) | (~a & c)) + X[i + 1], 7)
+            c = lrot(c + ((d & a) | (~d & b)) + X[i + 2], 11)
+            b = lrot(b + ((c & d) | (~c & a)) + X[i + 3], 19)
+        # Round 2: G = majority(b, c, d), constant 0x5A827999
+        for i in (0, 1, 2, 3):
+            a = lrot(a + ((b & c) | (b & d) | (c & d)) + X[i] + 0x5A827999, 3)
+            d = lrot(d + ((a & b) | (a & c) | (b & c)) + X[i + 4] + 0x5A827999, 5)
+            c = lrot(c + ((d & a) | (d & b) | (a & b)) + X[i + 8] + 0x5A827999, 9)
+            b = lrot(b + ((c & d) | (c & a) | (d & a)) + X[i + 12] + 0x5A827999, 13)
+        # Round 3: H = b ^ c ^ d, constant 0x6ED9EBA1
+        for i in (0, 2, 1, 3):
+            a = lrot(a + (b ^ c ^ d) + X[i] + 0x6ED9EBA1, 3)
+            d = lrot(d + (a ^ b ^ c) + X[i + 8] + 0x6ED9EBA1, 9)
+            c = lrot(c + (d ^ a ^ b) + X[i + 4] + 0x6ED9EBA1, 11)
+            b = lrot(b + (c ^ d ^ a) + X[i + 12] + 0x6ED9EBA1, 15)
+        A = (A + a) & 0xFFFFFFFF
+        B = (B + b) & 0xFFFFFFFF
+        C = (C + c) & 0xFFFFFFFF
+        D = (D + d) & 0xFFFFFFFF
+
+    return struct.pack('<4I', A, B, C, D)
+
+def ntlm_hash_hex(plaintext):
+    """Uppercase hex NTLM hash (MD4 over UTF-16LE) of a plaintext string.
+
+    Tries hashlib first (fast, available when OpenSSL still provides md4);
+    falls back to the pure-Python MD4 above. surrogatepass mirrors the
+    surrogateescape file read in the import endpoint so undecodable bytes
+    round-trip.
+    """
+    pw_bytes = plaintext.encode('utf-16le', 'surrogatepass')
+    try:
+        # MD4 here IS the NTLM algorithm being verified, not a security control.
+        digest = hashlib.new('md4', pw_bytes).digest()  # nosec B324
+    except ValueError:
+        digest = _md4_pure(pw_bytes)
+    return binascii.hexlify(digest).decode('ascii').upper()
 
 def import_hash_only(line, hash_type):
     """Function to import single hash"""

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -18,12 +18,29 @@ tests/unit/ tree at collection time instead of erroring on imports.
 """
 
 import importlib.util
+from pathlib import Path
 
 import pytest
 
 
 if importlib.util.find_spec("flask") is None:
     collect_ignore_glob = ["test_*.py"]
+
+
+# The hashview package dir; used as the app root_path so current_app.root_path
+# (and thus control/tmp, control/wordlists, …) matches the real application.
+_HASHVIEW_DIR = Path(__file__).resolve().parents[2] / "hashview"
+
+
+@pytest.fixture(autouse=True, scope="session")
+def control_dirs():
+    """Create the runtime control dirs the Dockerfile/setup guarantee. They're
+    gitignored, so a fresh clone lacks them; some routes write real files there
+    (e.g. the cracked-hash import endpoint writes to control/tmp)."""
+    import os
+
+    for sub in ("rules", "wordlists", "tmp", "hashes"):
+        os.makedirs(_HASHVIEW_DIR / "control" / sub, exist_ok=True)
 
 
 @pytest.fixture(autouse=True)
@@ -47,7 +64,7 @@ def _build_api_app():
     from hashview.models import db
     from hashview.api.routes import api
 
-    app = Flask(__name__)
+    app = Flask(__name__, root_path=str(_HASHVIEW_DIR))
     app.config.update(
         SQLALCHEMY_DATABASE_URI="sqlite://",
         SQLALCHEMY_TRACK_MODIFICATIONS=False,

--- a/tests/unit/test_api_hashes_import_ntlm.py
+++ b/tests/unit/test_api_hashes_import_ntlm.py
@@ -1,0 +1,94 @@
+"""Tests for POST /v1/hashes/import/<hash_type> (NTLM cracked-hash import).
+
+Two bugs made NTLM import silently do nothing on main:
+
+1. The route compared the ``<int:hash_type>`` URL arg to the *string* '1000'
+   (``hash_type == '1000'``), which is always False, so every request fell
+   through to ``403 'Unsupported Hashtype'``. Clients that only look for a
+   response reported this as "Success: Unsupported Hashtype" and no hashes
+   were ever marked cracked.
+2. Even past that, the import loop treated the plaintext as a list
+   (``line.split(':')[1:]``) and hashed via ``hashlib.new('md4', ...)``,
+   which raises on OpenSSL 3.x builds without the legacy provider.
+
+These tests pin the NTLM hashing helper against a known vector (exercising
+the pure-Python MD4 fallback) and verify the endpoint actually marks a
+matching uncracked hash as cracked.
+"""
+
+import pytest
+
+from hashview.models import db, Hashes, Users
+from hashview.utils.utils import ntlm_hash_hex, get_md5_hash
+
+
+# NTLM("password") — canonical test vector.
+KNOWN_PLAINTEXT = "password"
+KNOWN_NTLM = "8846F7EAEE8FB117AD06BDD830B7586C"
+
+
+def test_ntlm_hash_hex_matches_known_vector():
+    assert ntlm_hash_hex(KNOWN_PLAINTEXT) == KNOWN_NTLM
+
+
+def test_ntlm_hash_hex_handles_unicode():
+    # UTF-16LE(MD4) of a non-ASCII password must not raise and must be stable.
+    digest = ntlm_hash_hex("pässwörd")
+    assert len(digest) == 32
+    assert digest == ntlm_hash_hex("pässwörd")
+
+
+@pytest.fixture()
+def seeded(app):
+    """One uncracked NTLM hash whose ciphertext is NTLM('password')."""
+    with app.app_context():
+        user = Users(
+            first_name="Api",
+            last_name="User",
+            email_address="api@example.com",
+            password="x",
+            admin=True,
+            api_key="test-api-key",
+        )
+        db.session.add(user)
+        db.session.commit()
+
+        h = Hashes(
+            sub_ciphertext=get_md5_hash(KNOWN_NTLM),
+            ciphertext=KNOWN_NTLM,
+            hash_type=1000,
+            cracked=False,
+        )
+        db.session.add(h)
+        db.session.commit()
+        return {"api_key": user.api_key, "hash_id": h.id, "user_id": user.id}
+
+
+def test_import_marks_hash_cracked(client, seeded, app):
+    client.set_cookie("uuid", seeded["api_key"])
+    resp = client.post(
+        "/v1/hashes/import/1000",
+        data=f"{KNOWN_NTLM}:{KNOWN_PLAINTEXT}\n",
+        content_type="text/plain",
+    )
+    body = resp.get_json()
+    assert body["status"] == 200, body
+    assert body["msg"] == "OK"
+    with app.app_context():
+        h = Hashes.query.get(seeded["hash_id"])
+        assert h.cracked
+        assert h.recovered_by == seeded["user_id"]
+        # main stores plaintext as latin-1 hex; decode to verify round-trip.
+        assert bytes.fromhex(h.plaintext).decode("latin-1") == KNOWN_PLAINTEXT
+
+
+def test_import_rejects_unsupported_hash_type(client, seeded):
+    client.set_cookie("uuid", seeded["api_key"])
+    resp = client.post(
+        "/v1/hashes/import/9999",
+        data="deadbeef:whatever\n",
+        content_type="text/plain",
+    )
+    body = resp.get_json()
+    assert body["status"] == 403
+    assert body["msg"] == "Unsupported Hashtype"


### PR DESCRIPTION
## Problem

Uploading cracked NTLM hashes via `POST /v1/hashes/import/<hash_type>` silently imported nothing — the client reported **"Success: Unsupported Hashtype"** and no hashes were marked cracked. Two bugs:

1. The `<int:hash_type>` URL arg was compared to the **string** `'1000'` (`hash_type == '1000'`), which is always `False`, so every request fell through to `403 'Unsupported Hashtype'`.
2. Even past that, the import loop treated the plaintext as a **list** (`line.split(':')[1:]`) and hashed via `hashlib.new('md4', ...)`, which raises on OpenSSL 3.x builds without the legacy provider.

## Fix

- Compare `hash_type` as an int (`== 1000`).
- Parse plaintext as the full remainder after the first `:` (handles passwords containing `:`), stripping the trailing newline.
- Verify via a new `ntlm_hash_hex()` helper (MD4 over UTF-16LE) that falls back to a **pure-Python MD4** when `hashlib` lacks md4.

Existing `latin-1` hex plaintext storage and the inline recovered-hash notification block are left unchanged, so this stays consistent with main's readers (main does **not** use dev's `$HEX[]`/utf-8 storage format).

This mirrors the fix already on `v0.8.3-dev`, scoped to a minimal, main-consistent change.

## Tests

Developed test-first (verified failing before the fix: `403 Unsupported Hashtype`, then `500` on the file bug, then green):
- `ntlm_hash_hex` matches the canonical `NTLM("password") = 8846F7EAEE8FB117AD06BDD830B7586C` — this exercises the pure-Python MD4 fallback, since `hashlib` md4 is unavailable in the test env
- unicode plaintext hashes without raising
- the endpoint marks a matching uncracked hash as cracked (correct `plaintext`/`recovered_by`)
- an unsupported hash type still returns `403`

Also hardens the `tests/unit/` harness: a session-scoped control-dirs fixture + points the test app's `root_path` at the `hashview` package so `current_app.root_path` (e.g. `control/tmp`) matches production. Full `tests/unit/` suite: 10 passed. No version bump.

## Note (out of scope)

Line ~1170 has a pre-existing typo — the unauthorized redirect targets `/vi/not_authorized` instead of `/v1/not_authorized`. Left as-is here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)