### PR TITLE
fix(agent): make HTTP/API layer robust to non-200 / unexpected respon…

### DIFF
--- a/install/hashview-agent/agent/api/api.py
+++ b/install/hashview-agent/agent/api/api.py
@@ -1,6 +1,59 @@
 import json
+import logging
 
 from agent.http import http
+
+LOG = logging.getLogger('hashview-agent')
+
+_UPGRADE_MSG = ('Our agent version is older than the servers. You need to '
+                'upgrade your agent before continuing.')
+
+
+def _load(response, endpoint):
+    """Parse an HTTP-layer response into JSON, guarding the failure modes that
+    used to surface as opaque TypeErrors.
+
+    Returns the decoded object, or None when the server sent no body (the HTTP
+    layer returns None on a non-200 / connection failure, e.g. mid-reboot) or a
+    non-JSON body. When the decoded body carries the in-band status==426 upgrade
+    signal, exit -- the agent is too old to keep talking to this server.
+    """
+    if response is None:
+        LOG.warning('%s: no response from server (non-200 or connection failure).', endpoint)
+        return None
+    try:
+        decoded = json.loads(response)
+    except (TypeError, ValueError) as err:
+        LOG.warning('%s: could not parse server response (%s).', endpoint, err)
+        return None
+    if isinstance(decoded, dict) and decoded.get('status') == 426:
+        print('[ERROR] ' + _UPGRADE_MSG)
+        exit()
+    return decoded
+
+
+def _extract(response, endpoint, key, reparse=False):
+    """Pull a single payload key out of a decoded response.
+
+    Guards a missing key / wrong shape -- e.g. an authorized-but-Error reply that
+    the server returns as HTTP 200 with an {'type':'Error',...} body and no data
+    key. Returns the value, or None. reparse=True re-decodes the values the
+    server double-encodes as JSON strings (job_task / job / task).
+    """
+    decoded = _load(response, endpoint)
+    if decoded is None:
+        return None
+    if not isinstance(decoded, dict) or key not in decoded:
+        LOG.warning('%s: unexpected response shape (missing %r).', endpoint, key)
+        return None
+    value = decoded[key]
+    if reparse:
+        try:
+            return json.loads(value)
+        except (TypeError, ValueError) as err:
+            LOG.warning('%s: could not parse the %r payload (%s).', endpoint, key, err)
+            return None
+    return value
 
 
 def heartbeat(agent_status, hc_status):
@@ -10,21 +63,15 @@ def heartbeat(agent_status, hc_status):
     }
 
     response = http.post('/v1/agents/heartbeat', json.loads(json.dumps(message)))
-    try:
-        decoded_response = json.loads(response)
-    except (TypeError, ValueError):
+    decoded_response = _load(response, 'heartbeat')
+    if decoded_response is None:
         # response is None (server returned a non-200, e.g. it was mid-reboot) or
         # not JSON. Treat this beat as a no-op: keep the current work and retry on
         # the next cycle instead of crashing the agent loop.
         return {'type': 'message', 'status': 200, 'msg': None}
-    if decoded_response['type'] == 'message' and decoded_response['status'] == 200:
+    if decoded_response.get('type') == 'message' and decoded_response.get('status') == 200:
         return decoded_response
-    elif decoded_response['type'] == 'message' and decoded_response['status'] == 426:
-        print('Our agent version is older than the servers. You need to upgrade your agent before continuing.')
-        exit()
-    else:
-        print('we got an unexpected response type')
-        print(str(decoded_response['type']))
+    LOG.warning('heartbeat: unexpected response type %s.', decoded_response.get('type'))
 
 def report_benchmark(benchmark_results):
     message = {
@@ -32,87 +79,52 @@ def report_benchmark(benchmark_results):
     }
 
     response = http.post('/v1/agents/benchmark', json.loads(json.dumps(message)))
-    decoded_response = json.loads(response)
-    if decoded_response['type'] == 'message' and decoded_response['status'] == 200:
+    decoded_response = _load(response, 'report_benchmark')
+    if decoded_response is None:
+        return None
+    if decoded_response.get('type') == 'message' and decoded_response.get('status') == 200:
         return decoded_response
-    elif decoded_response['type'] == 'message' and decoded_response['status'] == 426:
-        print('Our agent version is older than the servers. You need to upgrade your agent before continuing.')
-        exit()
-    else:
-        print('we got an unexpected response type')
-        return decoded_response
+    LOG.warning('report_benchmark: unexpected response type %s.', decoded_response.get('type'))
+    return decoded_response
 
 def server_settings():
     response = http.get('/v1/admin/settings')
-    if(json.loads(response)['status'] == 426):
-        print('[ERROR] Our agent version is older than the servers. You need to upgrade your agent before continuing.')
-        exit()
-    else:
-        decoded_response = json.loads(response)['settings']
-        return decoded_response
+    return _extract(response, 'server_settings', 'settings')
 
 def rules_list():
-    response =  http.get('/v1/rules')
-    if(json.loads(response)['status'] == 426):
-        print('[ERROR] Our agent version is older than the servers. You need to upgrade your agent before continuing.')
-        exit()
-    else:
-        decoded_response = json.loads(response)['rules']
-        return decoded_response
+    response = http.get('/v1/rules')
+    return _extract(response, 'rules_list', 'rules')
 
 def get_rules_file(rules_id):
     return http.get('/v1/rules/' + str(rules_id))
 
 def getWordlists():
-    response =  http.get('/v1/wordlists')
-    if(json.loads(response)['status'] == 426):
-        print('[ERROR] Our agent version is older than the servers. You need to upgrade your agent before continuing.')
-        exit()
-    else:    
-        decoded_response = json.loads(response)['wordlists']
-        return decoded_response
+    response = http.get('/v1/wordlists')
+    return _extract(response, 'getWordlists', 'wordlists')
 
 def get_wordlists_file(wordlist_id):
     return http.get('/v1/wordlists/' + str(wordlist_id))
 
 def jobTasks(job_task_id):
     response = http.get('/v1/jobTasks/' + str(job_task_id))
-    if(json.loads(response)['status'] == 426):
-        print('[ERROR] Our agent version is older than the servers. You need to upgrade your agent before continuing.')
-        exit()
-    else:    
-        decoded_response = json.loads(json.loads(response)['job_task'])
-        return decoded_response
+    return _extract(response, 'jobTasks', 'job_task', reparse=True)
 
 def jobs(job_id):
     response = http.get('/v1/jobs/' + str(job_id))
-    if(json.loads(response)['status'] == 426):
-        print('[ERROR] Our agent version is older than the servers. You need to upgrade your agent before continuing.')
-        exit()
-    else:    
-        decoded_response = json.loads(json.loads(response)['job'])
-        return decoded_response
+    return _extract(response, 'jobs', 'job', reparse=True)
 
 def tasks(task_id):
     response = http.get('/v1/tasks/' + str(task_id))
-    if(json.loads(response)['status'] == 426):
-        print('[ERROR] Our agent version is older than the servers. You need to upgrade your agent before continuing.')
-        exit()
-    else:    
-        decoded_response = json.loads(json.loads(response)['task'])
-        return decoded_response
+    return _extract(response, 'tasks', 'task', reparse=True)
 
 def updateDynamicWordlists(wordlist_id):
     response = http.get('/v1/updateWordlist/' + str(wordlist_id))
-    decoded_response = json.loads(response)
-    if decoded_response['type'] == 'message' and decoded_response['status'] == 200:
+    decoded_response = _load(response, 'updateDynamicWordlists')
+    if decoded_response is None:
+        return None
+    if decoded_response.get('type') == 'message' and decoded_response.get('status') == 200:
         return decoded_response
-    elif decoded_response['type'] == 'message' and decoded_response['status'] == 426:
-        print('Our agent version is older than the servers. You need to upgrade your agent before continuing.')
-        exit()
-    else:
-        print('we got an unexpected response type')
-        print(str(decoded_response['type']))    
+    LOG.warning('updateDynamicWordlists: unexpected response type %s.', decoded_response.get('type'))
 
 def get_hashfile(hashfile_id):
     return http.get('/v1/hashfiles/' + str(hashfile_id))
@@ -123,30 +135,24 @@ def uploadCrackFile(file_path, job_task_id):
     # so decode tolerantly (errors='replace') instead of crashing the whole upload
     # on one stray byte and silently dropping every recovered crack in the file.
     with open(file_path, encoding='utf-8', errors='replace') as file:
-    # we use jobtask to determin hashtype server side. 
+    # we use jobtask to determin hashtype server side.
         #response =  http.post('/v1/uploadCrackFile/' + str(task_id) + "/" + str(hash_type), data={'file': file.read()})
         response = http.post('/v1/uploadCrackFile/' + str(job_task_id), data = {'file': file.read()})
-        decoded_response = json.loads(response)
-        if decoded_response['type'] == 'message' and decoded_response['status'] == 200:
+        decoded_response = _load(response, 'uploadCrackFile')
+        if decoded_response is None:
+            return None
+        if decoded_response.get('type') == 'message' and decoded_response.get('status') == 200:
             return decoded_response
-        elif decoded_response['type'] == 'message' and decoded_response['status'] == 426:
-            print('Our agent version is older than the servers. You need to upgrade your agent before continuing.')
-            exit()
-        else:
-            print('we got an unexpected response type')
-            print(str(decoded_response['type']))
+        LOG.warning('uploadCrackFile: unexpected response type %s.', decoded_response.get('type'))
 
 def getHashType(hashfile_id):
     response = http.get('/v1/getHashType/' + str(hashfile_id))
-    decoded_response = json.loads(response)
-    if decoded_response['type'] == 'message' and decoded_response['status'] == 200:
+    decoded_response = _load(response, 'getHashType')
+    if decoded_response is None:
+        return None
+    if decoded_response.get('type') == 'message' and decoded_response.get('status') == 200:
         return decoded_response
-    elif decoded_response['type'] == 'message' and decoded_response['status'] == 426:
-        print('Our agent version is older than the servers. You need to upgrade your agent before continuing.')
-        exit()
-    else:
-        print('we got an unexpected response type')
-        print(str(decoded_response['type']))
+    LOG.warning('getHashType: unexpected response type %s.', decoded_response.get('type'))
 
 def updateJobTask(job_task_id, task_status):
     message = {
@@ -155,31 +161,25 @@ def updateJobTask(job_task_id, task_status):
     }
 
     response = http.post('/v1/jobtask/status', json.loads(json.dumps(message)))
-    decoded_response = json.loads(response)
-    if decoded_response['type'] == 'message' and decoded_response['status'] == 200:
+    decoded_response = _load(response, 'updateJobTask')
+    if decoded_response is None:
+        return None
+    if decoded_response.get('type') == 'message' and decoded_response.get('status') == 200:
         return decoded_response
-    elif decoded_response['type'] == 'message' and decoded_response['status'] == 426:
-        print('Our agent version is older than the servers. You need to upgrade your agent before continuing.')
-        exit()
-    else:
-        print('We got an unexpected response type or status code.')
-        print('Type: ' + str(decoded_response['type']))
-        print('Code: ' + str(decoded_response['status']))
-        return decoded_response
+    LOG.warning('updateJobTask: unexpected response type %s / status %s.',
+                decoded_response.get('type'), decoded_response.get('status'))
+    return decoded_response
 
 def sendError(error_message):
     message = {
             'error': error_message
     }
     response = http.post('/v1/error', json.loads(json.dumps(message)))
-    decoded_response = json.loads(response)
-    if decoded_response['type'] == 'message' and decoded_response['status'] == 200:
+    decoded_response = _load(response, 'sendError')
+    if decoded_response is None:
+        return None
+    if decoded_response.get('type') == 'message' and decoded_response.get('status') == 200:
         return decoded_response
-    elif decoded_response['type'] == 'message' and decoded_response['status'] == 426:
-        print('Our agent version is older than the servers. You need to upgrade your agent before continuing.')
-        exit()
-    else:
-        print('We got an unexpected response type or status code.')
-        print('Type: ' + str(decoded_response['type']))
-        print('Code: ' + str(decoded_response['status']))
-        return decoded_response
+    LOG.warning('sendError: unexpected response type %s / status %s.',
+                decoded_response.get('type'), decoded_response.get('status'))
+    return decoded_response

--- a/install/hashview-agent/agent/config.py
+++ b/install/hashview-agent/agent/config.py
@@ -1,18 +1,41 @@
+import sys
 from configparser import ConfigParser
+
+_CONFIG_PATH = 'agent/config.conf'
 file_config = ConfigParser()
 
+
+def _die(msg):
+    """A bad config is fatal at startup -- the agent has no server address or
+    identity to run with -- so surface one actionable message and exit instead of
+    letting a bare KeyError escape from the class body below."""
+    print('[ERROR] ' + msg)
+    sys.exit(1)
+
+
+def _require(section, key):
+    try:
+        return file_config[section][key]
+    except KeyError:
+        _die("%s is missing required key '%s' in section [%s]. "
+             "Re-run the agent setup or fix the file." % (_CONFIG_PATH, key, section))
+
+
 class Config:
-    file_config.read('agent/config.conf')
+    # ConfigParser.read() silently returns [] for a missing/unreadable file, which
+    # would otherwise surface later as an opaque KeyError on the first key access.
+    if not file_config.read(_CONFIG_PATH):
+        _die("%s not found or unreadable. Run the agent once to generate it." % _CONFIG_PATH)
 
     # Server info
-    HASHVIEW_SERVER = file_config['HASHVIEW']['server']
-    HASHVIEW_PORT = file_config['HASHVIEW']['port']
-    USE_SSL = file_config['HASHVIEW']['use_ssl']
+    HASHVIEW_SERVER = _require('HASHVIEW', 'server')
+    HASHVIEW_PORT = _require('HASHVIEW', 'port')
+    USE_SSL = _require('HASHVIEW', 'use_ssl')
 
     # Agent Info
-    NAME = file_config['AGENT']['NAME']
-    UUID = file_config['AGENT']['UUID']
-    HC_BIN_PATH = file_config['AGENT']['HC_BIN_PATH']
+    NAME = _require('AGENT', 'NAME')
+    UUID = _require('AGENT', 'UUID')
+    HC_BIN_PATH = _require('AGENT', 'HC_BIN_PATH')
     # Optional host-specific hashcat args (e.g. '-d 3,4' to pin GPUs); applied to
     # both cracking and benchmarking. Absent in older configs -> '' (no args).
     HC_EXTRA_ARGS = file_config['AGENT'].get('HC_EXTRA_ARGS', '')

--- a/install/hashview-agent/agent/http/http.py
+++ b/install/hashview-agent/agent/http/http.py
@@ -1,10 +1,15 @@
 import requests
 import json
+import logging
 from agent.config import Config
 # to supress SSL Error messages
 import urllib3
 import builtins
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+# Share the agent's logger so transport-layer diagnostics land in the same stream
+# as the rest of the agent instead of bare prints.
+LOG = logging.getLogger('hashview-agent')
 
 from requests.packages.urllib3.util.retry import Retry
 from requests.adapters import HTTPAdapter
@@ -60,11 +65,19 @@ def get(url):
         print('[DEBUG] http.py->GET: ' + path)
         print('[DEBUG] http.py->GET: ' + str(cookie))
 
-    response = http.get(path, verify=False, cookies=cookie)
+    # A connection-level failure (refused/timeout/TLS/too many redirects) must not
+    # bubble a raw exception up to callers that expect a body-or-None. Log it and
+    # return None so the caller degrades gracefully and retries next cycle.
+    try:
+        response = http.get(path, verify=False, cookies=cookie)
+    except requests.exceptions.RequestException as err:
+        LOG.warning('GET %s failed: %s', path, err)
+        return None
     if response.status_code == 200:
         return response.content
-    else:
-        print('[!] HTTP POST (response): Got an unexpected return code:' + str(response.status_code))
+    LOG.warning('GET %s returned HTTP %s: %s',
+                path, response.status_code, response.text[:200])
+    return None
 
 def post(url, data):
     path = _scheme()
@@ -85,9 +98,13 @@ def post(url, data):
         print('[DEBUG] http.py->POST: ' + str(data))
         print('[DEBUG] http.py->POST: ' + str(cookie))
 
-    # put in try/catch statement for timeouts etc.
-    response = http.post(path, data=json.dumps(data), verify=False, cookies=cookie, headers=headers)
+    try:
+        response = http.post(path, data=json.dumps(data), verify=False, cookies=cookie, headers=headers)
+    except requests.exceptions.RequestException as err:
+        LOG.warning('POST %s failed: %s', path, err)
+        return None
     if response.status_code == 200:
         return response.text
-    else:
-        print('[!] HTTP POST (response): Got an unexpected return code:' + str(response.status_code))
+    LOG.warning('POST %s returned HTTP %s: %s',
+                path, response.status_code, response.text[:200])
+    return None

--- a/install/hashview-agent/hashview-agent.py
+++ b/install/hashview-agent/hashview-agent.py
@@ -196,6 +196,9 @@ def sync_rules():
                 # Download and verify new file
                 random_hex = secrets.token_hex(8)
                 compressed = api.get_rules_file(entry['id'])
+                if not compressed:
+                    LOG.warning('No data received for rule %s; will retry next sync.', rule_id)
+                    continue
                 tmp_gz = os.path.join('control/tmp', f'{random_hex}.gz')
                 with open(tmp_gz, 'wb') as f:
                     f.write(compressed)
@@ -224,6 +227,9 @@ def sync_rules():
             LOG.info('Downloading new rule %s.', rule_id)
             random_hex = secrets.token_hex(8)
             compressed = api.get_rules_file(entry['id'])
+            if not compressed:
+                LOG.warning('No data received for new rule %s; will retry next sync.', rule_id)
+                continue
             tmp_gz = os.path.join('control/tmp', f'{random_hex}.gz')
             with open(tmp_gz, 'wb') as f:
                 f.write(compressed)
@@ -429,9 +435,16 @@ def updateDynamicWordlists(wordlist_id):
 def download_hashfile(job_id, jobtask_id, hashfile_id):
     # Note we are not compressing our hashfile
     hashfile_content = api.get_hashfile(hashfile_id)
-    hashfile = open('control/hashes/hashfile_' + str(job_id) + '_' + str(jobtask_id) + '.txt', 'wb')
-    hashfile.write(hashfile_content)
-    hashfile.close()
+    if not hashfile_content:
+        # A non-200 / missing hashfile yields None; writing that straight to disk
+        # would raise. Report False so the caller skips launching hashcat against a
+        # missing target rather than crashing the cycle.
+        LOG.warning('No hashfile received for hashfile %s (job %s); skipping this task run.',
+                    hashfile_id, job_id)
+        return False
+    with open('control/hashes/hashfile_' + str(job_id) + '_' + str(jobtask_id) + '.txt', 'wb') as hashfile:
+        hashfile.write(hashfile_content)
+    return True
 
 def build_hashcat_argv(command):
     """Decode the server's stored command (a JSON argv list) into a real argv.
@@ -666,7 +679,8 @@ def maybe_update_dynamic_wordlist(task):
     for wordlist in server_wordlists:
         if wordlist['id'] == task['wl_id'] and wordlist['type'] == 'dynamic':
             LOG.info('Task uses a dynamic wordlist; requesting a server-side update.')
-            if updateDynamicWordlists(wordlist['id'])['msg'] != 'OK':
+            result = updateDynamicWordlists(wordlist['id'])
+            if not result or result.get('msg') != 'OK':
                 LOG.warning('Dynamic wordlist update failed for wordlist %s.', wordlist['id'])
             else:
                 LOG.info('Dynamic wordlist update complete.')
@@ -683,9 +697,13 @@ def upload_cracks(job, job_task):
     if not os.path.exists(crack_file):
         LOG.debug('No results yet for job task %s; nothing to upload.', job_task['id'])
         return
-    if getHashType(job['hashfile_id'])['msg'] != 'OK':
+    hash_type = getHashType(job['hashfile_id'])
+    if not hash_type or hash_type.get('msg') != 'OK':
+        LOG.warning('Could not confirm the hash type for job task %s; deferring crack upload.',
+                    job_task['id'])
         return
-    if uploadCrackFile(crack_file, str(job_task['id']))['msg'] == 'OK':
+    result = uploadCrackFile(crack_file, str(job_task['id']))
+    if result and result.get('msg') == 'OK':
         LOG.info('Uploaded recovered hashes to the server.')
 
 
@@ -727,17 +745,32 @@ def run_assigned_task(job_task_id):
     sync_rules()
     sync_wordlists()
 
+    # Any of these fetches can return None (server mid-restart, missing row,
+    # unexpected body). Bail with a clear message instead of crashing on a None
+    # subscript; the server keeps the task assigned and its runtime reaper (or a
+    # later reassignment) recovers it. We deliberately do NOT reset the status
+    # here -- a persistent failure (e.g. a genuinely missing hashfile) would then
+    # re-dispatch in a hot loop.
     job_task = jobTasks(job_task_id)
+    if not job_task:
+        LOG.warning('Could not fetch job task %s; skipping this run.', job_task_id)
+        return
+    task = tasks(job_task['task_id'])
+    job = jobs(job_task['job_id'])
+    if not task or not job:
+        LOG.warning('Could not fetch the task/job for job task %s; skipping this run.', job_task_id)
+        return
+
     # Defensive: the server occasionally misses flipping this to Running.
     updateJobTask(job_task['id'], 'Running')
-    maybe_update_dynamic_wordlist(tasks(job_task['task_id']))
+    maybe_update_dynamic_wordlist(task)
 
-    job = jobs(job_task['job_id'])
     # Name the hashfile to match the server-built command's target file: chunks
     # are keyed by JobTask id (so chunks of one task never collide); whole tasks
     # keep the legacy job+task id naming so existing agents stay compatible.
     file_key = job_task['id'] if job_task.get('chunk_total') else job_task['task_id']
-    download_hashfile(job['id'], file_key, job['hashfile_id'])
+    if not download_hashfile(job['id'], file_key, job['hashfile_id']):
+        return
 
     output_file = ('control/outfiles/hcoutput_'
                    + str(job['id']) + '_' + str(job_task['id']) + '.txt')
@@ -753,7 +786,8 @@ def run_assigned_task(job_task_id):
 
     upload_cracks(job, job_task)
 
-    if updateJobTask(job_task['id'], 'Completed')['msg'] == 'OK':
+    completed = updateJobTask(job_task['id'], 'Completed')
+    if completed and completed.get('msg') == 'OK':
         LOG.info('Job task %s set to Completed.', job_task['id'])
 
 
@@ -764,17 +798,21 @@ def handle_heartbeat():
         # We're not monitoring that process here, so we have no hc_status to report
         # -- send an empty one (the server skips the telemetry parse for a blank
         # value) rather than a placeholder it would fail to JSON-decode.
-        if send_heartbeat('Working', '')['msg'] == 'Canceled':
+        response = send_heartbeat('Working', '')
+        if response and response.get('msg') == 'Canceled':
             LOG.info('Server canceled the running task.')
         return
 
     response = send_heartbeat('Idle', '')
-    if response['msg'] == 'Go Away':
+    if not response:
+        # No usable reply this beat (server mid-restart / non-200); retry next cycle.
+        return
+    if response.get('msg') == 'Go Away':
         LOG.warning('This agent is not authorized on the server. Ask a Hashview admin to approve it.')
-    elif response['msg'] == 'BENCHMARK':
+    elif response.get('msg') == 'BENCHMARK':
         run_benchmark(response.get('hash_modes', []))
-    elif response['msg'] == 'START':
-        run_assigned_task(response['job_task_id'])
+    elif response.get('msg') == 'START':
+        run_assigned_task(response.get('job_task_id'))
 
 
 def main():

--- a/tests/agent_unit/test_agent_robustness.py
+++ b/tests/agent_unit/test_agent_robustness.py
@@ -1,0 +1,232 @@
+"""Regression tests for issue #280 — agent HTTP/API layer robustness.
+
+These pin the fixed behaviour so the opaque TypeErrors don't come back:
+  - http.get/post return None (not raise) on a non-200 or a connection error.
+  - api.* return None (not TypeError) on a None body, a non-JSON body, or a 200
+    reply whose shape is wrong (e.g. the server's authorized-but-Error body).
+  - the hashview-agent.py call sites tolerate a None api result.
+  - agent/config.py exits with a clear message on a missing file/section/key.
+
+The api/http tests monkeypatch at the agent.http.http boundary (the same object
+api.py bound). The main-script tests load hashview-agent.py the same way the
+issue-xfail suite does (argv/config/psutil stubbed). The config test loads the
+REAL agent/config.py by path, since conftest stubs agent.config in sys.modules.
+"""
+import builtins
+import importlib.util
+import json
+import os
+import sys
+import types
+from pathlib import Path
+from unittest import mock
+
+import pytest
+import requests
+from agent.api import api
+from agent.http import http
+
+AGENT_ROOT = Path(__file__).resolve().parents[2] / "install" / "hashview-agent"
+
+
+# ---------------------------------------------------------------------------
+# http.py — fail soft (return None), never bubble a raw exception / non-200
+# ---------------------------------------------------------------------------
+class _FakeResponse:
+    def __init__(self, status_code, text="", content=b""):
+        self.status_code = status_code
+        self.text = text
+        self.content = content
+
+
+@pytest.fixture
+def _http_env(monkeypatch):
+    # get()/post() open VERSION.TXT relative to CWD and read builtins.state.
+    monkeypatch.chdir(AGENT_ROOT)
+    monkeypatch.setattr(builtins, "state", "normal", raising=False)
+
+
+def test_http_get_returns_none_on_non_200(_http_env, monkeypatch):
+    monkeypatch.setattr(http.http, "get", lambda *a, **k: _FakeResponse(500, text="boom"))
+    assert http.get("/v1/rules") is None
+
+
+def test_http_get_returns_none_on_connection_error(_http_env, monkeypatch):
+    def boom(*a, **k):
+        raise requests.exceptions.ConnectionError("connection refused")
+    monkeypatch.setattr(http.http, "get", boom)
+    assert http.get("/v1/rules") is None
+
+
+def test_http_post_returns_none_on_non_200(_http_env, monkeypatch):
+    monkeypatch.setattr(http.http, "post", lambda *a, **k: _FakeResponse(503, text="unavailable"))
+    assert http.post("/v1/agents/heartbeat", {"agent_status": "Idle"}) is None
+
+
+def test_http_post_returns_none_on_connection_error(_http_env, monkeypatch):
+    def boom(*a, **k):
+        raise requests.exceptions.ConnectionError("connection refused")
+    monkeypatch.setattr(http.http, "post", boom)
+    assert http.post("/v1/error", {"error": "x"}) is None
+
+
+# ---------------------------------------------------------------------------
+# api.py — every function is None-safe (issue's problems A and C at the source)
+# ---------------------------------------------------------------------------
+ERROR_SHAPE_200 = json.dumps({"status": 200, "type": "Error", "msg": "not authorized"})
+
+_EXTRACT_CALLS = [
+    lambda: api.server_settings(),
+    lambda: api.rules_list(),
+    lambda: api.getWordlists(),
+    lambda: api.jobTasks(1),
+    lambda: api.jobs(1),
+    lambda: api.tasks(1),
+]
+
+
+@pytest.mark.parametrize("body", [None, "<html>500</html>", ERROR_SHAPE_200])
+def test_extract_family_returns_none_on_bad_response(monkeypatch, body):
+    # None (non-200), non-JSON, and a 200 Error-shape (missing the data key) all
+    # degrade to None instead of TypeError/KeyError.
+    monkeypatch.setattr(http, "get", lambda path: body)
+    for call in _EXTRACT_CALLS:
+        assert call() is None
+
+
+# A None body (non-200) and a non-JSON body are the #280-A crash cases: json.loads
+# on them used to TypeError. Every envelope function must now yield None instead.
+# (A 200 with a wrong *shape* is handled per-function and pinned in test_agent_api.py:
+# report_benchmark/updateJobTask/sendError return the decoded dict on that fallthrough,
+# so it is deliberately not asserted as None here.)
+@pytest.mark.parametrize("body", [None, "<html>500</html>"])
+def test_envelope_family_returns_none_on_bad_response(monkeypatch, body):
+    monkeypatch.setattr(http, "get", lambda path: body)
+    monkeypatch.setattr(http, "post", lambda path, data: body)
+    assert api.report_benchmark({}) is None
+    assert api.updateJobTask(1, "Running") is None
+    assert api.sendError("x") is None
+    assert api.getHashType(1) is None
+    assert api.updateDynamicWordlists(1) is None
+
+
+@pytest.mark.parametrize("body", [None, "<html>500</html>"])
+def test_heartbeat_returns_safe_sentinel_on_bad_response(monkeypatch, body):
+    # heartbeat is special: it returns a no-op dict (not None) so handle_heartbeat
+    # can read ['msg'] and simply find nothing to do this beat.
+    monkeypatch.setattr(http, "post", lambda path, data: body)
+    assert api.heartbeat("Idle", "") == {"type": "message", "status": 200, "msg": None}
+
+
+def test_uploadcrackfile_returns_none_on_bad_response(monkeypatch, tmp_path):
+    crack = tmp_path / "cracks.txt"
+    crack.write_text("hash:plain\n")
+    monkeypatch.setattr(http, "post", lambda path, data: None)
+    assert api.uploadCrackFile(str(crack), 11) is None
+
+
+# ---------------------------------------------------------------------------
+# hashview-agent.py call sites — tolerate a None api result (problem C)
+# ---------------------------------------------------------------------------
+def _load_agent_main():
+    if "psutil" not in sys.modules:
+        stub = types.ModuleType("psutil")
+
+        class _PsutilError(Exception):
+            pass
+
+        stub.Error = _PsutilError
+        stub.NoSuchProcess = type("NoSuchProcess", (_PsutilError,), {})
+        stub.AccessDenied = type("AccessDenied", (_PsutilError,), {})
+        stub.ZombieProcess = type("ZombieProcess", (_PsutilError,), {})
+        stub.process_iter = lambda *a, **k: []
+        sys.modules["psutil"] = stub
+
+    real_exists = os.path.exists
+    path = AGENT_ROOT / "hashview-agent.py"
+    with mock.patch.object(sys, "argv", ["hashview-agent.py"]), \
+         mock.patch(
+             "os.path.exists",
+             side_effect=lambda p: True if str(p).endswith("agent/config.conf") else real_exists(p),
+         ):
+        spec = importlib.util.spec_from_file_location("hashview_agent_main_robustness", path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+    return mod
+
+
+agent_main = _load_agent_main()
+
+
+def test_run_assigned_task_aborts_when_jobtask_missing(monkeypatch):
+    # jobTasks() -> None must abort before hashcat is ever built/launched.
+    monkeypatch.setattr(agent_main, "sync_rules", lambda: None)
+    monkeypatch.setattr(agent_main, "sync_wordlists", lambda: None)
+    monkeypatch.setattr(agent_main, "jobTasks", lambda job_task_id: None)
+
+    def _boom(*a, **k):
+        raise AssertionError("hashcat argv must not be built when the fetch failed")
+    monkeypatch.setattr(agent_main, "build_hashcat_argv", _boom)
+
+    agent_main.run_assigned_task(42)   # must return cleanly, no TypeError, no launch
+
+
+def test_upload_cracks_defers_when_hashtype_missing(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "control" / "outfiles").mkdir(parents=True)
+    (tmp_path / "control" / "outfiles" / "hc_cracked_1_9.txt").write_text("h:p\n")
+    monkeypatch.setattr(agent_main, "getHashType", lambda hashfile_id: None)
+
+    def _boom(*a, **k):
+        raise AssertionError("must not upload when the hash type couldn't be confirmed")
+    monkeypatch.setattr(agent_main, "uploadCrackFile", _boom)
+
+    agent_main.upload_cracks({"id": 1, "hashfile_id": 2}, {"id": 5, "task_id": 9})   # no raise
+
+
+def test_maybe_update_dynamic_wordlist_handles_none(monkeypatch):
+    monkeypatch.setattr(agent_main, "getWordlists",
+                        lambda: json.dumps([{"id": 3, "type": "dynamic"}]))
+    monkeypatch.setattr(agent_main, "updateDynamicWordlists", lambda wid: None)
+    monkeypatch.setattr(agent_main, "sync_wordlists", lambda: None)
+    agent_main.maybe_update_dynamic_wordlist({"wl_id": 3})   # no None['msg'] -> TypeError
+
+
+# ---------------------------------------------------------------------------
+# config.py — clear, fatal message on a missing file/section/key (problem D)
+# ---------------------------------------------------------------------------
+def _load_real_config():
+    # conftest stubs agent.config in sys.modules, so load the real module by path
+    # under a throwaway name. Its class body runs on import and may sys.exit().
+    path = AGENT_ROOT / "agent" / "config.py"
+    spec = importlib.util.spec_from_file_location("hv_agent_config_under_test", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_config_exits_on_missing_file(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)   # no agent/config.conf present
+    with pytest.raises(SystemExit):
+        _load_real_config()
+
+
+def test_config_exits_on_missing_key(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "agent").mkdir()
+    # [HASHVIEW] present but missing use_ssl, and no [AGENT] section at all.
+    (tmp_path / "agent" / "config.conf").write_text(
+        "[HASHVIEW]\nserver = 1.2.3.4\nport = 8443\n")
+    with pytest.raises(SystemExit):
+        _load_real_config()
+
+
+def test_config_loads_a_complete_file(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "agent").mkdir()
+    (tmp_path / "agent" / "config.conf").write_text(
+        "[HASHVIEW]\nserver = 1.2.3.4\nport = 8443\nuse_ssl = True\n\n"
+        "[AGENT]\nname = a\nuuid = u\nHC_BIN_PATH = /usr/bin/hashcat\n")
+    mod = _load_real_config()
+    assert mod.Config.HASHVIEW_SERVER == "1.2.3.4"
+    assert mod.Config.HC_EXTRA_ARGS == ""   # optional key defaults cleanly

--- a/tests/agent_unit/test_issue_xfail_agent_robustness.py
+++ b/tests/agent_unit/test_issue_xfail_agent_robustness.py
@@ -9,6 +9,8 @@ failure — a built-in reminder to drop the marker.
   A. api.* call json.loads() on the None that http.get/post return on non-200.
   B. download-to-disk call sites write that None straight to a file.
   C. callers index (`['msg']`) an api result that can be None even on a 200.
+  A/B/C are now FIXED — the tests below are regression guards, not xfails (see
+  also tests/agent_unit/test_agent_robustness.py for the wider coverage).
 
 #281 — agent process-control reliability:
   D. run_command treats ANY hashcat stderr as fatal and SIGINTs the agent.
@@ -80,28 +82,28 @@ def test_heartbeat_handles_non_200_without_typeerror(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# #280 B — a failed download must not be written to disk as None
+# #280 B — a failed download must not be written to disk as None (FIXED)
 # ---------------------------------------------------------------------------
-@pytest.mark.xfail(strict=True, raises=TypeError,
-                   reason="#280 B: download_hashfile writes the None from a failed "
-                          "download straight to the file (no guard)")
 def test_download_hashfile_handles_failed_download(tmp_path, monkeypatch):
+    # #280 B FIXED: a failed download (get_hashfile -> None) is not written to
+    # disk; download_hashfile returns False so the caller skips the run. Now a
+    # regression guard, not an xfail.
     monkeypatch.chdir(tmp_path)
     (tmp_path / "control" / "hashes").mkdir(parents=True)
     monkeypatch.setattr(agent_main.api, "get_hashfile", lambda hashfile_id: None)
-    agent_main.download_hashfile(1, 2, 3)   # desired: handled, not write(None) -> TypeError
+    assert agent_main.download_hashfile(1, 2, 3) is False   # handled, no write(None) -> TypeError
+    assert not (tmp_path / "control" / "hashes" / "hashfile_1_2.txt").exists()
 
 
 # ---------------------------------------------------------------------------
-# #280 C — callers must not index a response that can be None
+# #280 C — callers must not index a response that can be None (FIXED)
 # ---------------------------------------------------------------------------
-@pytest.mark.xfail(strict=True, raises=TypeError,
-                   reason="#280 C: handle_heartbeat does response['msg'] when "
-                          "send_heartbeat returns None")
 def test_handle_heartbeat_handles_none_response(monkeypatch):
-    # getHashcatPid() runs first; the default psutil stub yields no processes.
+    # #280 C FIXED: handle_heartbeat tolerates a None reply from send_heartbeat
+    # (getHashcatPid() runs first; the default psutil stub yields no processes).
+    # Now a regression guard, not an xfail.
     monkeypatch.setattr(agent_main, "send_heartbeat", lambda *a, **k: None)
-    agent_main.handle_heartbeat()   # desired: graceful, not None['msg'] -> TypeError
+    agent_main.handle_heartbeat()   # must not raise (was None['msg'] -> TypeError)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
…ses (#280)

The agent assumed every server reply was HTTP 200 with the expected JSON shape, so a non-200, a connection error, or a 200 with the wrong body (unauthorized -> {type:'Error'}, upgrade -> {status:426}) surfaced as opaque TypeErrors: json.loads(None), writing None bytes to disk, and indexing a None result. Replace those with actionable logging and graceful degradation, keeping the existing None-sentinel + retry resilience.

- http.py: catch RequestException and log+return None; on non-200 log the status + a body excerpt and return None explicitly.
- api.py: centralize on _load (None/non-JSON guard + in-band 426 -> exit) and _extract (missing-key/shape guard, reparse for the double-encoded job/task payloads); all functions are now None-safe with behavior otherwise unchanged.
- hashview-agent.py: guard the binary-download writes (download_hashfile, both sync_rules sites) and every ['msg'] subscript (handle_heartbeat, run_assigned_task, upload_cracks, maybe_update_dynamic_wordlist); abort a task run cleanly on a failed fetch instead of launching hashcat against a missing target. No jobtask status reset (would hot-loop on a persistent failure).
- config.py: validate the file/sections/keys and exit with a clear message instead of a bare KeyError at startup.

Drops the now-fixed #280 xfail markers (B, C) and adds tests/agent_unit/test_agent_robustness.py covering the http/api/config layers and the guarded call sites. The #281 xfails are untouched.