### PR TITLE
fix(wordlists): resolve wordlist paths robustly so legacy rows don't 404

### DIFF
--- a/hashview/api/routes.py
+++ b/hashview/api/routes.py
@@ -761,7 +761,17 @@ def v1_api_get_wordlist_download(wordlist_id):
 
     wordlists_dir = os.path.join(current_app.root_path, 'control/wordlists')
     tmp_dir = os.path.join(current_app.root_path, 'control/tmp')
-    wordlist_name = wordlist.path.split('/')[-1]
+    # Resolve by basename against the wordlists dir rather than trusting a
+    # possibly-relative wordlist.path against the CWD (legacy rows can hold a
+    # relative path). When the row outlives its file -- e.g. a wordlist stranded
+    # by an upgrade -- return a clear JSON 404 instead of send_from_directory's
+    # bare HTML page, so the agent logs an actionable body and the operator knows
+    # to re-upload. (Mirrors the /v1/rules/<id> download handler.)
+    wordlist_name = os.path.basename(wordlist.path or '')
+    src_path = os.path.join(wordlists_dir, wordlist_name)
+    if not wordlist_name or not os.path.exists(src_path):
+        return jsonify({'status': 404, 'type': 'Error',
+                        'msg': 'Wordlist file missing on disk: ' + (wordlist_name or '(no path)')}), 404
 
     if wordlist.type == 'static':
         # Stored compressed at rest: serve the .gz directly. The stored bytes
@@ -772,7 +782,7 @@ def v1_api_get_wordlist_download(wordlist_id):
     # DB via /v1/updateWordlist). Compress the current .txt into control/tmp
     # and serve that. No shell; pure-Python streamed gzip -9.
     tmp_gz = os.path.join(tmp_dir, secrets.token_hex(8) + '.gz')
-    compress_to_gz(wordlist.path, tmp_gz, 9)
+    compress_to_gz(src_path, tmp_gz, 9)
     return _send_generated_file(
         tmp_dir, os.path.basename(tmp_gz), mimetype='application/octet-stream')
 

--- a/hashview/setup/__init__.py
+++ b/hashview/setup/__init__.py
@@ -110,41 +110,74 @@ def compress_existing_wordlists_if_needed(db :SQLAlchemy):
       - dynamic -> never compressed (kept uncompressed on the server); only
         backfill byte_size if NULL.
 
+    Also self-heals path drift from older installs: a wordlist.path may be
+    RELATIVE (e.g. 'hashview/control/wordlists/<hex>.gz'), which only resolves
+    when the process CWD happens to be the repo root. Such a path is normalized
+    to its absolute on-disk location, and newly-compressed files are written
+    into the absolute wordlists dir (never derived from a possibly-relative
+    dirname), so a wordlist can't get stranded where the download route -- which
+    serves by basename from the wordlists dir -- can't find it.
+
     Idempotent (the gzip magic-byte check makes re-runs no-ops) and resilient:
-    each row is handled in its own try/except with a per-row commit, a missing
-    file is logged and skipped (never deletes the DB row), and any failure is
-    contained so it can never abort startup.
+    each row is handled in its own try/except with a per-row commit, a truly
+    missing file is logged and skipped (never deletes the DB row), and any
+    failure is contained so it can never abort startup.
     """
     from flask import current_app
     logger = current_app.logger
+    wordlists_dir = os.path.join(current_app.root_path, 'control/wordlists')
+
+    def _resolve(path):
+        """Locate a wordlist file, tolerating a relative/legacy stored path.
+        Prefer the canonical wordlists dir (where the download route serves
+        from); fall back to the path as-stored. Returns an absolute path, or
+        None when the file genuinely can't be found."""
+        if not path:
+            return None
+        for cand in (os.path.join(wordlists_dir, os.path.basename(path)), path):
+            if os.path.exists(cand):
+                return os.path.abspath(cand)
+        return None
 
     for wordlist in db.session.query(Wordlists).all():
         try:
-            path = wordlist.path
-            if not path or not os.path.exists(path):
-                logger.warning('Wordlist %s file missing (%s); skipping compression.', wordlist.id, path)
+            resolved = _resolve(wordlist.path)
+            if resolved is None:
+                logger.warning('Wordlist %s file not found (path=%s); leaving the DB row '
+                               'untouched. Re-upload the wordlist to restore it.',
+                               wordlist.id, wordlist.path)
                 continue
+
+            # Normalize a relative/legacy path to the absolute on-disk location so
+            # the download route and cracking commands find it regardless of the
+            # process CWD.
+            if wordlist.path != resolved:
+                logger.info('Normalized wordlist %s path %r -> %r', wordlist.id, wordlist.path, resolved)
+                wordlist.path = resolved
+                db.session.commit()
 
             if wordlist.type == 'dynamic':
                 # Dynamic wordlists stay uncompressed; just backfill byte_size.
                 if wordlist.byte_size is None:
-                    wordlist.byte_size = get_filesize(path)
+                    wordlist.byte_size = get_filesize(resolved)
                     db.session.commit()
                 continue
 
             # static
-            if is_gzip(path):
+            if is_gzip(resolved):
                 # Already compressed (new uploads, or a prior run). No-op aside
                 # from backfilling byte_size if it was never recorded.
                 if wordlist.byte_size is None:
-                    wordlist.byte_size = get_filesize(path)
+                    wordlist.byte_size = get_filesize(resolved)
                     db.session.commit()
                 continue
 
-            # static + uncompressed: compress in place (new file in same dir).
-            line_count = get_linecount(path)
-            new_gz = os.path.join(os.path.dirname(path), secrets.token_hex(8) + '.gz')
-            compress_to_gz(path, new_gz, 9)
+            # static + uncompressed: compress into the absolute wordlists dir (so
+            # the file always lands where the download route serves from) and
+            # store an absolute path.
+            line_count = get_linecount(resolved)
+            new_gz = os.path.join(wordlists_dir, secrets.token_hex(8) + '.gz')
+            compress_to_gz(resolved, new_gz, 9)
 
             # write -> commit -> delete: only remove the old plaintext after the
             # new path/checksum are durably committed.
@@ -154,12 +187,12 @@ def compress_existing_wordlists_if_needed(db :SQLAlchemy):
             wordlist.byte_size = get_filesize(new_gz)
             db.session.commit()
 
-            if os.path.exists(path):
-                os.remove(path)
+            if os.path.exists(resolved) and os.path.abspath(resolved) != os.path.abspath(new_gz):
+                os.remove(resolved)
             logger.info('Compressed static wordlist %s -> %s', wordlist.id, new_gz)
         except Exception:
             db.session.rollback()
-            logger.exception('Failed to compress wordlist %s; leaving it untouched.', getattr(wordlist, 'id', '?'))
+            logger.exception('Failed to process wordlist %s; leaving it untouched.', getattr(wordlist, 'id', '?'))
 
 
 def _decode_hex_column(db, model, col_name, logger):

--- a/tests/unit/test_wordlist_gzip_storage.py
+++ b/tests/unit/test_wordlist_gzip_storage.py
@@ -428,6 +428,25 @@ def test_download_missing_wordlist_404(app, client):
     assert resp.status_code == 404
 
 
+def test_download_static_missing_file_returns_json_404(app, client):
+    # Regression: a static row that outlived its file on disk (e.g. a wordlist
+    # stranded across an upgrade, with a relative legacy path) must return a
+    # clean, parseable JSON 404 -- not send_from_directory's bare HTML page.
+    user = _make_user(api_key="dlmiss")
+    _auth(client, "dlmiss")
+    wl = Wordlists(name="Stranded", owner_id=user.id, type="static",
+                   path="hashview/control/wordlists/deadbeefdeadbeef.gz",
+                   checksum="0" * 64, size=0, byte_size=1)
+    db.session.add(wl)
+    db.session.commit()
+
+    resp = client.get(f"/v1/wordlists/{wl.id}")
+    assert resp.status_code == 404
+    data = resp.get_json()
+    assert data and data["type"] == "Error"
+    assert "missing on disk" in data["msg"]
+
+
 # ---------------------------------------------------------------------------
 # Launch migration: compress_existing_wordlists_if_needed
 # ---------------------------------------------------------------------------
@@ -511,6 +530,62 @@ def test_launch_migration(app, tmp_path):
     static_wl = Wordlists.query.get(ids[0])
     assert static_wl.path == path_after
     assert static_wl.checksum == checksum_after
+
+
+def test_migration_normalizes_relative_wordlist_path(app, client, tmp_path):
+    # A legacy row with a RELATIVE .gz path whose file IS present in the
+    # wordlists dir (the exact shape that stranded wordlist 6) gets its path
+    # rewritten to absolute, so the download route and cracking commands find it
+    # regardless of the process CWD.
+    user = _make_user(api_key="relkey")
+    _auth(client, "relkey")
+    content = b"one\ntwo\n"
+    gzname = secrets.token_hex(8) + ".gz"
+    abs_gz = WORDLISTS_DIR / gzname
+    with gzip.open(str(abs_gz), "wb", compresslevel=9) as f:
+        f.write(content)
+    rel_path = os.path.join("hashview", "control", "wordlists", gzname)   # legacy relative form
+    wl = Wordlists(name="RelPath", owner_id=user.id, type="static",
+                   path=rel_path, checksum=get_filehash(str(abs_gz)), size=2, byte_size=None)
+    db.session.add(wl)
+    db.session.commit()
+    wl_id = wl.id
+
+    compress_existing_wordlists_if_needed(db)
+
+    wl = Wordlists.query.get(wl_id)
+    assert os.path.isabs(wl.path)
+    assert os.path.abspath(wl.path) == os.path.abspath(str(abs_gz))
+    assert wl.byte_size == os.path.getsize(str(abs_gz))
+    # end-to-end: it now serves
+    resp = client.get(f"/v1/wordlists/{wl_id}")
+    assert resp.status_code == 200
+    assert gzip.decompress(resp.data) == content
+
+
+def test_migration_compresses_into_wordlists_dir(app, tmp_path):
+    # A static, uncompressed legacy file living OUTSIDE the wordlists dir must be
+    # compressed INTO the absolute wordlists dir (not next to the source), so it
+    # lands where the download route serves from.
+    user = _make_user(api_key="cmpkey")
+    content = b"aa\nbb\ncc\n"
+    src = tmp_path / "legacy_plain.txt"
+    src.write_bytes(content)
+    wl = Wordlists(name="LegacyPlain", owner_id=user.id, type="static",
+                   path=str(src), checksum=get_filehash(str(src)), size=3)
+    db.session.add(wl)
+    db.session.commit()
+    wl_id = wl.id
+
+    compress_existing_wordlists_if_needed(db)
+
+    wl = Wordlists.query.get(wl_id)
+    assert os.path.isabs(wl.path)
+    assert os.path.dirname(os.path.abspath(wl.path)) == os.path.abspath(str(WORDLISTS_DIR))
+    assert is_gzip(wl.path)
+    assert not src.exists()   # old plaintext removed after the durable commit
+    with gzip.open(wl.path, "rb") as f:
+        assert f.read() == content
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
A wordlist whose DB row outlived/mismatched its on-disk file (e.g. a v0.8.2 wordlist with a RELATIVE path that only resolves at the repo-root CWD) produced a bare HTML 404 from the download route, and the startup compress backfill could strand files by writing them relative to a dirname/CWD it didn't control.

- api/routes.py (/v1/wordlists/<id>): resolve the file by basename against the absolute control/wordlists dir (never trust a relative path against the CWD) and return a clear JSON 404 ('Wordlist file missing on disk: <name>') for both static and dynamic when the row's file is gone -- mirroring the already-hardened /v1/rules/<id> handler, so the agent logs a parseable body.
- setup/compress_existing_wordlists_if_needed: locate files tolerantly (canonical wordlists dir first, then as-stored), normalize relative/legacy paths to absolute, write newly-compressed .gz into the absolute wordlists dir with an absolute stored path, and log a clear 're-upload' message when a file is truly missing. Self-heals path drift on restart; can't strand a file anymore.

Tests: static missing-file -> JSON 404 (the reported scenario), migration normalizes a relative path to absolute (+ serves 200), and migration compresses an out-of-dir legacy plaintext into the wordlists dir. Existing wordlist/API/ download suites stay green.