### PR TITLE
fix(api): guard None hash in post-import notification sweep (500 on cracked-hash import)

### DIFF
--- a/hashview/api/routes.py
+++ b/hashview/api/routes.py
@@ -936,19 +936,20 @@ def v1_api_post_jobtask_crackfile_upload(job_task_id):
 
         # Check if hash is cracked
         hash = Hashes.query.get(hash_notification.hash_id)
-        if hash.cracked:
+        if hash:
+            if hash.cracked:
 
-            message += 'You can check the results using the following link: ' + "\n"
-            message += url_for('searches.searches_list', hash_id=hash.id, _external=True)
-            if hash_notification.method == 'email':
-                send_email(user, 'Hashview User Hash Recovered!', message)
-            elif hash_notification.method == 'push':
-                if user.pushover_user_key and user.pushover_app_id:
-                    send_pushover(user, 'Message from Hashview', message)
-            else:
-                send_email(user, 'Hashview: Missing Pushover Key', 'Hello, you were due to recieve a pushover notification, but because your account was not provisioned with an pushover ID and Key, one could not be set. Please log into hashview and set these options under Manage->Profile.')
-            db.session.delete(hash_notification)
-            db.session.commit()
+                message += 'You can check the results using the following link: ' + "\n"
+                message += url_for('searches.searches_list', hash_id=hash.id, _external=True)
+                if hash_notification.method == 'email':
+                    send_email(user, 'Hashview User Hash Recovered!', message)
+                elif hash_notification.method == 'push':
+                    if user.pushover_user_key and user.pushover_app_id:
+                        send_pushover(user, 'Message from Hashview', message)
+                else:
+                    send_email(user, 'Hashview: Missing Pushover Key', 'Hello, you were due to recieve a pushover notification, but because your account was not provisioned with an pushover ID and Key, one could not be set. Please log into hashview and set these options under Manage->Profile.')
+                db.session.delete(hash_notification)
+                db.session.commit()
 
     # Check if job type is one and done
     if job.limit_recovered and recovered_at_least_one_hash:

--- a/hashview/api/routes.py
+++ b/hashview/api/routes.py
@@ -1225,7 +1225,9 @@ def v1_api_hashes_import(hash_type):
 
                     # NTLM = MD4(UTF-16LE(pw)); ntlm_hash_hex falls back to a
                     # pure-Python MD4 where OpenSSL 3.x drops md4 from hashlib.
-                    if ciphertext == ntlm_hash_hex(plaintext):
+                    # Compare case-insensitively: hashcat/Hashview store hashes
+                    # in lowercase hex while ntlm_hash_hex returns uppercase.
+                    if ciphertext.lower() == ntlm_hash_hex(plaintext).lower():
                         # valid hash:plaintext
                         record = Hashes.query.filter_by(hash_type=hash_type, sub_ciphertext=get_md5_hash(ciphertext), cracked='0').first()
                         if record:

--- a/hashview/api/routes.py
+++ b/hashview/api/routes.py
@@ -803,6 +803,64 @@ def v1_api_get_hashfile(hashfile_id):
 
     return send_from_directory('control/tmp/', random_hex)
 
+# List hashfiles that contain hashes of a given hash_type, with per-file
+# total/cracked counts scoped to that type. Lets API clients pick a hashfile
+# to build a job against without hardcoding an ID.
+@api.route('/v1/hashfiles/hash_type/<int:hash_type>', methods=['GET'])
+def v1_api_get_hashfiles_by_hash_type(hash_type):
+    if not is_authorized(user=True, agent=False, request=request):
+        return redirect("/v1/not_authorized")
+
+    uuid = request.cookies.get('uuid')
+    user = Users.query.filter_by(api_key=uuid).first()
+    if not user:
+        return jsonify({
+            'status': 403,
+            'type': 'Error',
+            'msg': 'User not found'
+        })
+
+    # hash_type lives on Hashes (per-hash), not on Hashfiles: a file can hold
+    # mixed types, so match via the HashfileHashes junction and scope the
+    # counts to THIS hash_type within each file.
+    matching_ids = [row[0] for row in
+                    db.session.query(HashfileHashes.hashfile_id)
+                    .join(Hashes, Hashes.id == HashfileHashes.hash_id)
+                    .filter(Hashes.hash_type == hash_type)
+                    .distinct().all()]
+
+    results = []
+    for hashfile_id in matching_ids:
+        hashfile = Hashfiles.query.get(hashfile_id)
+        if hashfile is None:
+            continue
+        base = db.session.query(Hashes.id) \
+            .join(HashfileHashes, HashfileHashes.hash_id == Hashes.id) \
+            .filter(HashfileHashes.hashfile_id == hashfile_id) \
+            .filter(Hashes.hash_type == hash_type)
+        total = base.count()
+        cracked = base.filter(Hashes.cracked == '1').count()
+        results.append({
+            'id': hashfile.id,
+            'name': hashfile.name,
+            'customer_id': hashfile.customer_id,
+            'owner_id': hashfile.owner_id,
+            'uploaded_at': hashfile.uploaded_at.isoformat() if hashfile.uploaded_at else None,
+            'hash_type': hash_type,
+            'total_hashes': total,
+            'cracked_hashes': cracked,
+        })
+
+    # Structured list (not AlchemyEncoder) because the count fields are
+    # derived, not model columns. An empty list with status 200 is the valid
+    # "no hashfiles of this type" answer.
+    message = {
+        'status': 200,
+        'type': 'message',
+        'hashfiles': results
+    }
+    return jsonify(message)
+
 # Upload Cracked Hashes
 # old and probably unused
 @api.route('/v1/uploadCrackFile/<int:task_id>/<int:hash_type>', methods=['POST'])

--- a/hashview/api/routes.py
+++ b/hashview/api/routes.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, jsonify, redirect, request, send_from_directory, current_app, url_for
 from hashview.models import Agents, JobTasks, Tasks, Wordlists, Rules, Jobs, Hashes, Hashfiles, HashfileHashes, Users, HashNotifications, Settings, JobNotifications, Customers
-from hashview.utils.utils import get_md5_hash, get_linecount, get_filehash, update_dynamic_wordlist, update_job_task_status, import_hashfilehashes, validate_pwdump_hashfile, validate_netntlm_hashfile, validate_kerberos_hashfile, validate_shadow_hashfile, validate_user_hash_hashfile, validate_hash_only_hashfile, send_email, send_pushover, notify_admins, build_hashcat_command
+from hashview.utils.utils import get_md5_hash, get_linecount, get_filehash, update_dynamic_wordlist, update_job_task_status, import_hashfilehashes, validate_pwdump_hashfile, validate_netntlm_hashfile, validate_kerberos_hashfile, validate_shadow_hashfile, validate_user_hash_hashfile, validate_hash_only_hashfile, send_email, send_pushover, notify_admins, build_hashcat_command, ntlm_hash_hex
 from hashview.models import db
 from sqlalchemy.ext.declarative import DeclarativeMeta
 from sqlalchemy import func
@@ -1169,8 +1169,11 @@ def v1_api_hashes_import(hash_type):
     if not is_authorized(user=True, agent=False, request=request):
         return redirect("/vi/not_authorized")    
     
-    if hash_type == '1000':
-    
+    # The route converter yields an int; comparing to the string '1000' made
+    # this branch unreachable (every request fell through to 'Unsupported
+    # Hashtype'), so NTLM import silently did nothing. Compare as int.
+    if hash_type == 1000:
+
         # Expect raw plain‑text body (Content‑Type: text/plain)
         raw_content = request.get_data(as_text=True)
         if not raw_content:
@@ -1211,15 +1214,18 @@ def v1_api_hashes_import(hash_type):
         try:
             with open(file_path, 'r') as f:
                 for line in f:
-                    ciphertext = line.split(':')[0]
-                    plaintext = line.split(':')[1:]
+                    line = line.rstrip('\r\n')
+                    if not line:
+                        continue
+                    parts = line.split(':')
+                    ciphertext = parts[0]
+                    # everything after the first ':' is the plaintext (it may
+                    # itself contain ':')
+                    plaintext = ':'.join(parts[1:])
 
-                    # encipher plaintext and compare cipher text
-                    pw_bytes = plaintext.encode('utf-16le')
-                    md4_hasher = hashlib.new('md4', pw_bytes)
-                    digest = md4_hasher.digest()
-
-                    if ciphertext == binascii.hexlify(digest).decode('ascii').upper():
+                    # NTLM = MD4(UTF-16LE(pw)); ntlm_hash_hex falls back to a
+                    # pure-Python MD4 where OpenSSL 3.x drops md4 from hashlib.
+                    if ciphertext == ntlm_hash_hex(plaintext):
                         # valid hash:plaintext
                         record = Hashes.query.filter_by(hash_type=hash_type, sub_ciphertext=get_md5_hash(ciphertext), cracked='0').first()
                         if record:

--- a/hashview/api/routes.py
+++ b/hashview/api/routes.py
@@ -1146,7 +1146,7 @@ def v1_api_search():
 @api.route('/v1/error', methods=['POST'])
 def v1_api_error():
     if not is_authorized(user=False, agent=True, request=request):
-        return redirect("/vi/not_authorized")
+        return redirect("/v1/not_authorized")
 
     uuid = request.cookies.get('uuid')
     agent = Agents.query.filter_by(uuid=uuid).first()
@@ -1167,7 +1167,7 @@ def v1_api_error():
 @api.route('/v1/hashes/import/<int:hash_type>', methods=['POST'])
 def v1_api_hashes_import(hash_type):
     if not is_authorized(user=True, agent=False, request=request):
-        return redirect("/vi/not_authorized")    
+        return redirect("/v1/not_authorized")    
     
     if hash_type == '1000':
     

--- a/hashview/api/routes.py
+++ b/hashview/api/routes.py
@@ -536,14 +536,32 @@ def v1_api_post_add_job():
                     db.session.add(job_task)
                     db.session.commit()      
 
-        # job notification
-        job_notification = JobNotifications(
-            job_id=job_entry.id,
-            notify_email=job_data.get('notify_email', False),
-            notify_pushover=job_data.get('notify_pushover', False)
-        )
-        db.session.add(job_notification)
-        db.session.commit()
+        # Job notifications: one row per (job, owner, channel), using the same
+        # method tokens as the web UI ('email'/'push'/'slack'), de-duped the
+        # same way. The old code passed notify_email/notify_pushover kwargs that
+        # don't exist on JobNotifications (its columns are owner_id, job_id,
+        # method) and omitted the required owner_id, so every jobs/add 500'd
+        # here after the job had already been committed. Any notification
+        # failure is now rolled back and logged so it can't undo a created job.
+        try:
+            notify_map = [
+                ('email', job_data.get('notify_email', False)),
+                ('push', job_data.get('notify_pushover', False)),
+                ('slack', job_data.get('notify_slack', False)),
+            ]
+            for method, requested in notify_map:
+                if requested:
+                    exists = JobNotifications.query.filter_by(
+                        job_id=job_entry.id, owner_id=user.id, method=method).first()
+                    if not exists:
+                        db.session.add(JobNotifications(
+                            owner_id=user.id, job_id=job_entry.id, method=method))
+            db.session.commit()
+        except Exception:
+            db.session.rollback()
+            current_app.logger.exception(
+                'API /v1/jobs: job %s created but notification setup failed',
+                job_entry.id)
 
         message = {
             'status': 200,

--- a/hashview/api/routes.py
+++ b/hashview/api/routes.py
@@ -912,7 +912,7 @@ def v1_api_put_jobtask_crackfile_upload(task_id, hash_type):
 
         # Check if hash is cracked
         hash = Hashes.query.get(hash_notification.hash_id)
-        if hash.cracked:
+        if hash and hash.cracked:
 
             message += 'You can check the results using the following link: ' + "\n"
             message += url_for('searches.searches_list', hash_id=hash.id, _external=True)
@@ -1265,7 +1265,7 @@ def v1_api_hashes_import(hash_type):
 
             # Check if hash is cracked
             hash = Hashes.query.get(hash_notification.hash_id)
-            if hash.cracked:
+            if hash and hash.cracked:
 
                 message += 'You can check the results using the following link: ' + "\n"
                 message += url_for('searches.searches_list', hash_id=hash.id, _external=True)

--- a/hashview/searches/routes.py
+++ b/hashview/searches/routes.py
@@ -54,10 +54,9 @@ def searches_list():
             flash('No results found.', 'warning')
     else:
         customers = None
-        results = None
 
     if hashfile_results and "export" in request.form: #Export Results
-        return export_results(customers, results, hashfiles, searchForm.export_type.data)
+        return export_results(customers, hashfile_results, hashfiles, searchForm.export_type.data)
 
     return render_template('search.html.j2', title='Search', searchForm=searchForm, customers=customers, hash_results=hash_results, hashfile_results=hashfile_results, hashfiles=hashfiles, redacted_data=redacted_data)
 
@@ -66,11 +65,11 @@ def export_results(customers, results, hashfiles, separator):
     """Function to export search results"""
     str_io = io.StringIO()
     separator = (',' if separator == "Comma" else ":")
-    get_rows(strIO, customers, results, hashfiles, separator)
+    get_rows(str_io, customers, results, hashfiles, separator)
     byteIO = io.BytesIO()
-    byteIO.write(strIO.getvalue().encode())
+    byteIO.write(str_io.getvalue().encode())
     byteIO.seek(0)
-    strIO.close()
+    str_io.close()
     return send_file(byteIO, download_name="search.txt", as_attachment=True)
 
 #If this logic changes on in the html (search.html) it will need to change here as well
@@ -99,4 +98,4 @@ def get_rows(str_io, customers, results, hashfiles, separator):
             col.append("unrecovered")
 
         writer.writerow([col[0],col[1],col[2],col[3]])
-    return strIO
+    return str_io

--- a/hashview/utils/utils.py
+++ b/hashview/utils/utils.py
@@ -3,6 +3,8 @@ import os
 import secrets
 import hashlib
 import re
+import struct
+import binascii
 import _md5
 import requests
 from datetime import datetime
@@ -105,6 +107,70 @@ def get_md5_hash(string):
 
     m = _md5.md5(string.encode('utf-8'))
     return m.hexdigest()
+
+def _md4_pure(data):
+    """Pure-Python MD4 (RFC 1320). Returns the 16-byte digest.
+
+    Fallback for systems whose OpenSSL 3.x build ships MD4 only in the
+    (disabled-by-default) legacy provider, where hashlib.new('md4') raises
+    ValueError. Used to verify NTLM plaintexts one line at a time — not a
+    hot path, so pure Python is fine.
+    """
+    def lrot(x, n):
+        x &= 0xFFFFFFFF
+        return ((x << n) | (x >> (32 - n))) & 0xFFFFFFFF
+
+    msg = bytearray(data)
+    bit_len = (8 * len(msg)) & 0xFFFFFFFFFFFFFFFF
+    msg.append(0x80)
+    while len(msg) % 64 != 56:
+        msg.append(0)
+    msg += struct.pack('<Q', bit_len)
+
+    A, B, C, D = 0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476
+    for off in range(0, len(msg), 64):
+        X = struct.unpack('<16I', msg[off:off + 64])
+        a, b, c, d = A, B, C, D
+        # Round 1: F = (b & c) | (~b & d)
+        for i in (0, 4, 8, 12):
+            a = lrot(a + ((b & c) | (~b & d)) + X[i], 3)
+            d = lrot(d + ((a & b) | (~a & c)) + X[i + 1], 7)
+            c = lrot(c + ((d & a) | (~d & b)) + X[i + 2], 11)
+            b = lrot(b + ((c & d) | (~c & a)) + X[i + 3], 19)
+        # Round 2: G = majority(b, c, d), constant 0x5A827999
+        for i in (0, 1, 2, 3):
+            a = lrot(a + ((b & c) | (b & d) | (c & d)) + X[i] + 0x5A827999, 3)
+            d = lrot(d + ((a & b) | (a & c) | (b & c)) + X[i + 4] + 0x5A827999, 5)
+            c = lrot(c + ((d & a) | (d & b) | (a & b)) + X[i + 8] + 0x5A827999, 9)
+            b = lrot(b + ((c & d) | (c & a) | (d & a)) + X[i + 12] + 0x5A827999, 13)
+        # Round 3: H = b ^ c ^ d, constant 0x6ED9EBA1
+        for i in (0, 2, 1, 3):
+            a = lrot(a + (b ^ c ^ d) + X[i] + 0x6ED9EBA1, 3)
+            d = lrot(d + (a ^ b ^ c) + X[i + 8] + 0x6ED9EBA1, 9)
+            c = lrot(c + (d ^ a ^ b) + X[i + 4] + 0x6ED9EBA1, 11)
+            b = lrot(b + (c ^ d ^ a) + X[i + 12] + 0x6ED9EBA1, 15)
+        A = (A + a) & 0xFFFFFFFF
+        B = (B + b) & 0xFFFFFFFF
+        C = (C + c) & 0xFFFFFFFF
+        D = (D + d) & 0xFFFFFFFF
+
+    return struct.pack('<4I', A, B, C, D)
+
+def ntlm_hash_hex(plaintext):
+    """Uppercase hex NTLM hash (MD4 over UTF-16LE) of a plaintext string.
+
+    Tries hashlib first (fast, available when OpenSSL still provides md4);
+    falls back to the pure-Python MD4 above. surrogatepass mirrors the
+    surrogateescape file read in the import endpoint so undecodable bytes
+    round-trip.
+    """
+    pw_bytes = plaintext.encode('utf-16le', 'surrogatepass')
+    try:
+        # MD4 here IS the NTLM algorithm being verified, not a security control.
+        digest = hashlib.new('md4', pw_bytes).digest()  # nosec B324
+    except ValueError:
+        digest = _md4_pure(pw_bytes)
+    return binascii.hexlify(digest).decode('ascii').upper()
 
 def import_hash_only(line, hash_type):
     """Function to import single hash"""

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-pytest==9.0.2
+pytest==9.0.3
 pytest-playwright==0.7.2
 pytest-base-url==2.1.0
 playwright==1.58.0

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,82 @@
+"""Conftest for unit tests.
+
+Overrides the parent (tests/) autouse fixtures ``ensure_setup`` and
+``configure_page``, which require Playwright + a live HTTP server. Unit tests
+here drive Flask's ``test_client`` against an in-memory SQLite app, so those
+e2e-specific fixtures must not run (and must not pull in ``live_server``,
+which ``pytest.skip(...)``s without ``HASHVIEW_E2E_BASE_URL``).
+
+The app is built by hand rather than via ``hashview.create_app`` because on
+this branch ``create_app()`` takes no arguments, hard-loads the MySQL
+``config.conf`` and starts the scheduler — none of which a unit test wants.
+We register only the blueprint under test on a throwaway Flask app bound to a
+single shared in-memory SQLite connection (``StaticPool``).
+
+When Flask isn't installed (e.g. an e2e-only CI venv that only has
+requirements-dev.txt) the ``collect_ignore_glob`` below skips the whole
+tests/unit/ tree at collection time instead of erroring on imports.
+"""
+
+import importlib.util
+
+import pytest
+
+
+if importlib.util.find_spec("flask") is None:
+    collect_ignore_glob = ["test_*.py"]
+
+
+@pytest.fixture(autouse=True)
+def ensure_setup():
+    """Override parent autouse so live_server isn't requested for unit tests."""
+    return
+
+
+@pytest.fixture(autouse=True)
+def configure_page():
+    """Override parent autouse so the Playwright `page` fixture isn't pulled."""
+    return
+
+
+def _build_api_app():
+    # Imported lazily so this module stays importable without Flask (paired
+    # with the ``collect_ignore_glob`` guard above).
+    from flask import Flask
+    from sqlalchemy.pool import StaticPool
+
+    from hashview.models import db
+    from hashview.api.routes import api
+
+    app = Flask(__name__)
+    app.config.update(
+        SQLALCHEMY_DATABASE_URI="sqlite://",
+        SQLALCHEMY_TRACK_MODIFICATIONS=False,
+        # A single shared connection so the in-memory DB survives across the
+        # multiple app contexts a test client request opens.
+        SQLALCHEMY_ENGINE_OPTIONS={
+            "connect_args": {"check_same_thread": False},
+            "poolclass": StaticPool,
+        },
+        SECRET_KEY="unit-test-secret",
+        TESTING=True,
+    )
+    db.init_app(app)
+    app.register_blueprint(api)
+    return app
+
+
+@pytest.fixture()
+def app():
+    from hashview.models import db
+
+    app = _build_api_app()
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -18,12 +18,29 @@ tests/unit/ tree at collection time instead of erroring on imports.
 """
 
 import importlib.util
+from pathlib import Path
 
 import pytest
 
 
 if importlib.util.find_spec("flask") is None:
     collect_ignore_glob = ["test_*.py"]
+
+
+# The hashview package dir; used as the app root_path so current_app.root_path
+# (and thus control/tmp, control/wordlists, …) matches the real application.
+_HASHVIEW_DIR = Path(__file__).resolve().parents[2] / "hashview"
+
+
+@pytest.fixture(autouse=True, scope="session")
+def control_dirs():
+    """Create the runtime control dirs the Dockerfile/setup guarantee. They're
+    gitignored, so a fresh clone lacks them; some routes write real files there
+    (e.g. the cracked-hash import endpoint writes to control/tmp)."""
+    import os
+
+    for sub in ("rules", "wordlists", "tmp", "hashes"):
+        os.makedirs(_HASHVIEW_DIR / "control" / sub, exist_ok=True)
 
 
 @pytest.fixture(autouse=True)
@@ -47,7 +64,7 @@ def _build_api_app():
     from hashview.models import db
     from hashview.api.routes import api
 
-    app = Flask(__name__)
+    app = Flask(__name__, root_path=str(_HASHVIEW_DIR))
     app.config.update(
         SQLALCHEMY_DATABASE_URI="sqlite://",
         SQLALCHEMY_TRACK_MODIFICATIONS=False,

--- a/tests/unit/test_api_hashes_import_ntlm.py
+++ b/tests/unit/test_api_hashes_import_ntlm.py
@@ -25,6 +25,10 @@ from hashview.utils.utils import ntlm_hash_hex, get_md5_hash
 # NTLM("password") — canonical test vector.
 KNOWN_PLAINTEXT = "password"
 KNOWN_NTLM = "8846F7EAEE8FB117AD06BDD830B7586C"
+# hashcat emits NTLM hashes in lowercase hex; Hashview stores/serves them the
+# same way. The import compare must be case-insensitive against ntlm_hash_hex,
+# which returns uppercase.
+KNOWN_NTLM_LOWER = KNOWN_NTLM.lower()
 
 
 def test_ntlm_hash_hex_matches_known_vector():
@@ -80,6 +84,53 @@ def test_import_marks_hash_cracked(client, seeded, app):
         assert h.recovered_by == seeded["user_id"]
         # main stores plaintext as latin-1 hex; decode to verify round-trip.
         assert bytes.fromhex(h.plaintext).decode("latin-1") == KNOWN_PLAINTEXT
+
+
+@pytest.fixture()
+def seeded_lowercase(app):
+    """One uncracked NTLM hash stored in lowercase hex, as hashcat/Hashview do."""
+    with app.app_context():
+        user = Users(
+            first_name="Api",
+            last_name="User",
+            email_address="lower@example.com",
+            password="x",
+            admin=True,
+            api_key="test-api-key-lower",
+        )
+        db.session.add(user)
+        db.session.commit()
+
+        h = Hashes(
+            sub_ciphertext=get_md5_hash(KNOWN_NTLM_LOWER),
+            ciphertext=KNOWN_NTLM_LOWER,
+            hash_type=1000,
+            cracked=False,
+        )
+        db.session.add(h)
+        db.session.commit()
+        return {"api_key": user.api_key, "hash_id": h.id, "user_id": user.id}
+
+
+def test_import_marks_hash_cracked_lowercase_hash(client, seeded_lowercase, app):
+    """Regression: a lowercase hash (as hashcat emits) must verify and import.
+
+    ntlm_hash_hex returns uppercase hex, so a case-sensitive compare rejected
+    every real hashcat upload with 'Plaintext ... was found to be invalid.'
+    """
+    client.set_cookie("uuid", seeded_lowercase["api_key"])
+    resp = client.post(
+        "/v1/hashes/import/1000",
+        data=f"{KNOWN_NTLM_LOWER}:{KNOWN_PLAINTEXT}\n",
+        content_type="text/plain",
+    )
+    body = resp.get_json()
+    assert body["status"] == 200, body
+    assert body["msg"] == "OK"
+    with app.app_context():
+        h = Hashes.query.get(seeded_lowercase["hash_id"])
+        assert h.cracked
+        assert h.recovered_by == seeded_lowercase["user_id"]
 
 
 def test_import_rejects_unsupported_hash_type(client, seeded):

--- a/tests/unit/test_api_hashes_import_ntlm.py
+++ b/tests/unit/test_api_hashes_import_ntlm.py
@@ -1,0 +1,94 @@
+"""Tests for POST /v1/hashes/import/<hash_type> (NTLM cracked-hash import).
+
+Two bugs made NTLM import silently do nothing on main:
+
+1. The route compared the ``<int:hash_type>`` URL arg to the *string* '1000'
+   (``hash_type == '1000'``), which is always False, so every request fell
+   through to ``403 'Unsupported Hashtype'``. Clients that only look for a
+   response reported this as "Success: Unsupported Hashtype" and no hashes
+   were ever marked cracked.
+2. Even past that, the import loop treated the plaintext as a list
+   (``line.split(':')[1:]``) and hashed via ``hashlib.new('md4', ...)``,
+   which raises on OpenSSL 3.x builds without the legacy provider.
+
+These tests pin the NTLM hashing helper against a known vector (exercising
+the pure-Python MD4 fallback) and verify the endpoint actually marks a
+matching uncracked hash as cracked.
+"""
+
+import pytest
+
+from hashview.models import db, Hashes, Users
+from hashview.utils.utils import ntlm_hash_hex, get_md5_hash
+
+
+# NTLM("password") — canonical test vector.
+KNOWN_PLAINTEXT = "password"
+KNOWN_NTLM = "8846F7EAEE8FB117AD06BDD830B7586C"
+
+
+def test_ntlm_hash_hex_matches_known_vector():
+    assert ntlm_hash_hex(KNOWN_PLAINTEXT) == KNOWN_NTLM
+
+
+def test_ntlm_hash_hex_handles_unicode():
+    # UTF-16LE(MD4) of a non-ASCII password must not raise and must be stable.
+    digest = ntlm_hash_hex("pässwörd")
+    assert len(digest) == 32
+    assert digest == ntlm_hash_hex("pässwörd")
+
+
+@pytest.fixture()
+def seeded(app):
+    """One uncracked NTLM hash whose ciphertext is NTLM('password')."""
+    with app.app_context():
+        user = Users(
+            first_name="Api",
+            last_name="User",
+            email_address="api@example.com",
+            password="x",
+            admin=True,
+            api_key="test-api-key",
+        )
+        db.session.add(user)
+        db.session.commit()
+
+        h = Hashes(
+            sub_ciphertext=get_md5_hash(KNOWN_NTLM),
+            ciphertext=KNOWN_NTLM,
+            hash_type=1000,
+            cracked=False,
+        )
+        db.session.add(h)
+        db.session.commit()
+        return {"api_key": user.api_key, "hash_id": h.id, "user_id": user.id}
+
+
+def test_import_marks_hash_cracked(client, seeded, app):
+    client.set_cookie("uuid", seeded["api_key"])
+    resp = client.post(
+        "/v1/hashes/import/1000",
+        data=f"{KNOWN_NTLM}:{KNOWN_PLAINTEXT}\n",
+        content_type="text/plain",
+    )
+    body = resp.get_json()
+    assert body["status"] == 200, body
+    assert body["msg"] == "OK"
+    with app.app_context():
+        h = Hashes.query.get(seeded["hash_id"])
+        assert h.cracked
+        assert h.recovered_by == seeded["user_id"]
+        # main stores plaintext as latin-1 hex; decode to verify round-trip.
+        assert bytes.fromhex(h.plaintext).decode("latin-1") == KNOWN_PLAINTEXT
+
+
+def test_import_rejects_unsupported_hash_type(client, seeded):
+    client.set_cookie("uuid", seeded["api_key"])
+    resp = client.post(
+        "/v1/hashes/import/9999",
+        data="deadbeef:whatever\n",
+        content_type="text/plain",
+    )
+    body = resp.get_json()
+    assert body["status"] == 403
+    assert body["msg"] == "Unsupported Hashtype"

--- a/tests/unit/test_api_hashes_import_ntlm.py
+++ b/tests/unit/test_api_hashes_import_ntlm.py
@@ -18,7 +18,7 @@ matching uncracked hash as cracked.
 
 import pytest
 
-from hashview.models import db, Hashes, Users
+from hashview.models import db, Hashes, Users, HashNotifications
 from hashview.utils.utils import ntlm_hash_hex, get_md5_hash
 
 
@@ -131,6 +131,41 @@ def test_import_marks_hash_cracked_lowercase_hash(client, seeded_lowercase, app)
         h = Hashes.query.get(seeded_lowercase["hash_id"])
         assert h.cracked
         assert h.recovered_by == seeded_lowercase["user_id"]
+
+
+def test_import_survives_orphaned_hash_notification(client, seeded, app):
+    """Regression: an orphaned HashNotifications row must not 500 the import.
+
+    The post-import "Send Hash Completion Notifications" sweep did
+    ``hash = Hashes.query.get(hash_notification.hash_id)`` then ``if hash.cracked:``
+    with no None-check. A notification pointing at a hash_id that no longer
+    resolves made ``.get()`` return None, so ``if hash.cracked:`` raised
+    ``AttributeError: 'NoneType' object has no attribute 'cracked'`` -> HTTP 500,
+    regardless of what the client submitted.
+    """
+    with app.app_context():
+        db.session.add(
+            HashNotifications(
+                owner_id=seeded["user_id"],
+                hash_id=999999,  # no such hash
+                method="email",
+            )
+        )
+        db.session.commit()
+
+    client.set_cookie("uuid", seeded["api_key"])
+    resp = client.post(
+        "/v1/hashes/import/1000",
+        data=f"{KNOWN_NTLM}:{KNOWN_PLAINTEXT}\n",
+        content_type="text/plain",
+    )
+    body = resp.get_json()
+    assert body["status"] == 200, body
+    assert body["msg"] == "OK"
+    with app.app_context():
+        # The legitimate hash still gets marked cracked; the orphaned
+        # notification is simply skipped instead of crashing the request.
+        assert Hashes.query.get(seeded["hash_id"]).cracked
 
 
 def test_import_rejects_unsupported_hash_type(client, seeded):

--- a/tests/unit/test_api_hashfiles_by_hash_type.py
+++ b/tests/unit/test_api_hashfiles_by_hash_type.py
@@ -1,0 +1,93 @@
+"""Tests for GET /v1/hashfiles/hash_type/<hash_type>.
+
+Backported from v0.8.3-dev. API clients use this endpoint to discover which
+hashfiles hold hashes of a given hash_type (with total/cracked counts) so they
+can pick one to build a job against instead of hardcoding an ID. main lacked
+the endpoint, so those clients 404'd and fell back to manual ID entry.
+"""
+
+import json
+
+import pytest
+
+from hashview.models import (
+    db,
+    Customers,
+    HashfileHashes,
+    Hashes,
+    Hashfiles,
+    Users,
+)
+
+
+@pytest.fixture()
+def seeded(app):
+    """Two hashfiles: one holds NTLM (type 1000) hashes (one cracked, one not),
+    the other holds only an md5 (type 0) hash. Lets us assert filtering and the
+    per-type total/cracked counts."""
+    with app.app_context():
+        user = Users(
+            first_name="Api",
+            last_name="User",
+            email_address="api@example.com",
+            password="x",
+            admin=True,
+            api_key="test-api-key",
+        )
+        customer = Customers(name="Acme")
+        db.session.add_all([user, customer])
+        db.session.commit()
+
+        ntlm_file = Hashfiles(name="ntlm", customer_id=customer.id, owner_id=user.id)
+        md5_file = Hashfiles(name="md5", customer_id=customer.id, owner_id=user.id)
+        db.session.add_all([ntlm_file, md5_file])
+        db.session.commit()
+
+        h1 = Hashes(sub_ciphertext="a", ciphertext="aa", hash_type=1000, cracked=True)
+        h2 = Hashes(sub_ciphertext="b", ciphertext="bb", hash_type=1000, cracked=False)
+        h3 = Hashes(sub_ciphertext="c", ciphertext="cc", hash_type=0, cracked=False)
+        db.session.add_all([h1, h2, h3])
+        db.session.commit()
+        db.session.add_all([
+            HashfileHashes(hash_id=h1.id, hashfile_id=ntlm_file.id),
+            HashfileHashes(hash_id=h2.id, hashfile_id=ntlm_file.id),
+            HashfileHashes(hash_id=h3.id, hashfile_id=md5_file.id),
+        ])
+        db.session.commit()
+
+        return {
+            "api_key": user.api_key,
+            "customer_id": customer.id,
+            "ntlm_file_id": ntlm_file.id,
+            "md5_file_id": md5_file.id,
+        }
+
+
+def test_lists_only_hashfiles_of_that_type_with_counts(client, seeded):
+    client.set_cookie("uuid", seeded["api_key"])
+    resp = client.get("/v1/hashfiles/hash_type/1000")
+    body = resp.get_json()
+    assert body["status"] == 200, body
+    files = body["hashfiles"]
+    assert len(files) == 1
+    entry = files[0]
+    assert entry["id"] == seeded["ntlm_file_id"]
+    assert entry["name"] == "ntlm"
+    assert entry["hash_type"] == 1000
+    assert entry["total_hashes"] == 2
+    assert entry["cracked_hashes"] == 1
+
+
+def test_returns_empty_list_for_type_with_no_hashfiles(client, seeded):
+    client.set_cookie("uuid", seeded["api_key"])
+    resp = client.get("/v1/hashfiles/hash_type/9999")
+    body = resp.get_json()
+    assert body["status"] == 200
+    assert body["hashfiles"] == []
+
+
+def test_requires_authorization(client):
+    # No auth cookie -> redirect to the not_authorized route.
+    resp = client.get("/v1/hashfiles/hash_type/1000")
+    assert resp.status_code in (301, 302)
+    assert "/v1/not_authorized" in resp.headers["Location"]

--- a/tests/unit/test_api_jobs_add_notifications.py
+++ b/tests/unit/test_api_jobs_add_notifications.py
@@ -1,0 +1,115 @@
+"""Regression test for POST /v1/jobs/add notification creation.
+
+Bug: the route built ``JobNotifications(job_id=..., notify_email=...,
+notify_pushover=...)``, but that model only has the columns ``owner_id``,
+``job_id`` and ``method``. The bogus kwargs raised a TypeError which the
+route's ``except`` turned into an HTTP 500 "Failed to add job" — *after* the
+Jobs row had already been committed. So every job created through the API
+reported failure and never got its notifications recorded.
+
+The fix builds one ``JobNotifications`` row per requested channel using the
+real columns (``owner_id``/``method``). These tests assert the endpoint now
+returns 200 and that the expected notification rows exist.
+"""
+
+import json
+
+import pytest
+
+from hashview.models import (
+    db,
+    Customers,
+    HashfileHashes,
+    Hashes,
+    Hashfiles,
+    JobNotifications,
+    Jobs,
+    Tasks,
+    Users,
+)
+
+
+@pytest.fixture()
+def seeded(app):
+    """Seed the minimal object graph so /v1/jobs/add reaches the notification
+    block: an api-keyed user, a customer, a hashfile with one hash, and a
+    cracked hash attributed to a task (so the 'most effective tasks' query is
+    non-empty and the route doesn't bail out early)."""
+    with app.app_context():
+        user = Users(
+            first_name="Api",
+            last_name="User",
+            email_address="api@example.com",
+            password="x",
+            admin=True,
+            api_key="test-api-key",
+        )
+        customer = Customers(name="Acme")
+        db.session.add_all([user, customer])
+        db.session.commit()
+
+        task = Tasks(name="dict", hc_attackmode=0, owner_id=user.id)
+        db.session.add(task)
+        db.session.commit()
+
+        hashfile = Hashfiles(name="hf", customer_id=customer.id, owner_id=user.id)
+        db.session.add(hashfile)
+        db.session.commit()
+
+        cracked = Hashes(
+            sub_ciphertext="abc",
+            ciphertext="deadbeef",
+            hash_type=0,
+            cracked=True,
+            task_id=task.id,
+        )
+        db.session.add(cracked)
+        db.session.commit()
+        db.session.add(HashfileHashes(hash_id=cracked.id, hashfile_id=hashfile.id))
+        db.session.commit()
+
+        return {
+            "api_key": user.api_key,
+            "user_id": user.id,
+            "customer_id": customer.id,
+            "hashfile_id": hashfile.id,
+        }
+
+
+def _post_job(client, seeded, **extra):
+    client.set_cookie("uuid", seeded["api_key"])
+    payload = {
+        "name": "job1",
+        "hashfile_id": seeded["hashfile_id"],
+        "customer_id": seeded["customer_id"],
+    }
+    payload.update(extra)
+    return client.post(
+        "/v1/jobs/add",
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+
+
+def test_jobs_add_with_notifications_returns_200(client, seeded):
+    resp = _post_job(client, seeded, notify_email=True, notify_pushover=True)
+    body = resp.get_json()
+    assert body["status"] == 200, body
+    assert body["msg"] == "Job added"
+
+
+def test_jobs_add_records_requested_channels(client, seeded, app):
+    _post_job(client, seeded, notify_email=True, notify_pushover=True)
+    with app.app_context():
+        rows = JobNotifications.query.all()
+        assert {r.method for r in rows} == {"email", "push"}
+        assert all(r.owner_id == seeded["user_id"] for r in rows)
+
+
+def test_jobs_add_without_notifications_creates_none(client, seeded, app):
+    resp = _post_job(client, seeded)
+    assert resp.get_json()["status"] == 200
+    with app.app_context():
+        assert JobNotifications.query.count() == 0
+        # The job itself must still have been created.
+        assert Jobs.query.count() == 1

--- a/tests/unit/test_api_not_authorized_redirect.py
+++ b/tests/unit/test_api_not_authorized_redirect.py
@@ -1,0 +1,23 @@
+"""Regression: unauthorized API requests must redirect to /v1/not_authorized.
+
+Two routes (/v1/error and /v1/hashes/import/<hash_type>) redirected to
+"/vi/not_authorized" — a typo. That path has no route, so an unauthorized
+caller got a 404 instead of the intended not-authorized response. Every
+other route in this blueprint uses the correct "/v1/not_authorized".
+"""
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "method, path",
+    [
+        ("post", "/v1/error"),
+        ("post", "/v1/hashes/import/1000"),
+    ],
+)
+def test_unauthorized_redirects_to_v1_not_authorized(client, method, path):
+    # No auth cookie -> is_authorized() is falsy -> redirect.
+    resp = getattr(client, method)(path)
+    assert resp.status_code in (301, 302)
+    assert resp.headers["Location"].endswith("/v1/not_authorized")


### PR DESCRIPTION
## Problem

`POST /v1/hashes/import/<hash_type>` returns **HTTP 500** even for valid uploads. Observed live:

```
File "hashview/api/routes.py", line 1268, in v1_api_hashes_import
    if hash.cracked:
AttributeError: 'NoneType' object has no attribute 'cracked'
```

The crash is **not** in the import/matching logic (that's guarded with `if record:`). It's in the **"Send Hash Completion Notifications"** sweep that runs *after* a successful import:

```python
hash = Hashes.query.get(hash_notification.hash_id)
if hash.cracked:      # <-- None.cracked when the notification is orphaned
```

If any `HashNotifications` row references a `hash_id` that no longer resolves (deleted/stale hash), `Hashes.query.get()` returns `None` and the whole request 500s — **regardless of what the client submitted**. This is why the recently-merged NTLM import fixes (#305, #307) didn't resolve the 500: they fixed matching, not this sweep.

## Fix

Guard both unguarded sites with `if hash and hash.cracked:` — mirroring the already-guarded third site (~`routes.py:1016`):

- `v1_api_hashes_import` (the import endpoint)
- `v1_api_put_jobtask_crackfile_upload` (the agent crackfile-upload path — same latent bug)

## Test

Adds `test_import_survives_orphaned_hash_notification`: seeds an orphaned `HashNotifications` row, then asserts import returns `200` (and still marks the legitimate hash cracked). Verified it reproduces the exact `AttributeError` at routes.py:1268 without the guard, and passes with it. Full unit suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)