### PR TITLE
feat(jobs): scrollable, filterable InstaCrack results on the hashfile…

### DIFF
--- a/hashview/templates/jobs_assigned_hashfiles_cracked.html.j2
+++ b/hashview/templates/jobs_assigned_hashfiles_cracked.html.j2
@@ -10,13 +10,26 @@
 </div>
 {{ wizard_stepper('hashfile') }}
 
+<style>
+    /* Keep the (potentially huge) instacrack list in a scrollable box so the
+       wizard Next button stays reachable without scrolling past every row. */
+    #ic-scroll { max-height: 55vh; overflow-y: auto; }
+    #ic-table thead th { position: sticky; top: 0; z-index: 1; background: var(--surface); padding-top: 12px; }
+</style>
 <div class="card">
     <div class="card-head">
-        <h3>Local Check</h3>
-        <span class="page-sub" title="The following hashes are already cracked in Hashview's Local database!">{{ icon('info', size=15) }} Already cracked in Hashview's local database</span>
+        <div style="display:flex; flex-direction:column; gap:3px;">
+            <h3>InstaCrack!</h3>
+            <span class="page-sub" style="margin-top:0; display:inline-flex; align-items:center; gap:6px;" title="The following hashes are already cracked in Hashview's Local database!">{{ icon('info', size=15) }} Already cracked in Hashview's local database</span>
+        </div>
     </div>
     {% if cracked_hashfiles_hashes|length > 0 %}
-    <table class="tbl">
+    <div style="display:flex; align-items:center; gap:10px; padding:12px 16px; border-bottom:1px solid var(--border-soft);">
+        <input type="text" id="ic-filter" class="input" style="flex:1;" placeholder="Filter by name, hash, or plaintext…" autocomplete="off" oninput="hvIcFilter(this.value)">
+        <span class="mono" id="ic-count" style="font-size:11px; color:var(--text-mute); white-space:nowrap;"></span>
+    </div>
+    <div id="ic-scroll">
+    <table class="tbl" id="ic-table">
         <thead>
             <tr>
                 <th>Username</th>
@@ -26,10 +39,12 @@
         </thead>
         <tbody>
             {% for entry in cracked_hashfiles_hashes %}
-            <tr>
+            {% set nm = (entry[1].username | jinja_hex_decode) if entry[1].username else '' %}
+            {% set pt = (entry[0].plaintext | jinja_hex_decode) if entry[0].plaintext else '' %}
+            <tr class="ic-row" data-search="{{ (nm ~ ' ' ~ entry[0].ciphertext ~ ' ' ~ pt) | lower }}">
                 <td>
                     {% if entry[1].username %}
-                        {{ entry[1].username | jinja_hex_decode }}
+                        {{ nm }}
                     {% else %}
                         <span style="color:var(--text-mute);">None</span>
                     {% endif %}
@@ -37,15 +52,17 @@
                 <td class="mono" style="color:var(--text-dim);">{{ entry[0].ciphertext }}</td>
                 <td>
                     {% if entry[0].plaintext %}
-                        <span class="mono" style="color:var(--primary); text-shadow:var(--glow-text);">{{ entry[0].plaintext | jinja_hex_decode }}</span>
+                        <span class="mono" style="color:var(--primary); text-shadow:var(--glow-text);">{{ pt }}</span>
                     {% else %}
                         <span style="color:var(--text-mute);">None</span>
                     {% endif %}
                 </td>
             </tr>
             {% endfor %}
+            <tr id="ic-no-match" style="display:none;"><td colspan="3" style="text-align:center; padding:28px 16px; color:var(--text-mute);" class="mono">No results match that filter.</td></tr>
         </tbody>
     </table>
+    </div>
     {% else %}
     <div class="card-body" style="text-align:center; padding:48px 24px;">
         <div class="mono" style="color:var(--text-dim);">No previously cracked hashes found.</div>
@@ -57,5 +74,39 @@
     <span class="spacer"></span>
     <a class="btn btn-primary" href="/jobs/{{job.id}}/notifications" role="button">Next {{ icon('arrowRight', size=15) }}</a>
 </div>
+
+{% if cracked_hashfiles_hashes|length > 0 %}
+<script>
+function hvIcFilter(q) {
+    q = (q || '').trim().toLowerCase();
+    var rows = document.querySelectorAll('#ic-table tbody tr.ic-row');
+    var shown = 0;
+    rows.forEach(function (r) {
+        var hit = !q || (r.getAttribute('data-search') || '').indexOf(q) !== -1;
+        r.style.display = hit ? '' : 'none';
+        if (hit) shown++;
+    });
+    var none = document.getElementById('ic-no-match');
+    if (none) none.style.display = shown === 0 ? '' : 'none';
+    var count = document.getElementById('ic-count');
+    if (count) count.textContent = shown + ' / ' + rows.length + ' shown';
+}
+// Size the results box to exactly fill the space between its top and the wizard
+// nav, so the Back/Next buttons are visible on load without scrolling the page.
+function hvIcResize() {
+    var box = document.getElementById('ic-scroll');
+    var nav = document.querySelector('.wizard-nav');
+    if (!box || !nav) return;
+    var boxTop = box.getBoundingClientRect().top;
+    // Space consumed below the box (nav height + the gap to it). This is
+    // invariant to the box's own height, so a single measurement is stable.
+    var belowBox = nav.getBoundingClientRect().bottom - box.getBoundingClientRect().bottom;
+    var avail = window.innerHeight - boxTop - belowBox - 12;   // 12px breathing room
+    box.style.maxHeight = Math.max(avail, 160) + 'px';         // floor for tiny viewports
+}
+window.addEventListener('resize', hvIcResize);
+document.addEventListener('DOMContentLoaded', function () { hvIcFilter(''); hvIcResize(); });
+</script>
+{% endif %}
 
 {% endblock content %}

--- a/tests/unit/test_jobs_routes_guards.py
+++ b/tests/unit/test_jobs_routes_guards.py
@@ -306,6 +306,27 @@ def test_jobs_assigned_hashfile_cracked_flashes_instacracks(app, client):
     assert b"instacracked" in resp.data
 
 
+def test_jobs_assigned_hashfile_cracked_scrollable_filter_box(app, client):
+    """Instacrack results render in a scrollable box with a name/hash/plaintext
+    filter, so the wizard Next button stays reachable for large result sets."""
+    user = _nonadmin()
+    customer = _make_customer()
+    job = _make_job(user.id, customer.id)
+    hf, h = _attach_hashfile(job, user.id, cracked=True)
+    _login(client, user)
+
+    body = client.get(f"/jobs/{job.id}/assigned_hashfile/{hf.id}").get_data(as_text=True)
+    assert 'InstaCrack!' in body and 'Local Check' not in body   # renamed title
+    assert 'id="ic-scroll"' in body                       # scrollable results box
+    assert 'id="ic-filter"' in body                       # filter input in the header
+    assert 'Filter by name, hash, or plaintext' in body   # filters name/hash/plaintext
+    assert 'position: sticky' in body                     # column headers stay visible
+    assert 'id="ic-no-match"' in body                     # shown when nothing matches
+    assert 'function hvIcFilter' in body                  # client-side filtering
+    assert 'function hvIcResize' in body                  # box sized to keep Next on-screen
+    assert 'data-search="' in body                        # each row is searchable
+
+
 # ------------------------------------------------------------ jobs_list_tasks
 
 def test_jobs_list_tasks_renders(app, client):


### PR DESCRIPTION
… step

The instacrack ("already cracked in Hashview's local database") results were a flat table that grew unbounded, pushing the wizard Next button far below the fold. Rework the page so large result sets stay usable:

- Results render in a scrollable box with a sticky column header.
- hvIcResize() sizes the box to fill exactly the space between its top and the wizard nav (on load + resize, with a floor for tiny viewports), so Back/Next are on-screen without scrolling the page.
- A header filter input (hvIcFilter) live-filters rows by name, hash, or plaintext via a per-row lowercased data-search attribute, with a "no results match" row and an N/M shown count. Values are autoescaped (including in data-search) so a hostile plaintext can't break out.
- Rename the card title "Local Check" -> "InstaCrack!" and stack the title/subtitle in a left-aligned column (drops the .page-sub margin-top that made the header look askew).

Test: test_jobs_assigned_hashfile_cracked_scrollable_filter_box asserts the box, filter, sticky header, resize hook, and new title render through the route.