### PR TITLE
feat(jobs): redirect to the dashboard after Create & Queue

### DIFF
--- a/hashview/jobs/routes.py
+++ b/hashview/jobs/routes.py
@@ -866,7 +866,7 @@ def jobs_summary(job_id):
 
         flash('Job created and queued', 'success')
 
-        return redirect(url_for('jobs.jobs_list'))
+        return redirect(url_for('main.home'))
 
     return render_template('jobs_summary.html.j2', title='Job Summary', job=job, form=form, job_notification=job_notification, cracked_rate=cracked_rate, cracked_cnt=cracked_cnt, hash_total=hash_total, hashfile_hash_type=hashfile_hash_type, job_tasks=job_tasks, hash_notification_cnt=hash_notification_cnt, customer=customer, hashfile=hashfile, tasks=tasks, hash_notification=hash_notification, settings=settings, website=_job_uses_website_keywords(job_id))
 

--- a/tests/unit/test_jobs_routes_guards.py
+++ b/tests/unit/test_jobs_routes_guards.py
@@ -552,6 +552,8 @@ def test_jobs_summary_post_queues_job_and_tasks(app, client):
     resp = client.post(f"/jobs/{job.id}/summary", data={"submit": "Create & Queue Job"},
                        follow_redirects=False)
     assert resp.status_code in (301, 302)
+    # Create & Queue lands on the dashboard ("/"), not the jobs listing ("/jobs").
+    assert resp.headers.get("Location", "").endswith("/")
     db.session.expire_all()
     job = Jobs.query.get(job.id)
     jt = JobTasks.query.filter_by(job_id=job.id).first()


### PR DESCRIPTION
The final wizard step (jobs_summary "Create & Queue Job") sent the user back to the jobs listing; land them on the dashboard (main.home) instead. The "Job created and queued" flash now shows on the dashboard.

Tightened test_jobs_summary_post_queues_job_and_tasks to assert the redirect targets "/" rather than "/jobs" (it previously only checked for a 302).