### PR TITLE
feat(hashfiles): bulk select + bulk delete on the hashfiles list (iss…

### DIFF
--- a/hashview/hashfiles/routes.py
+++ b/hashview/hashfiles/routes.py
@@ -2,7 +2,7 @@
 import io
 from datetime import datetime
 
-from flask import Blueprint, abort, flash, redirect, render_template, send_file, url_for
+from flask import Blueprint, abort, flash, redirect, render_template, request, send_file, url_for
 from flask_login import current_user, login_required
 from sqlalchemy import case, func
 from sqlalchemy.sql import exists
@@ -130,6 +130,26 @@ def hashfiles_list():
                            total_hashes=total_hashes, total_recovered=total_recovered,
                            overall_rate=overall_rate, hashfile_jobs=hashfile_jobs)
 
+def _cascade_delete_hashfile(hashfile):
+    """Cascade-delete one hashfile in a single transaction: the hashfile-hash
+    links, the hashfile, then any uncracked hashes / notifications left orphaned
+    by it. The caller must have already checked ownership and that the hashfile
+    is not associated with a job. Returns True on a successful commit.
+
+    Shared by the single-file (hashfiles_delete) and bulk (hashfiles_bulk_delete)
+    delete paths so both apply the exact same cleanup.
+    """
+    HashfileHashes.query.filter_by(hashfile_id=hashfile.id).delete(synchronize_session=False)
+    db.session.delete(hashfile)
+    Hashes.query.filter(Hashes.cracked == 0).filter(
+        ~exists().where(HashfileHashes.hash_id == Hashes.id)
+    ).delete(synchronize_session=False)
+    HashNotifications.query.filter(
+        ~exists().where(Hashes.id == HashNotifications.hash_id)
+    ).delete(synchronize_session=False)
+    return try_commit(f'delete hashfile {hashfile.id}')
+
+
 @hashfiles.route("/hashfiles/delete/<int:hashfile_id>", methods=['GET', 'POST'])
 @login_required
 def hashfiles_delete(hashfile_id):
@@ -145,23 +165,75 @@ def hashfiles_delete(hashfile_id):
         flash('Error: Hashfile currently associated with a job.', 'danger')
         return redirect(url_for('hashfiles.hashfiles_list'))
 
-    # Cascade in a single transaction (atomic): the hashfile-hash links, the
-    # hashfile, then any uncracked hashes / notifications left orphaned by it.
     hashfile_target = f'hashfile:{hashfile.id} {hashfile.name!r}'
-    HashfileHashes.query.filter_by(hashfile_id=hashfile.id).delete(synchronize_session=False)
-    db.session.delete(hashfile)
-    Hashes.query.filter(Hashes.cracked == 0).filter(
-        ~exists().where(HashfileHashes.hash_id == Hashes.id)
-    ).delete(synchronize_session=False)
-    HashNotifications.query.filter(
-        ~exists().where(Hashes.id == HashNotifications.hash_id)
-    ).delete(synchronize_session=False)
-    if not try_commit(f'delete hashfile {hashfile_id}'):
+    if not _cascade_delete_hashfile(hashfile):
         flash('Hashfile could not be deleted — it may have already been removed.', 'danger')
         return redirect(url_for('hashfiles.hashfiles_list'))
 
     log_event('hashfile.delete', target=hashfile_target)
     flash('Hashfile has been deleted!', 'success')
+    return redirect(url_for('hashfiles.hashfiles_list'))
+
+
+@hashfiles.route("/hashfiles/bulk_delete", methods=['POST'])
+@login_required
+def hashfiles_bulk_delete():
+    """Delete several hashfiles at once (from the list's bulk-select bar).
+
+    Applies the SAME per-file rules as hashfiles_delete to each submitted id —
+    ownership, the not-associated-with-a-job guard, and the shared cascade — and
+    reuses _cascade_delete_hashfile. A skip/failure on one file does not abort the
+    batch; the flash reports a per-outcome summary.
+    """
+    deleted = skipped_job = skipped_rights = skipped_missing = failed = 0
+    seen = set()
+    for raw in request.form.getlist('hashfile_ids'):
+        try:
+            hashfile_id = int(raw)
+        except (TypeError, ValueError):
+            continue
+        if hashfile_id in seen:
+            continue
+        seen.add(hashfile_id)
+
+        hashfile = Hashfiles.query.get(hashfile_id)
+        if hashfile is None:
+            skipped_missing += 1
+            continue
+        if not (current_user.admin or hashfile.owner_id == current_user.id):
+            skipped_rights += 1
+            continue
+        if Jobs.query.filter_by(hashfile_id=hashfile_id).first():
+            skipped_job += 1
+            continue
+
+        hashfile_target = f'hashfile:{hashfile.id} {hashfile.name!r}'
+        if _cascade_delete_hashfile(hashfile):
+            log_event('hashfile.delete', target=hashfile_target)
+            deleted += 1
+        else:
+            failed += 1
+
+    parts = []
+    if deleted:
+        parts.append(f'{deleted} deleted')
+    if skipped_job:
+        parts.append(f'{skipped_job} skipped — associated with a job')
+    if skipped_rights:
+        parts.append(f'{skipped_rights} skipped — insufficient rights')
+    if skipped_missing:
+        parts.append(f'{skipped_missing} skipped — not found')
+    if failed:
+        parts.append(f'{failed} failed')
+
+    if not parts:
+        flash('No hashfiles selected for deletion.', 'warning')
+    elif deleted and not (skipped_job or skipped_rights or skipped_missing or failed):
+        flash(', '.join(parts) + '.', 'success')
+    elif deleted:
+        flash(', '.join(parts) + '.', 'warning')
+    else:
+        flash(', '.join(parts) + '.', 'danger')
     return redirect(url_for('hashfiles.hashfiles_list'))
 
 

--- a/hashview/templates/hashfiles.html.j2
+++ b/hashview/templates/hashfiles.html.j2
@@ -5,6 +5,14 @@
 <style>
 .hv-dl-opt { transition: border-color .15s, background .15s; }
 .hv-dl-opt:hover { border-color: var(--primary-dim); background: rgba(var(--primary-rgb), 0.06); }
+/* bulk-select bar — appears once ≥1 selectable row is checked */
+.hf-bulkbar { display:none; align-items:center; gap:12px; margin:0 16px 14px; padding:11px 16px;
+    border:1px solid var(--primary-dim); border-radius:10px; background:rgba(var(--primary-rgb),0.07); box-shadow:var(--glow-sm); }
+.hf-bulkbar.on { display:flex; }
+.hf-sel-count { color:var(--primary); text-shadow:var(--glow-text); font-family:var(--mono); font-size:13px; letter-spacing:.3px; }
+.hf-lock { color:var(--text-mute); display:inline-flex; }
+.hf-bulk-row { display:flex; align-items:center; gap:10px; padding:7px 0; border-bottom:1px solid var(--border-soft); }
+.hf-bulk-row:last-child { border-bottom:none; }
 </style>
 
 <div class="page-head">
@@ -37,9 +45,16 @@
         <input type="text" id="hf-filter" class="input" style="width:260px; flex:none;" placeholder="filter by hashfile or customer…" autocomplete="off" oninput="hvFilterHashfiles(this.value)">
     </div>
     {% if hashfiles %}
+    <div class="hf-bulkbar" id="hf-bulkbar">
+        <span class="hf-sel-count"><span id="hf-sel-count">0</span> selected</span>
+        <span style="flex:1;"></span>
+        <button type="button" class="btn" onclick="hvHfClearSel()">Clear</button>
+        <button type="button" class="btn btn-danger" onclick="hvHfOpenBulkDel()">{{ icon('trash', size=15) }} Delete selected</button>
+    </div>
     <table class="tbl">
         <thead>
             <tr>
+                <th style="width:34px; text-align:center;"><input type="checkbox" class="hv-check" id="hf-select-all" onclick="hvHfToggleAll(this)" title="Select all deletable hashfiles"></th>
                 <th>Hashfile</th>
                 <th class="center">Type</th>
                 <th>Customer</th>
@@ -52,11 +67,24 @@
         <tbody id="hf-tbody">
             {% for hashfile in hashfiles %}
             {% set st = hashfile_stats.get(hashfile.id) if hashfile_stats is defined else none %}
+            {% set in_job = hashfile_jobs.get(hashfile.id) if hashfile_jobs is defined else none %}
             <tr data-name="{{ hashfile.name|lower }}{% for c in customers %}{% if c.id == hashfile.customer_id %} {{ c.name|lower }}{% endif %}{% endfor %}">
+                <td class="center">
+                    {% if in_job %}
+                    <span class="hf-lock" title="In a job — remove the job before deleting">{{ icon('lock', size=15) }}</span>
+                    {% else %}
+                    <input type="checkbox" class="hv-check hf-check" value="{{ hashfile.id }}"
+                           data-name="{{ hashfile.name }}"
+                           data-customer="{% for c in customers %}{% if c.id == hashfile.customer_id %}{{ c.name }}{% endif %}{% endfor %}"
+                           data-recovered="{{ st.cracked if st else 0 }}"
+                           onchange="hvHfSelChanged()">
+                    {% endif %}
+                </td>
                 <td style="font-weight:500;">
                     <span style="display:inline-flex; align-items:center; gap:9px;">
                         <span style="color:var(--text-mute); display:inline-flex;">{{ icon('file', size=16) }}</span>
                         {{ hashfile.name }}
+                        {% if in_job %}<span class="badge amber" style="font-size:9px;">IN JOB</span>{% endif %}
                     </span>
                 </td>
                 <td class="center"><span class="badge cyan">{{ hash_type_dict[hashfile.id] }}</span></td>
@@ -81,12 +109,16 @@
                         <button type="button" class="icon-btn" title="Download" onclick="document.getElementById('dl-{{ hashfile.id }}').showModal()">{{ icon('download', size=15) }}</button>
                         <a class="icon-btn" href="/analytics?customer_id={{hashfile.customer_id}}&hashfile_id={{hashfile.id}}" title="Analytics">{{ icon('chart', size=15) }}</a>
                         <button type="button" class="icon-btn" title="Info" onclick="document.getElementById('info-{{ hashfile.id }}').showModal()">{{ icon('info', size=15) }}</button>
+                        {% if in_job %}
+                        <span class="icon-btn" style="color:var(--text-mute); opacity:.45; cursor:not-allowed;" title="In a job — cannot be deleted">{{ icon('trash', size=15) }}</span>
+                        {% else %}
                         <button type="button" class="icon-btn act-del" style="color:var(--red); border-color:var(--red-dim);" title="Delete" onclick="document.getElementById('del-{{ hashfile.id }}').showModal()">{{ icon('trash', size=15) }}</button>
+                        {% endif %}
                     </div>
                 </td>
             </tr>
             {% endfor %}
-            <tr id="hf-no-match" style="display:none;"><td colspan="7" style="text-align:center; padding:28px 16px; color:var(--text-mute);" class="mono">No hashfiles match that filter.</td></tr>
+            <tr id="hf-no-match" style="display:none;"><td colspan="8" style="text-align:center; padding:28px 16px; color:var(--text-mute);" class="mono">No hashfiles match that filter.</td></tr>
         </tbody>
     </table>
     {% else %}
@@ -107,6 +139,62 @@ function hvFilterHashfiles(q){
     });
     var none = document.getElementById('hf-no-match');
     if (none) none.style.display = shown === 0 ? '' : 'none';
+}
+
+// ---- bulk selection + bulk delete -------------------------------------------
+var HF_FILE_ICON = '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:var(--text-mute); flex:none;"><path d="M14 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8z"/><path d="M14 3v5h5"/></svg>';
+
+function hvHfSelected(){
+    return Array.prototype.slice.call(document.querySelectorAll('.hf-check:checked'));
+}
+function hvHfSelChanged(){
+    var n = hvHfSelected().length;
+    var all = document.querySelectorAll('.hf-check').length;
+    var cEl = document.getElementById('hf-sel-count'); if (cEl) cEl.textContent = n;
+    var bar = document.getElementById('hf-bulkbar'); if (bar) bar.classList.toggle('on', n > 0);
+    var sa = document.getElementById('hf-select-all');
+    if (sa) { sa.checked = n > 0 && n === all; sa.indeterminate = n > 0 && n < all; }
+}
+function hvHfToggleAll(cb){
+    document.querySelectorAll('.hf-check').forEach(function(c){ c.checked = cb.checked; });
+    hvHfSelChanged();
+}
+function hvHfClearSel(){
+    document.querySelectorAll('.hf-check').forEach(function(c){ c.checked = false; });
+    hvHfSelChanged();
+}
+function hvHfOpenBulkDel(){
+    var sel = hvHfSelected();
+    if (!sel.length) return;
+    var list = document.getElementById('hf-bulk-list');
+    var hidden = document.getElementById('hf-bulk-hidden');
+    list.innerHTML = ''; hidden.innerHTML = '';
+    sel.forEach(function(c){
+        var row = document.createElement('div');
+        row.className = 'hf-bulk-row';
+        var ico = document.createElement('span');
+        ico.style.cssText = 'display:inline-flex; flex:none;';
+        ico.innerHTML = HF_FILE_ICON;                 // static markup, safe
+        var name = document.createElement('span');
+        name.className = 'mono'; name.style.color = 'var(--text)';
+        name.textContent = c.getAttribute('data-name') || '';   // textContent — XSS-safe
+        var meta = document.createElement('span');
+        meta.style.color = 'var(--text-mute)';
+        var cust = c.getAttribute('data-customer') || '';
+        var rec = c.getAttribute('data-recovered') || '0';
+        meta.textContent = (cust ? ' · ' + cust : '') + ' · ' + rec + ' recovered';
+        row.appendChild(ico); row.appendChild(name); row.appendChild(meta);
+        list.appendChild(row);
+        var inp = document.createElement('input');
+        inp.type = 'hidden'; inp.name = 'hashfile_ids'; inp.value = c.value;
+        hidden.appendChild(inp);
+    });
+    var n = sel.length;
+    document.getElementById('hf-bulk-title').textContent =
+        'Delete ' + n + ' hashfile' + (n === 1 ? '' : 's') + '?';
+    document.getElementById('hf-bulk-btn-count').textContent = n;
+    var m = document.getElementById('hf-bulk-del-modal');
+    try { m.showModal(); } catch (e) { m.setAttribute('open', ''); }
 }
 </script>
 
@@ -211,5 +299,28 @@ function hvFilterHashfiles(q){
     </div>
 </dialog>
 {% endfor %}
+
+{# ---- bulk-delete confirmation (one modal for the whole selected set) ---- #}
+<dialog class="hv-dialog" id="hf-bulk-del-modal" style="max-width:620px; width:94vw;">
+    <div class="hv-dialog-head">
+        <span style="color:var(--red); display:inline-flex;">{{ icon('trash', size=16) }}</span>
+        <div style="line-height:1.2;">
+            <h3 style="margin:0;" id="hf-bulk-title">Delete hashfiles?</h3>
+            <div class="mono" style="font-size:10px; letter-spacing:0.5px; text-transform:uppercase; color:var(--text-mute); margin-top:3px;">this permanently removes the hashfiles and their recovered plaintext</div>
+        </div>
+        <button class="icon-btn" onclick="this.closest('dialog').close()" aria-label="Close" style="margin-left:auto;">{{ icon('x', size=15) }}</button>
+    </div>
+    <div class="hv-dialog-body" style="max-height:52vh; overflow-y:auto;">
+        <div class="mono" style="font-size:11px; color:var(--text-mute); margin-bottom:10px;">The following will be permanently deleted:</div>
+        <div id="hf-bulk-list"></div>
+    </div>
+    <div class="hv-dialog-foot">
+        <button class="btn" onclick="this.closest('dialog').close()">Cancel</button>
+        <form id="hf-bulk-form" action="{{ url_for('hashfiles.hashfiles_bulk_delete') }}" method="POST" style="display:inline;">
+            <span id="hf-bulk-hidden"></span>
+            <button type="submit" class="btn btn-danger">{{ icon('trash', size=15) }} Delete <span id="hf-bulk-btn-count">0</span></button>
+        </form>
+    </div>
+</dialog>
 
 {% endblock content %}

--- a/hashview/templates/icons.html.j2
+++ b/hashview/templates/icons.html.j2
@@ -44,6 +44,7 @@
   'hash':   '<path d="M9 4 7 20M17 4l-2 16M4 9h16M3 15h16"/>',
   'power':  '<path d="M12 4v8"/><path d="M7.5 7a7 7 0 1 0 9 0"/>',
   'list':   '<path d="M8 6h13M8 12h13M8 18h13M3 6h.01M3 12h.01M3 18h.01"/>',
+  'lock':   '<rect x="3" y="11" width="18" height="11" rx="2" ry="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/>',
   'chevR':  '<path d="m9 6 6 6-6 6"/>',
   'play':   '<path d="M7 4v16l13-8z"/>',
   'edit':   '<path d="M12 20h9"/><path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4z"/>',

--- a/tests/unit/test_hashfile_cascade.py
+++ b/tests/unit/test_hashfile_cascade.py
@@ -19,6 +19,7 @@ from hashview.models import (
     HashfileHashes,
     Hashes,
     Hashfiles,
+    Jobs,
     Users,
     db,
 )
@@ -35,6 +36,14 @@ def _make_admin():
     db.session.add(admin)
     db.session.commit()
     return admin
+
+
+def _make_user(email="user@example.com"):
+    u = Users(first_name="U", last_name="U", email_address=email,
+              password="x" * 60, admin=False)
+    db.session.add(u)
+    db.session.commit()
+    return u
 
 
 def _make_customer():
@@ -112,3 +121,93 @@ def test_hashfile_delete_keeps_shared_hash_and_cracked_hash(app, client):
 
     # The orphan uncracked hash that A solely owned should be pruned.
     assert Hashes.query.get(only_a_id) is None
+
+
+# ---------------------------------------------------------------------------
+# Bulk delete (issue #311)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.security
+def test_bulk_delete_deletes_free_and_skips_in_job(app, client):
+    """Free hashfiles are deleted; one attached to a job is skipped, and the
+    flash reports a per-outcome summary (batch not aborted on the skip)."""
+    admin = _make_admin()
+    cust = _make_customer()
+    free = Hashfiles(name="free", customer_id=cust.id, owner_id=admin.id)
+    locked = Hashfiles(name="locked", customer_id=cust.id, owner_id=admin.id)
+    db.session.add_all([free, locked])
+    db.session.commit()
+    db.session.add(Jobs(name="j", status="Running", customer_id=cust.id,
+                        owner_id=admin.id, hashfile_id=locked.id))
+    db.session.commit()
+    free_id, locked_id = free.id, locked.id
+
+    _login(client, admin.id)
+    resp = client.post("/hashfiles/bulk_delete",
+                       data={"hashfile_ids": [str(free_id), str(locked_id)]},
+                       follow_redirects=True)
+    assert resp.status_code == 200
+    assert b"1 deleted" in resp.data
+    assert b"associated with a job" in resp.data
+    assert Hashfiles.query.get(free_id) is None          # free deleted
+    assert Hashfiles.query.get(locked_id) is not None    # in-job retained
+
+
+@pytest.mark.security
+def test_bulk_delete_reuses_cascade(app, client):
+    """Bulk delete applies the same cascade as single delete: orphaned uncracked
+    hashes pruned, cracked hashes retained."""
+    admin = _make_admin()
+    cust = _make_customer()
+    hf = Hashfiles(name="bulk", customer_id=cust.id, owner_id=admin.id)
+    db.session.add(hf)
+    db.session.commit()
+    unc = Hashes(sub_ciphertext="0" * 32, ciphertext="a", hash_type=0, cracked=False)
+    crk = Hashes(sub_ciphertext="1" * 32, ciphertext="b", hash_type=0,
+                 cracked=True, plaintext="70617373")
+    db.session.add_all([unc, crk])
+    db.session.commit()
+    db.session.add_all([
+        HashfileHashes(hashfile_id=hf.id, hash_id=unc.id),
+        HashfileHashes(hashfile_id=hf.id, hash_id=crk.id),
+    ])
+    db.session.commit()
+    hf_id, unc_id, crk_id = hf.id, unc.id, crk.id
+
+    _login(client, admin.id)
+    resp = client.post("/hashfiles/bulk_delete",
+                       data={"hashfile_ids": [str(hf_id)]}, follow_redirects=True)
+    assert resp.status_code == 200
+    assert Hashfiles.query.get(hf_id) is None
+    assert Hashes.query.get(unc_id) is None       # orphaned uncracked pruned
+    assert Hashes.query.get(crk_id) is not None    # cracked retained
+
+
+@pytest.mark.security
+def test_bulk_delete_skips_non_owned(app, client):
+    """A non-admin cannot bulk-delete a hashfile they don't own."""
+    admin = _make_admin()
+    cust = _make_customer()
+    other = _make_user("other@example.com")
+    hf = Hashfiles(name="admins", customer_id=cust.id, owner_id=admin.id)
+    db.session.add(hf)
+    db.session.commit()
+    hf_id = hf.id
+
+    _login(client, other.id)
+    resp = client.post("/hashfiles/bulk_delete",
+                       data={"hashfile_ids": [str(hf_id)]}, follow_redirects=True)
+    assert resp.status_code == 200
+    assert b"insufficient rights" in resp.data
+    assert Hashfiles.query.get(hf_id) is not None
+
+
+@pytest.mark.security
+def test_bulk_delete_empty_selection(app, client):
+    """Posting no ids reports nothing to do rather than erroring."""
+    admin = _make_admin()
+    _login(client, admin.id)
+    resp = client.post("/hashfiles/bulk_delete", data={}, follow_redirects=True)
+    assert resp.status_code == 200
+    assert b"No hashfiles selected" in resp.data


### PR DESCRIPTION
…ue #311)

Adds interactive multi-select deletion to the hashfiles table, per the design mockups:

- Left column: a checkbox for deletable hashfiles, a padlock for any that are a member of a job (not selectable); plus a select-all header checkbox (indeterminate-aware). In-job rows also show an "IN JOB" pill and a dimmed (non-actionable) per-row trash.
- A phosphor selection bar appears once >=1 row is checked: "N selected" with Clear and Delete selected buttons.
- Delete selected opens a single confirmation modal listing each file (name / customer / recovered count); the list is built via textContent so a hostile hashfile name can't inject markup.

Backend: extract the delete cascade into a shared _cascade_delete_hashfile() helper (single-file hashfiles_delete now calls it, behavior unchanged) and add POST /hashfiles/bulk_delete. The bulk handler applies the SAME per-file rules to each id — ownership (admin or owner), refuse-if-associated-with-a-job, and the shared cascade (HashfileHashes -> Hashfiles -> orphaned uncracked Hashes -> HashNotifications) with log_event per file. A skip/failure does not abort the batch; the flash reports a per-outcome summary.

Adds a `lock` icon. Tests: 5 bulk-delete cases (free/in-job mix, shared cascade, non-owner skip, empty selection) in test_hashfile_cascade.py; full suite 1290.