### PR TITLE
fix(api): compare NTLM hash case-insensitively on cracked-hash import

### DIFF
--- a/hashview/api/routes.py
+++ b/hashview/api/routes.py
@@ -1749,8 +1749,10 @@ def v1_api_hashes_import(hash_type):
 
                     # encipher plaintext and compare cipher text (NTLM = MD4(UTF-16LE(pw)));
                     # ntlm_hash_hex falls back to pure-Python MD4 where OpenSSL 3.x
-                    # no longer provides md4.
-                    if ciphertext == ntlm_hash_hex(plaintext):
+                    # no longer provides md4. Compare case-insensitively: hashcat
+                    # and Hashview store hashes in lowercase hex while
+                    # ntlm_hash_hex returns uppercase.
+                    if ciphertext.lower() == ntlm_hash_hex(plaintext).lower():
                         # valid hash:plaintext
                         record = Hashes.query.filter_by(hash_type=hash_type, sub_ciphertext=get_md5_hash(ciphertext), cracked='0').first()
                         if record:

--- a/tests/unit/test_api_endpoints.py
+++ b/tests/unit/test_api_endpoints.py
@@ -376,6 +376,43 @@ def test_hashes_import_ntlm_marks_hash_cracked(
 
 
 @pytest.mark.security
+def test_hashes_import_ntlm_lowercase_hash_marks_cracked(
+    client, app, admin_user, tmp_path, monkeypatch
+):
+    """Regression: a lowercase hash (as hashcat emits) must verify and import.
+
+    ntlm_hash_hex returns uppercase hex, so a case-sensitive compare rejected
+    every real hashcat upload with 'Plaintext ... was found to be invalid.'
+    Hashview stores/serves NTLM hashes in lowercase, so seed lowercase here.
+    """
+    from hashview.utils.utils import get_md5_hash
+
+    _import_dirs(app, tmp_path, monkeypatch)
+    lower_hash = NTLM_PASSWORD_HASH.lower()
+    record = Hashes(
+        sub_ciphertext=get_md5_hash(lower_hash),
+        ciphertext=lower_hash,
+        hash_type=1000,
+        cracked=False,
+    )
+    _db.session.add(record)
+    _db.session.commit()
+
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    resp = client.post(
+        "/v1/hashes/import/1000",
+        data=f"{lower_hash}:password",
+        content_type="text/plain",
+    )
+
+    body = _json_body(resp)
+    assert body["status"] == 200, body
+    assert body["msg"] == "OK"
+    assert record.cracked
+    assert record.recovered_by == admin_user.id
+
+
+@pytest.mark.security
 def test_hashes_import_invalid_plaintext_returns_500(
     client, app, admin_user, tmp_path, monkeypatch
 ):


### PR DESCRIPTION
## Problem

`POST /v1/hashes/import/<hash_type>` rejected every real hashcat upload with:

> Plaintext for hash `0f7cb0f91c29cbb71c533fd76f562f44`, was found to be invalid.

The endpoint validates each pair by comparing the uploaded ciphertext to `ntlm_hash_hex(plaintext)`. hashcat emits — and Hashview stores/serves — NTLM hashes in **lowercase** hex, but `ntlm_hash_hex` returns **uppercase**, so the case-sensitive `==` never matched. The existing test passed only because it seeded an **uppercase** hash, which doesn't reflect real hashcat output.

## Fix

Compare with `.lower()` on both sides.

## Why this is safe for case-sensitive hashes

- This route is **NTLM-only** (`if hash_type == 1000:`); all other types return `Unsupported Hashtype`.
- NTLM ciphertext is 32 hex chars — case is semantically meaningless in hex, so lowercasing both sides is the correct canonical comparison.
- The **plaintext is never lowercased** — it's hashed and stored verbatim, so case-sensitive passwords are preserved.

## Tests

Adds `test_hashes_import_ntlm_lowercase_hash_marks_cracked`, which seeds a lowercase hash (mirroring hashcat) and fails before the fix with the exact production error. Full unit suite: 1275 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)