### PR TITLE
feat(jobs): show a chunked task as one attack in the job editor

### DIFF
--- a/hashview/jobs/routes.py
+++ b/hashview/jobs/routes.py
@@ -144,8 +144,14 @@ def jobs_list():
     except Exception:  # pragma: no cover - defensive
         hash_type_names = {}
 
+    # Count ATTACKS (assignments), not raw rows: a task split into N chunks is one
+    # attack, so count it once (at its chunk_no==1 row) rather than N times. Whole
+    # rows -- including a dynamic-wordlist task legitimately assigned twice -- each
+    # count once.
     job_task_count = {}
     for jt in job_tasks:
+        if jt.chunk_total and jt.chunk_no != 1:
+            continue
         job_task_count[jt.job_id] = job_task_count.get(jt.job_id, 0) + 1
 
     jn_by_job = {}
@@ -464,6 +470,30 @@ def jobs_assigned_hashfile_cracked(job_id, hashfile_id):
 
     return render_template('jobs_assigned_hashfiles_cracked.html.j2', title='Jobs Assigned Hashfiles Cracked', hashfile=hashfile, job=job, cracked_hashfiles_hashes=cracked_hashfiles_hashes)
 
+def _assigned_tasks(job_id):
+    """A job's task assignments in queue order, with a split task's chunk rows
+    collapsed into a single logical entry.
+
+    At queue time a chunkable task fans out into N JobTasks rows (each with
+    chunk_total set); those are ONE assignment and collapse to a single entry
+    that carries the chunk count. A dynamic-wordlist task may be assigned more
+    than once -- those are separate WHOLE rows (chunk_total is NULL) and each
+    stays its own entry. Ordered by JobTasks id, which matches both the
+    pre-chunk insertion order and the agent-dispatch order (min id per task).
+    Returns a list of {'task_id': int, 'chunks': int}.
+    """
+    entries, seen_chunked = [], set()
+    for jt in (JobTasks.query.filter_by(job_id=job_id)
+               .order_by(JobTasks.id.asc()).all()):
+        if jt.chunk_total:
+            if jt.task_id in seen_chunked:
+                continue
+            seen_chunked.add(jt.task_id)
+            entries.append({'task_id': jt.task_id, 'chunks': jt.chunk_total})
+        else:
+            entries.append({'task_id': jt.task_id, 'chunks': 1})
+    return entries
+
 @jobs.route("/jobs/<int:job_id>/tasks", methods=['GET'])
 @login_required
 def jobs_list_tasks(job_id):
@@ -505,7 +535,11 @@ def jobs_list_tasks(job_id):
     if job.hashfile_id:
         alert_hashes = db.session.query(HashNotifications).join(HashfileHashes, HashNotifications.hash_id == HashfileHashes.hash_id).filter(HashfileHashes.hashfile_id == job.hashfile_id).first() is not None
 
-    return render_template('jobs_assigned_tasks.html.j2', title='Jobs Assigned Tasks', job=job, tasks=tasks, job_tasks=job_tasks, assignable_tasks=assignable_tasks, task_meta=task_meta, task_groups=task_groups, wordlists=wordlists, alert_hashes=alert_hashes, website=_job_uses_website_keywords(job_id))
+    # One card per logical assignment: chunk rows of a split task collapse to a
+    # single entry (the editor shows the attack once, not once per chunk).
+    assigned = _assigned_tasks(job_id)
+
+    return render_template('jobs_assigned_tasks.html.j2', title='Jobs Assigned Tasks', job=job, tasks=tasks, job_tasks=job_tasks, assigned=assigned, assignable_tasks=assignable_tasks, task_meta=task_meta, task_groups=task_groups, wordlists=wordlists, alert_hashes=alert_hashes, website=_job_uses_website_keywords(job_id))
 
 @jobs.route("/jobs/<int:job_id>/assign_task/<int:task_id>", methods=['POST'])
 @login_required
@@ -616,7 +650,11 @@ def jobs_reorder_tasks(job_id):
         flash('Security check failed (invalid or missing CSRF token).', 'danger')
         return redirect("/jobs/" + str(job_id) + "/tasks")
 
-    current = [jt.task_id for jt in JobTasks.query.filter_by(job_id=job_id).all()]
+    # Compare against the COLLAPSED assignment list (one entry per attack), which
+    # is what the page renders and submits. Using the raw per-chunk rows here made
+    # a split task's task_id appear N times, so a reorder recreated N whole rows
+    # for it -- multiplying the task on the next queue. One entry per attack fixes that.
+    current = [e['task_id'] for e in _assigned_tasks(job_id)]
     try:
         submitted = [int(x) for x in request.form.get('order', '').split(',') if x != '']
     except ValueError:
@@ -643,11 +681,19 @@ def jobs_remove_task(job_id, task_id):
         flash('Security check failed (invalid or missing CSRF token).', 'danger')
         return redirect("/jobs/" + str(job_id) + "/tasks")
 
-    job_task = JobTasks.query.filter_by(job_id=job_id, task_id=task_id).first()
-    if job_task is None:
+    job_tasks = JobTasks.query.filter_by(job_id=job_id, task_id=task_id).all()
+    if not job_tasks:
         flash('That task is no longer on this job — it may have already been removed.', 'warning')
         return redirect("/jobs/"+str(job_id)+"/tasks")
-    db.session.delete(job_task)
+    # A split task is many chunk rows sharing this task_id -> removing the attack
+    # removes ALL of them (the old .first() left chunks 2..N orphaned). A
+    # dynamic-wordlist task can be assigned more than once as separate whole rows;
+    # there, drop a single instance so the others survive.
+    if any(jt.chunk_total for jt in job_tasks):
+        for jt in job_tasks:
+            db.session.delete(jt)
+    else:
+        db.session.delete(job_tasks[0])
     if not try_commit(f'remove task {task_id} from job {job_id}'):
         flash('Could not remove the task — it may have already been removed.', 'danger')
 
@@ -868,7 +914,11 @@ def jobs_summary(job_id):
 
         return redirect(url_for('main.home'))
 
-    return render_template('jobs_summary.html.j2', title='Job Summary', job=job, form=form, job_notification=job_notification, cracked_rate=cracked_rate, cracked_cnt=cracked_cnt, hash_total=hash_total, hashfile_hash_type=hashfile_hash_type, job_tasks=job_tasks, hash_notification_cnt=hash_notification_cnt, customer=customer, hashfile=hashfile, tasks=tasks, hash_notification=hash_notification, settings=settings, website=_job_uses_website_keywords(job_id))
+    # Collapse a split task's chunk rows into one entry so the review step lists
+    # each attack once (matches the assign-tasks step), not once per chunk.
+    assigned = _assigned_tasks(job_id)
+
+    return render_template('jobs_summary.html.j2', title='Job Summary', job=job, form=form, job_notification=job_notification, cracked_rate=cracked_rate, cracked_cnt=cracked_cnt, hash_total=hash_total, hashfile_hash_type=hashfile_hash_type, job_tasks=job_tasks, assigned=assigned, hash_notification_cnt=hash_notification_cnt, customer=customer, hashfile=hashfile, tasks=tasks, hash_notification=hash_notification, settings=settings, website=_job_uses_website_keywords(job_id))
 
 @jobs.route("/jobs/start/<int:job_id>", methods=['POST'])
 @login_required

--- a/hashview/tasks/routes.py
+++ b/hashview/tasks/routes.py
@@ -113,7 +113,24 @@ def tasks_list():
     # too); the list view uses this to disable the edit button for those tasks.
     tasks_in_jobs = {jt.task_id for jt in job_tasks}
 
-    return render_template('tasks.html.j2', title='tasks', tasks=tasks, users=users, jobs=jobs, job_tasks=job_tasks, wordlists=wordlists, task_groups=task_groups, task_recovery_performance=task_recovery_performance, pagination=pagination, sort_by=sort_by, sort_order=sort_order, rules=Rules.query.all(), wl_filesize=wl_filesize, tasks_in_jobs=tasks_in_jobs, tasksForm=TasksForm(), form_err=session.pop('tasks_form_err', None))
+    # DISTINCT jobs each task is used in, for the info modal's "Used in N jobs"
+    # panel. Collapse chunk rows so a job the task was split across is listed once
+    # (not once per chunk); a task used more than once in the same job also lists
+    # that job once.
+    jobs_by_id = {j.id: j for j in jobs}
+    jobs_by_task = {}
+    _seen_job_for_task = {}
+    for jt in job_tasks:
+        job = jobs_by_id.get(jt.job_id)
+        if job is None:
+            continue
+        seen = _seen_job_for_task.setdefault(jt.task_id, set())
+        if job.id in seen:
+            continue
+        seen.add(job.id)
+        jobs_by_task.setdefault(jt.task_id, []).append(job)
+
+    return render_template('tasks.html.j2', title='tasks', tasks=tasks, users=users, jobs=jobs, job_tasks=job_tasks, jobs_by_task=jobs_by_task, wordlists=wordlists, task_groups=task_groups, task_recovery_performance=task_recovery_performance, pagination=pagination, sort_by=sort_by, sort_order=sort_order, rules=Rules.query.all(), wl_filesize=wl_filesize, tasks_in_jobs=tasks_in_jobs, tasksForm=TasksForm(), form_err=session.pop('tasks_form_err', None))
 
 @tasks.route("/tasks/add", methods=['GET', 'POST'])
 @login_required

--- a/hashview/templates/jobs_assigned_tasks.html.j2
+++ b/hashview/templates/jobs_assigned_tasks.html.j2
@@ -93,17 +93,21 @@
                 <input type="hidden" name="order" id="reorder-order">
             </form>
             <div id="task-queue">
-                {% for job_task in job_tasks %}
-                    {% set m = task_meta.get(job_task.task_id) if task_meta is defined else none %}
-                    <div class="tq-item" draggable="true" data-task-id="{{ job_task.task_id }}">
+                {# One card per logical assignment. A task split into chunks at queue
+                   time collapses to a single card (with a chunk-count note), not one
+                   card per chunk; dynamic-wordlist tasks assigned more than once still
+                   show one card each. #}
+                {% for a in (assigned if assigned is defined else []) %}
+                    {% set m = task_meta.get(a.task_id) if task_meta is defined else none %}
+                    <div class="tq-item" draggable="true" data-task-id="{{ a.task_id }}">
                         <span class="tq-index">{{ '%02d' % loop.index }}</span>
                         <span class="tq-grip" title="Drag to reorder">{{ icon('drag', size=16) }}</span>
                         <div class="tq-body">
                             <div class="tq-name">{{ m.name if m else 'Unknown task' }}</div>
-                            <div class="tq-sub">{{ m.type if m else 'Task' }}{% if m and m.wordlist %} · {{ m.wordlist }}{% endif %}</div>
+                            <div class="tq-sub">{{ m.type if m else 'Task' }}{% if m and m.wordlist %} · {{ m.wordlist }}{% endif %}{% if a.chunks > 1 %} · split into {{ a.chunks | commafy }} chunks{% endif %}</div>
                         </div>
                         <div class="tq-controls">
-                            <form method="POST" action="/jobs/{{job.id}}/remove_task/{{job_task.task_id}}" style="display:contents">
+                            <form method="POST" action="/jobs/{{job.id}}/remove_task/{{a.task_id}}" style="display:contents">
                                 <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                                 <button type="submit" class="icon-btn act-del" title="Remove task">{{ icon('trash', size=15) }}</button>
                             </form>

--- a/hashview/templates/jobs_summary.html.j2
+++ b/hashview/templates/jobs_summary.html.j2
@@ -61,11 +61,11 @@
                     <tr>
                         <td style="color:var(--text-dim);">Tasks</td>
                         <td>
-                            {% for job_task in job_tasks %}
+                            {% for a in (assigned if assigned is defined else []) %}
                                 {% set order = loop.index %}
                                 {% for task in tasks %}
-                                    {% if task.id == job_task.task_id %}
-                                        <span class="mono" style="color:var(--text-mute); margin-right:8px;">{{ '%02d' % order }}</span>{{ task.name }} <br>
+                                    {% if task.id == a.task_id %}
+                                        <span class="mono" style="color:var(--text-mute); margin-right:8px;">{{ '%02d' % order }}</span>{{ task.name }}{% if a.chunks > 1 %} <span class="mono" style="color:var(--text-mute);">({{ a.chunks | commafy }} chunks)</span>{% endif %} <br>
                                     {% endif %}
                                 {% endfor %}
                             {% endfor %}

--- a/hashview/templates/tasks.html.j2
+++ b/hashview/templates/tasks.html.j2
@@ -395,20 +395,20 @@ function hvFilterTasks(q){
             <div>{{ kv_label('Historical hits') }}<div><span class="mono" style="color:{{ 'var(--primary)' if ns.recovered else 'var(--text-mute)' }};{% if ns.recovered %}text-shadow:var(--glow-text);{% endif %}">{{ "{:,}".format(ns.recovered|int) }}</span> <span style="color:var(--text-dim);">passwords recovered</span></div></div>
         </div>
 
-        {# used-in jobs #}
-        {% set jl = namespace(count=0) %}
-        {% for jt in job_tasks %}{% if jt.task_id == task.id %}{% for j in jobs %}{% if j.id == jt.job_id %}{% set jl.count = jl.count + 1 %}{% endif %}{% endfor %}{% endif %}{% endfor %}
+        {# used-in jobs: DISTINCT jobs (chunk rows collapsed so a job the task was
+           split across is listed once, not once per chunk) #}
+        {% set used = (jobs_by_task.get(task.id, []) if jobs_by_task is defined else []) %}
         <div style="margin-top:24px;">
-            <div class="mono" style="display:flex; align-items:center; gap:8px; font-size:10px; letter-spacing:1px; text-transform:uppercase; color:var(--text-mute); margin-bottom:11px;">{{ icon('jobs', size=14) }} Used in {{ jl.count | commafy }} job{{ '' if jl.count == 1 else 's' }}</div>
-            {% if jl.count %}
-            {% for jt in job_tasks %}{% if jt.task_id == task.id %}{% for j in jobs %}{% if j.id == jt.job_id %}
+            <div class="mono" style="display:flex; align-items:center; gap:8px; font-size:10px; letter-spacing:1px; text-transform:uppercase; color:var(--text-mute); margin-bottom:11px;">{{ icon('jobs', size=14) }} Used in {{ used|length | commafy }} job{{ '' if used|length == 1 else 's' }}</div>
+            {% if used %}
+            {% for j in used %}
             <div class="card" style="margin-bottom:8px; padding:12px 14px; display:flex; align-items:center; gap:10px;">
                 <span class="dot-led {% if j.status == 'Running' %}run{% elif j.status == 'Completed' %}on{% elif j.status == 'Canceled' %}off{% else %}idle{% endif %}"></span>
                 <span class="mono" style="color:var(--text-mute);">#{{ j.id }}</span>
                 <span style="font-weight:600; color:var(--text);">{{ j.name }}</span>
                 <span style="margin-left:auto;">{{ status_badge(j.status) }}</span>
             </div>
-            {% endif %}{% endfor %}{% endif %}{% endfor %}
+            {% endfor %}
             {% else %}
             <div class="mono" style="color:var(--text-mute);">Not used in any jobs yet.</div>
             {% endif %}

--- a/tests/unit/test_jobs_routes.py
+++ b/tests/unit/test_jobs_routes.py
@@ -216,6 +216,109 @@ def test_jobs_reorder_tasks_bad_order_is_noop(app, client):
     assert _ordered_task_ids(job) == [t1.id, t2.id]
 
 
+# --- chunked tasks read as ONE attack in the editor ------------------------
+
+def _chunk(job, task, chunk_no, chunk_total, status="Queued"):
+    """A single chunk row of a split task (queue-time fan-out)."""
+    jt = JobTasks(job_id=job.id, task_id=task.id, status=status, priority=3,
+                  chunk_no=chunk_no, chunk_total=chunk_total)
+    db.session.add(jt)
+    db.session.commit()
+    return jt
+
+
+def test_jobs_list_collapses_chunked_task_to_one_card(app, client):
+    admin = make_admin()
+    login(client, admin)
+    cust = make_customer()
+    job = _job(admin, cust)
+    task = _task(admin, name="MaskAttack")
+    for n in range(1, 4):                 # one task fanned into 3 chunk rows
+        _chunk(job, task, n, 3)
+    body = client.get(f"/jobs/{job.id}/tasks").get_data(as_text=True)
+    assert body.count(f'data-task-id="{task.id}"') == 1     # one card, not three
+    assert "split into 3 chunks" in body
+
+
+def test_jobs_remove_chunked_task_deletes_all_chunks(app, client):
+    admin = make_admin()
+    login(client, admin)
+    cust = make_customer()
+    job = _job(admin, cust)
+    task = _task(admin, name="MaskAttack")
+    for n in range(1, 4):
+        _chunk(job, task, n, 3)
+    resp = client.post(f"/jobs/{job.id}/remove_task/{task.id}", follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    assert JobTasks.query.filter_by(job_id=job.id, task_id=task.id).count() == 0
+
+
+def test_jobs_reorder_does_not_multiply_chunked_task(app, client):
+    admin = make_admin()
+    login(client, admin)
+    cust = make_customer()
+    job = _job(admin, cust)
+    t1 = _task(admin, name="mask")
+    t2 = _task(admin, name="dict")
+    for n in range(1, 4):                 # t1 split into 3 chunks
+        _chunk(job, t1, n, 3)
+    _assign(job, t2)                      # t2 whole
+    # collapsed order is [t1, t2]; reorder to [t2, t1]
+    resp = client.post(f"/jobs/{job.id}/reorder_tasks",
+                       data={"order": f"{t2.id},{t1.id}"}, follow_redirects=False)
+    assert resp.status_code in (301, 302)
+    rows = JobTasks.query.filter_by(job_id=job.id).order_by(JobTasks.id).all()
+    # t1 collapses to ONE whole row (the old code recreated 3 -> re-chunk x3)
+    assert sum(1 for r in rows if r.task_id == t1.id) == 1
+    assert [r.task_id for r in rows] == [t2.id, t1.id]     # order swapped
+    assert all(r.chunk_total is None for r in rows)        # de-chunked; re-chunks at next queue
+
+
+def test_jobs_dynamic_duplicate_tasks_stay_separate(app, client):
+    # A dynamic-wordlist task may be assigned more than once (separate WHOLE rows,
+    # never chunked). Those must stay distinct cards, and removing one leaves the rest.
+    admin = make_admin()
+    login(client, admin)
+    cust = make_customer()
+    job = _job(admin, cust)
+    task = _task(admin, name="DynTask")
+    _assign(job, task)                    # two whole rows, same task_id
+    _assign(job, task)
+    body = client.get(f"/jobs/{job.id}/tasks").get_data(as_text=True)
+    assert body.count(f'data-task-id="{task.id}"') == 2     # two cards
+    client.post(f"/jobs/{job.id}/remove_task/{task.id}", follow_redirects=False)
+    assert JobTasks.query.filter_by(job_id=job.id, task_id=task.id).count() == 1
+
+
+def test_jobs_list_counts_chunked_task_as_one_attack(app, client):
+    # Jobs list "N attacks queued" must count the attack once, not once per chunk.
+    admin = make_admin()
+    login(client, admin)
+    cust = make_customer()
+    job = _job(admin, cust, name="chunked-job")
+    task = _task(admin, name="MaskAttack")
+    for n in range(1, 4):
+        _chunk(job, task, n, 3)
+    body = client.get("/jobs").get_data(as_text=True)
+    assert "1 attack queued" in body
+    assert "3 attacks queued" not in body
+
+
+def test_task_detail_used_in_jobs_dedupes_chunks(app, client):
+    # Task info modal "Used in N jobs" counts a job once even when the task was
+    # split across N chunk rows in it.
+    admin = make_admin()
+    login(client, admin)
+    cust = make_customer()
+    job = _job(admin, cust)
+    task = _task(admin, name="MaskAttack")
+    for n in range(1, 4):
+        _chunk(job, task, n, 3)
+    body = client.get("/tasks").get_data(as_text=True)
+    assert "Used in 1 job" in body
+    assert "Used in 3 jobs" not in body
+
+
 def test_jobs_remove_all_tasks_clears(app, client):
     admin = make_admin()
     login(client, admin)


### PR DESCRIPTION
With chunking enabled, queuing a job splits an eligible task into N JobTasks rows (same job_id+task_id, chunk_total set). The job editor, summary, jobs list, and task-detail page all counted/listed raw rows, so one attack showed up N times and two routes mishandled it.

Model the assignment layer on "(job, task) is the attack; its rows are chunks":
- add _assigned_tasks(job_id): collapse a split task's chunk rows into one entry (keyed by task_id) while keeping dynamic-wordlist duplicate whole rows separate; order by id (matches dispatch order).
- assign-tasks editor + summary: render one entry per attack with a "split into N chunks" note (jobs_assigned_tasks / jobs_summary templates).
- jobs_remove_task: delete ALL rows of a split task (was .first(), which orphaned chunks 2..N); still drop a single dynamic-duplicate instance.
- jobs_reorder_tasks: build the parity/submit list from the collapsed view, so a split task is recreated once, not N times (which had re-chunked it N-fold).
- jobs list "N attacks queued": count assignments, not chunk rows.
- task detail "Used in N jobs": count DISTINCT jobs (a task split across chunks in one job is listed once).

Adds tests for the collapse, remove-all-chunks, no-multiply-on-reorder, dynamic-duplicate separation, the jobs-list count, and the task-detail dedup.