### PR TITLE
feat(api): add DELETE /v1/hashfiles/<id> (issue #310)

### DIFF
--- a/hashview/api/routes.py
+++ b/hashview/api/routes.py
@@ -12,7 +12,7 @@ from flask import (
     send_from_directory,
 )
 from packaging import version
-from sqlalchemy import func
+from sqlalchemy import exists, func
 from sqlalchemy.ext.declarative import DeclarativeMeta
 
 import hashview
@@ -23,6 +23,7 @@ from hashview.models import (
     Hashes,
     HashfileHashes,
     Hashfiles,
+    HashNotifications,
     JobNotifications,
     Jobs,
     JobTasks,
@@ -1393,6 +1394,70 @@ def v1_api_get_hashfile(hashfile_id):
             file_object.write(result[0].ciphertext + '\n')
 
     return _send_generated_file(tmp_dir, random_hex)
+
+@api.route('/v1/hashfiles/<int:hashfile_id>', methods=['DELETE'])
+def v1_api_delete_hashfile(hashfile_id):
+    if not is_authorized(user=True, agent=False, request=request):
+        return redirect("/v1/not_authorized")
+
+    uuid = request.cookies.get('uuid')
+    user = Users.query.filter_by(api_key=uuid).first()
+    if not user:
+        return jsonify({
+            'status': 403,
+            'type': 'Error',
+            'msg': 'User not found'
+        })
+
+    hashfile = Hashfiles.query.get(hashfile_id)
+    if hashfile is None:
+        return jsonify({'status': 404, 'type': 'Error', 'msg': 'Hashfile not found'}), 404
+
+    if not (user.admin or hashfile.owner_id == user.id):
+        return jsonify({
+            'status': 403,
+            'type': 'Error',
+            'msg': 'You do not have rights to delete this hashfile'
+        })
+
+    # Refuse while the hashfile is still assigned to a job — the web UI does the
+    # same (hashfiles_delete) and does NOT cascade job deletion from a hashfile.
+    if Jobs.query.filter_by(hashfile_id=hashfile_id).first():
+        return jsonify({
+            'status': 409,
+            'type': 'Error',
+            'msg': 'Hashfile is currently associated with a job'
+        }), 409
+
+    # Mirror the web UI's hashfiles_delete cascade, atomically: the hashfile-hash
+    # links, the hashfile, then any uncracked hashes / notifications it orphans.
+    hashfile_target = f'hashfile:{hashfile.id} {hashfile.name!r}'
+    try:
+        HashfileHashes.query.filter_by(hashfile_id=hashfile.id).delete(synchronize_session=False)
+        db.session.delete(hashfile)
+        Hashes.query.filter(Hashes.cracked == 0).filter(
+            ~exists().where(HashfileHashes.hash_id == Hashes.id)
+        ).delete(synchronize_session=False)
+        HashNotifications.query.filter(
+            ~exists().where(Hashes.id == HashNotifications.hash_id)
+        ).delete(synchronize_session=False)
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        current_app.logger.exception('API /v1/hashfiles: failed to delete hashfile')
+        return jsonify({
+            'status': 500,
+            'type': 'Error',
+            'msg': 'Failed to delete hashfile.'
+        })
+
+    log_event('hashfile.delete', actor=(user.email_address, user.id), target=hashfile_target)
+    return jsonify({
+        'status': 200,
+        'type': 'message',
+        'msg': 'Hashfile deleted',
+        'hashfile_id': hashfile_id
+    })
 
 # List hashfiles containing at least one hash of the given hash type.
 # No collision with /v1/hashfiles/<int:hashfile_id>: the static 'hash_type/'

--- a/hashview/api_docs/openapi.yaml
+++ b/hashview/api_docs/openapi.yaml
@@ -954,6 +954,55 @@ paths:
               schema: {type: string}
         '302':
           $ref: '#/components/responses/NotAuthorizedRedirect'
+    delete:
+      tags: [Hashfiles]
+      summary: Delete a hashfile
+      description: >-
+        Owner or admin only. Refuses (409) while the hashfile is still
+        assigned to a job. On success cascades like the web UI: removes the
+        hashfile-hash links, the hashfile, and any uncracked hashes / hash
+        notifications it orphans, in one transaction.
+      operationId: deleteHashfile
+      x-audience: user
+      security:
+        - userApiKey: []
+      parameters:
+        - name: hashfile_id
+          in: path
+          required: true
+          schema: {type: integer}
+      responses:
+        '200':
+          description: >-
+            HTTP 200; body status 200 on success, 403 when not owner or
+            admin, 500 on a database error.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/HashfileDeletedResponse'
+                  - $ref: '#/components/schemas/ApiError'
+              examples:
+                deleted: {value: {status: 200, type: message, msg: Hashfile deleted, hashfile_id: 12}}
+                forbidden: {value: {status: 403, type: Error, msg: You do not have rights to delete this hashfile}}
+        '404':
+          description: Real HTTP 404 — unknown hashfile id.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+              example: {status: 404, type: Error, msg: Hashfile not found}
+        '409':
+          description: >-
+            Real HTTP 409 — the hashfile is still associated with a job and
+            cannot be deleted until that job is removed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+              example: {status: 409, type: Error, msg: Hashfile is currently associated with a job}
+        '302':
+          $ref: '#/components/responses/NotAuthorizedRedirect'
 
   /v1/hashfiles/hash_type/{hash_type}:
     get:
@@ -1750,6 +1799,14 @@ components:
           required: [job_id]
           properties:
             job_id: {type: integer}
+
+    HashfileDeletedResponse:
+      allOf:
+        - $ref: '#/components/schemas/ApiMessage'
+        - type: object
+          required: [hashfile_id]
+          properties:
+            hashfile_id: {type: integer}
 
     TaskAddedResponse:
       allOf:

--- a/tests/unit/test_api_endpoints.py
+++ b/tests/unit/test_api_endpoints.py
@@ -1007,3 +1007,106 @@ def test_jobs_add_creates_notification_rows(client, admin_user):
     rows = JobNotifications.query.filter_by(job_id=body["job_id"]).all()
     assert {r.method for r in rows} == {"email", "slack"}
     assert all(r.owner_id == admin_user.id for r in rows)
+
+
+# ---------------------------------------------------------------------------
+# DELETE /v1/hashfiles/<hashfile_id>
+# ---------------------------------------------------------------------------
+
+
+def _seed_hashfile(owner, name="doomed-hf"):
+    """Seed a customer + hashfile owned by *owner*."""
+    cust = Customers(name="HFDelCo-" + name)
+    _db.session.add(cust)
+    _db.session.commit()
+    hf = Hashfiles(name=name, customer_id=cust.id, owner_id=owner.id)
+    _db.session.add(hf)
+    _db.session.commit()
+    return hf
+
+
+@pytest.mark.security
+def test_hashfiles_delete_cascades_and_keeps_cracked(client, admin_user):
+    """DELETE /v1/hashfiles/<id> removes the hashfile + its links; orphaned
+    uncracked hashes are deleted, cracked hashes are kept (web-UI cascade)."""
+    hf = _seed_hashfile(admin_user)
+    hf_id = hf.id
+    uncracked_id = _seed_hash(hf_id, 1000, False).id
+    cracked_id = _seed_hash(hf_id, 1000, True).id
+
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    resp = client.delete(f"/v1/hashfiles/{hf_id}")
+
+    body = _json_body(resp)
+    assert body["status"] == 200
+    assert body["msg"] == "Hashfile deleted"
+    assert body["hashfile_id"] == hf_id
+    # Bulk cascade deletes use synchronize_session=False; expire cached state so
+    # the assertions below read the committed rows rather than stale objects.
+    _db.session.expire_all()
+    assert Hashfiles.query.get(hf_id) is None
+    assert HashfileHashes.query.filter_by(hashfile_id=hf_id).count() == 0
+    assert Hashes.query.get(uncracked_id) is None       # orphaned uncracked hash removed
+    assert Hashes.query.get(cracked_id) is not None     # cracked hash retained
+
+
+@pytest.mark.security
+def test_hashfiles_delete_missing_returns_404(client, admin_user):
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    resp = client.delete("/v1/hashfiles/424242")
+    assert resp.status_code == 404
+    body = _json_body(resp)
+    assert body["status"] == 404
+    assert "not found" in body["msg"].lower()
+
+
+@pytest.mark.security
+def test_hashfiles_delete_rejects_agent_cookie(client, authorized_agent):
+    """User-only: a valid agent uuid is refused with the not-authorized redirect."""
+    client.set_cookie("uuid", authorized_agent.uuid, domain="localhost.test")
+    resp = client.delete("/v1/hashfiles/1")
+    assert 300 <= resp.status_code < 400
+    assert "not_authorized" in resp.headers.get("Location", "")
+
+
+@pytest.mark.security
+def test_hashfiles_delete_non_owner_returns_403(client, admin_user, regular_user):
+    """A non-admin cannot delete another user's hashfile."""
+    hf = _seed_hashfile(admin_user)
+    hf_id = hf.id
+    client.set_cookie("uuid", regular_user.api_key, domain="localhost.test")
+    resp = client.delete(f"/v1/hashfiles/{hf_id}")
+    body = _json_body(resp)
+    assert body["status"] == 403
+    assert Hashfiles.query.get(hf_id) is not None       # not deleted
+
+
+@pytest.mark.security
+def test_hashfiles_delete_refuses_when_assigned_to_job(client, admin_user):
+    """A hashfile still attached to a job cannot be deleted (409)."""
+    hf = _seed_hashfile(admin_user)
+    hf_id = hf.id
+    job = Jobs(name="uses-hf", status="Ready", customer_id=hf.customer_id,
+               owner_id=admin_user.id, hashfile_id=hf_id)
+    _db.session.add(job)
+    _db.session.commit()
+
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    resp = client.delete(f"/v1/hashfiles/{hf_id}")
+    assert resp.status_code == 409
+    body = _json_body(resp)
+    assert body["status"] == 409
+    assert "associated with a job" in body["msg"].lower()
+    assert Hashfiles.query.get(hf_id) is not None       # not deleted
+
+
+@pytest.mark.security
+def test_hashfiles_delete_admin_can_delete_others(client, admin_user, regular_user):
+    """An admin can delete a hashfile owned by another user."""
+    hf = _seed_hashfile(regular_user)
+    hf_id = hf.id
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    resp = client.delete(f"/v1/hashfiles/{hf_id}")
+    body = _json_body(resp)
+    assert body["status"] == 200
+    assert Hashfiles.query.get(hf_id) is None


### PR DESCRIPTION
The v1 API could create hashfiles but never delete them, orphaning API-uploaded files (e.g. hate_crack integration test data) on shared instances. Add DELETE /v1/hashfiles/<int:hashfile_id> mirroring v1_api_delete_job and the web-UI hashfiles_delete cascade:

- user-only auth (is_authorized user=True, agent=False), caller resolved from the uuid cookie -> api_key;
- 404 unknown hashfile; 403 when not owner and not admin;
- 409 when the hashfile is still assigned to a job (matches the UI refusal — no implicit job cascade);
- atomic cascade on success: HashfileHashes links, the hashfile, then orphaned uncracked Hashes and orphaned HashNotifications (rollback + 500 on error);
- log_event('hashfile.delete', ...) and the standard {status,type,msg} envelope (+ hashfile_id).

Adds the exists / HashNotifications imports, documents the operation in openapi.yaml (+ HashfileDeletedResponse schema) to keep the spec<->routes parity test green, and adds 6 endpoint tests (cascade/keep-cracked, 404, agent-rejected, non-owner 403, job-associated 409, admin-deletes-others).