### PR TITLE
chore: remove debug/noise console output during normal server operation

### DIFF
--- a/hashview.py
+++ b/hashview.py
@@ -291,8 +291,6 @@ def data_retention_cleanup(app):
         )
         from hashview.utils.utils import send_email
 
-        print('[DEBUG] Im retaining all the data: ' + str(datetime.now()))
-
         setting = Settings.query.get('1')
         retention_period = setting.retention_period
         filter_after = datetime.today() - timedelta(days = retention_period)
@@ -316,8 +314,6 @@ def data_retention_cleanup(app):
             db.session.delete(job)
             db.session.commit()
 
-            print("[DEBUG] Job Name: " + str(job.name) + '  Owner ID: ' + str(job.owner_id))
-
         # Remove Hashfiles (jobs younger than retention period that reference
         # these hashfiles get removed too).
         hashfiles = Hashfiles.query.filter(Hashfiles.uploaded_at < filter_after).all()
@@ -326,7 +322,6 @@ def data_retention_cleanup(app):
             # Job, jobtask and job notifications
             jobs = Jobs.query.filter_by(hashfile_id = hashfile.id).all()
             for job in jobs:
-                print("[DEBUG] Hashfile->jobs: Job Name: " +str(job.name))
                 user = Users.query.get(job.owner_id)
                 subject = (
                     'Hashview removed a job that was associated to an old hash file: '
@@ -347,11 +342,6 @@ def data_retention_cleanup(app):
                 db.session.commit()
 
             # Hashfiles, HashfileHashes and Hash notifications
-            print(
-                f'[DEBUG] Hashfile Name: {hashfile.name}    '
-                f'Owner ID: {hashfile.owner_id}'
-            )
-            print('[DEBUG] Hashfile ID: ' + str(hashfile.id))
             user = Users.query.get(hashfile.owner_id)
             subject = 'Hashview removed an old Hashfile: ' + str(hashfile.name)
             message = (
@@ -382,17 +372,10 @@ def data_retention_cleanup(app):
 
         # Clean temp folder of files older than RETENTION PERIOD
         for file in os.listdir('hashview/control/tmp'):
-            print('[DEBUG] hashview.py->data_retention_cleanup() ' + file)
-            if file == '.gitignore':
-                print('Found Git Ignore!')
             tmp_path = 'hashview/control/tmp/' + file
             age_limit = time.time() - retention_period * 86400
             if os.stat(tmp_path).st_mtime < age_limit and file != '.gitignore':
                 os.remove(tmp_path)
-                print('[DEBUG] hashview.py->data_retention_cleanup() '
-                      f'Removed: {tmp_path}')
-
-        print('[DEBUG] ==============')
 
 
 def cli(args) -> int:

--- a/hashview/__init__.py
+++ b/hashview/__init__.py
@@ -28,20 +28,14 @@ def do_gui_setup_if_needed():
     from hashview.models import db
     from hashview.setup import admin_pass_needs_changed
     from hashview.users.routes import bcrypt
-    if not admin_pass_needs_changed(db, bcrypt):
-        logger.info('Admin password does not need changed.')
-
-    else:
+    if admin_pass_needs_changed(db, bcrypt):
         logger.info('Admin password needs changed.')
         if url_for('setup.admin_pass_get') != parsed_url.path:
             return redirect(url_for('setup.admin_pass_get'))
         return None
 
     from hashview.setup import settings_needs_added
-    if not settings_needs_added(db):
-        logger.info('Settings does not need created.')
-
-    else:
+    if settings_needs_added(db):
         logger.info('Settings needs created.')
         if url_for('setup.settings_get') != parsed_url.path:
             return redirect(url_for('setup.settings_get'))

--- a/hashview/jobs/routes.py
+++ b/hashview/jobs/routes.py
@@ -443,18 +443,8 @@ def jobs_assigned_hashfile(job_id):
                 msgs.extend(str(m) for m in _field.errors)
             return jsonify({'status': 'error',
                             'msg': '; '.join(msgs) or 'Invalid upload request.'}), 400
-        for error in jobs_new_hashfile_form.name.errors:
-            print(str(error))
-        for error in jobs_new_hashfile_form.file_type.errors:
-            print(str(error))
-        for error in jobs_new_hashfile_form.hash_type.errors:
-            print(str(error))
-        for error in jobs_new_hashfile_form.hashfile.errors:
-            print(str(error))
-        for error in jobs_new_hashfile_form.hashfilehashes.errors:
-            print(str(error))
-        for error in jobs_new_hashfile_form.submit.errors:
-            print(str(error))
+        # Non-AJAX submit: fall through and re-render the page — WTForms shows the
+        # field errors inline, so there's nothing to print to the console.
 
     return render_template('jobs_assigned_hashfiles.html.j2', title='Jobs Assigned Hashfiles', hashfiles=hashfiles, job=job, jobsNewHashFileForm=jobs_new_hashfile_form, hashfile_cracked_rate=hashfile_cracked_rate, hashfile_info=hashfile_info)
 

--- a/hashview/searches/routes.py
+++ b/hashview/searches/routes.py
@@ -35,7 +35,6 @@ def searches_list():
     # We should be able to include Customers and Hashfiles in the following queries
     if searchForm.validate_on_submit():
         if searchForm.search_type.data == 'hash':
-            print(f"[DEBUG] {searchForm.query.data}")
             # can be found in hashfiles, or not, or both?
             hash_results = db.session.query(Hashes).filter(Hashes.ciphertext==searchForm.query.data).all()
             hashfile_results = db.session.query(Hashes, HashfileHashes).join(HashfileHashes, Hashes.id==HashfileHashes.hash_id).filter(Hashes.ciphertext==searchForm.query.data).all()


### PR DESCRIPTION
- __init__.py: drop the two per-request INFO logs ("Admin password does not need changed." / "Settings does not need created.") by inverting the setup checks so the no-op branches vanish; the meaningful "needs changed/created" logs (only when setup is actually required) are kept. Behavior unchanged.
- searches/routes.py: remove the per-search `[DEBUG]` query print.
- jobs/routes.py: remove the six print(str(error)) loops that dumped hashfile form-validation errors to the console (already rendered inline in the form).
- hashview.py: remove the eight `[DEBUG]` prints in data_retention_cleanup (including "Found Git Ignore!") that fired on every scheduler run.

Intentional startup/first-run CLI output (hashview.py "✓ …" checks, prompts; setup.py installer) is left as-is.