### PR TITLE
fix(api): redirect unauthorized callers to /v1/not_authorized

### DIFF
--- a/hashview/api/routes.py
+++ b/hashview/api/routes.py
@@ -1146,7 +1146,7 @@ def v1_api_search():
 @api.route('/v1/error', methods=['POST'])
 def v1_api_error():
     if not is_authorized(user=False, agent=True, request=request):
-        return redirect("/vi/not_authorized")
+        return redirect("/v1/not_authorized")
 
     uuid = request.cookies.get('uuid')
     agent = Agents.query.filter_by(uuid=uuid).first()
@@ -1167,7 +1167,7 @@ def v1_api_error():
 @api.route('/v1/hashes/import/<int:hash_type>', methods=['POST'])
 def v1_api_hashes_import(hash_type):
     if not is_authorized(user=True, agent=False, request=request):
-        return redirect("/vi/not_authorized")    
+        return redirect("/v1/not_authorized")    
     
     if hash_type == '1000':
     

--- a/tests/unit/test_api_not_authorized_redirect.py
+++ b/tests/unit/test_api_not_authorized_redirect.py
@@ -1,0 +1,23 @@
+"""Regression: unauthorized API requests must redirect to /v1/not_authorized.
+
+Two routes (/v1/error and /v1/hashes/import/<hash_type>) redirected to
+"/vi/not_authorized" — a typo. That path has no route, so an unauthorized
+caller got a 404 instead of the intended not-authorized response. Every
+other route in this blueprint uses the correct "/v1/not_authorized".
+"""
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "method, path",
+    [
+        ("post", "/v1/error"),
+        ("post", "/v1/hashes/import/1000"),
+    ],
+)
+def test_unauthorized_redirects_to_v1_not_authorized(client, method, path):
+    # No auth cookie -> is_authorized() is falsy -> redirect.
+    resp = getattr(client, method)(path)
+    assert resp.status_code in (301, 302)
+    assert resp.headers["Location"].endswith("/v1/not_authorized")


### PR DESCRIPTION
## Problem

Two API routes redirected unauthorized callers to `/vi/not_authorized` (typo — `vi` instead of `v1`):
- `POST /v1/error`
- `POST /v1/hashes/import/<hash_type>`

That path has no route, so an unauthorized caller received a `404` instead of the intended not-authorized response. Every other route in the blueprint uses the correct `/v1/not_authorized`.

Already correct on `v0.8.3-dev` (which has zero `/vi/` occurrences); this aligns `main`.

## Fix

Change both redirects to `/v1/not_authorized`.

## Tests

Regression test (verified failing first — both redirected to `/vi/`) asserting `POST /v1/error` and `POST /v1/hashes/import/1000` redirect to `/v1/not_authorized` when unauthenticated. Full `tests/unit/` suite: 8 passed. No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)