### PR TITLE
feat(hooks): add pre-push sensitive-keyword scanner

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# Pre-push hook: scan outgoing commits for sensitive info.
+#
+# Enable once per clone:
+#   git config core.hooksPath .githooks
+#
+# Bypass (use sparingly):
+#   git push --no-verify
+
+set -u
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+KEYWORDS_FILE="${REPO_ROOT}/.sensitive-keywords"
+ALLOWLIST_FILE="${REPO_ROOT}/.githooks/safe-allowlist.txt"
+
+# Load allowlist patterns once (regex, case-insensitive). A hit whose full
+# matched line matches any allowlist pattern is treated as a false positive
+# and suppressed.
+ALLOWLIST_PATTERNS=""
+if [ -f "$ALLOWLIST_FILE" ]; then
+    ALLOWLIST_PATTERNS=$(grep -Ev '^[[:space:]]*(#|$)' "$ALLOWLIST_FILE" || true)
+fi
+
+filter_allowlist() {
+    if [ -z "$ALLOWLIST_PATTERNS" ]; then
+        cat
+    else
+        grep -vEi -f <(printf '%s\n' "$ALLOWLIST_PATTERNS") || true
+    fi
+}
+
+RED=$'\033[0;31m'
+YEL=$'\033[0;33m'
+DIM=$'\033[2m'
+RST=$'\033[0m'
+
+fail=0
+findings=""
+
+record() {
+    findings+="$1"$'\n'
+    fail=1
+}
+
+# Read refs being pushed from stdin: <local_ref> <local_sha> <remote_ref> <remote_sha>
+zero="0000000000000000000000000000000000000000"
+
+while read -r local_ref local_sha remote_ref remote_sha; do
+    [ -z "${local_sha:-}" ] && continue
+
+    # Deletion — nothing to scan.
+    if [ "$local_sha" = "$zero" ]; then
+        continue
+    fi
+
+    if [ "$remote_sha" = "$zero" ]; then
+        # New branch: scan everything reachable from local_sha not already on any remote.
+        range_args=("$local_sha" --not --remotes)
+    else
+        range_args=("${remote_sha}..${local_sha}")
+    fi
+
+    # List commits being pushed.
+    commits=$(git rev-list "${range_args[@]}" 2>/dev/null)
+    [ -z "$commits" ] && continue
+
+    # Combined diff of added lines only for the push range.
+    diff=$(git diff --unified=0 --no-color "${range_args[@]}" 2>/dev/null)
+
+    # Files added/modified in this push.
+    changed_files=$(git diff --name-only --diff-filter=AM "${range_args[@]}" 2>/dev/null)
+
+    # Commit messages (subject + body) for every commit in the push range,
+    # prefixed with the short SHA so findings point at the offending commit.
+    messages=$(git log --format='%h %B%n---END---' "${range_args[@]}" 2>/dev/null)
+
+    if [ -z "$diff" ] && [ -z "$messages" ]; then
+        continue
+    fi
+
+    # --- Built-in patterns (scan added diff lines + commit messages) ---
+
+    added=$(printf '%s\n' "$diff" | grep -E '^\+' | grep -Ev '^\+\+\+')
+    # Tag commit-message lines so scan output shows they came from a message.
+    msg_tagged=$(printf '%s\n' "$messages" | sed 's/^/[commit-msg] /')
+    haystack=$(printf '%s\n%s\n' "$added" "$msg_tagged")
+
+    scan() {
+        local label="$1" pattern="$2"
+        local hits
+        hits=$(printf '%s\n' "$haystack" | grep -InEi -e "$pattern" | filter_allowlist || true)
+        if [ -n "$hits" ]; then
+            record "${RED}[${label}]${RST}"
+            while IFS= read -r line; do
+                record "  ${DIM}${line}${RST}"
+            done <<<"$hits"
+        fi
+    }
+
+    scan "AWS access key ID"      'AKIA[0-9A-Z]{16}'
+    scan "AWS secret key"         '(aws.{0,20})?(secret|access)?.{0,5}[=:][[:space:]]*["'\'']?[A-Za-z0-9/+=]{40}["'\'']?'
+    scan "Generic secret assign"  '(api[_-]?key|secret|password|passwd|token|bearer)[[:space:]]*[=:][[:space:]]*["'\''][^"'\'']{6,}["'\'']'
+    scan "PEM private key"        '-----BEGIN [A-Z ]*PRIVATE KEY-----'
+    scan "URL"                    '(https?|ftp|ssh|git|s3|smb)://[A-Za-z0-9._~:/?#@!$&+;=%-]+'
+    scan "IP address"             '\b([0-9]{1,3}\.){3}[0-9]{1,3}\b'
+
+    # --- .env file additions ---
+    if [ -n "$changed_files" ]; then
+        env_hits=$(printf '%s\n' "$changed_files" | grep -E '(^|/)\.env(\.|$)' || true)
+        if [ -n "$env_hits" ]; then
+            record "${RED}[.env file added/modified]${RST}"
+            while IFS= read -r f; do
+                record "  ${DIM}${f}${RST}"
+            done <<<"$env_hits"
+        fi
+    fi
+
+    # --- Keyword file (regex, case-insensitive) ---
+    if [ -f "$KEYWORDS_FILE" ]; then
+        # Strip comments and blank lines.
+        patterns=$(grep -Ev '^[[:space:]]*(#|$)' "$KEYWORDS_FILE" || true)
+        if [ -n "$patterns" ]; then
+            while IFS= read -r pat; do
+                [ -z "$pat" ] && continue
+                hits=$(printf '%s\n' "$haystack" | grep -InEi -- "$pat" | filter_allowlist || true)
+                if [ -n "$hits" ]; then
+                    record "${YEL}[keyword: ${pat}]${RST}"
+                    while IFS= read -r line; do
+                        record "  ${DIM}${line}${RST}"
+                    done <<<"$hits"
+                fi
+            done <<<"$patterns"
+        fi
+    else
+        printf '%spre-push:%s no %s found — keyword scan skipped.\n' "$YEL" "$RST" "$KEYWORDS_FILE" >&2
+    fi
+done
+
+if [ "$fail" -ne 0 ]; then
+    printf '\n%sPush blocked — potential sensitive content detected:%s\n\n' "$RED" "$RST" >&2
+    printf '%s\n' "$findings" >&2
+    printf '%sReview the matches above. To bypass (only if you are sure), use:%s\n' "$YEL" "$RST" >&2
+    printf '  git push --no-verify\n\n' >&2
+    exit 1
+fi
+
+exit 0

--- a/.githooks/safe-allowlist.txt
+++ b/.githooks/safe-allowlist.txt
@@ -1,0 +1,23 @@
+# Allowlist for the pre-push hook — suppresses known false positives.
+#
+# One regex per line. Blank lines and '# ...' comments are ignored.
+# Matching is case-insensitive against the entire hit line
+# (the line from `grep -In`, e.g. "42:+some code here" or
+# "3:[commit-msg] abc1234 subject line").
+#
+# If ANY pattern here matches the hit line, the hit is dropped.
+#
+# Prefer specific patterns over broad ones — an over-broad allowlist
+# defeats the point of the hook. Anchor on file/path or unique context
+# where possible.
+#
+# Examples:
+#   # ignore trustedsec mentions in the example template only
+#   sensitive-keywords\.example
+#
+#   # allow the word "session" (which contains "ses") in test files
+#   tests/.*session
+#
+#   # allow a specific known-safe token literal used in fixtures
+#   fixtures/.*dummy-token-abc123
+example\.com

--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,5 @@ hashview/ssl/*
 # test artifacts / local env
 coverage.json
 .env.test
+# pre-push hook — local sensitive keywords (per-clone)
+.sensitive-keywords

--- a/tests/run_migration_e2e.sh
+++ b/tests/run_migration_e2e.sh
@@ -82,17 +82,33 @@ wait_healthy db
 wait_healthy db-fresh
 
 echo "== app-main: create + migrate the main-era schema =="
+# Compute main's alembic head from the migration files in the main worktree.
+# Waiting for ANY revision (the old behavior) races the seed load against the
+# still-running migration chain -- e.g. the seed references settings.max_runtime_jobs,
+# added by 0fa1e1dc4069, but the poll can break on an earlier revision like
+# e57e9bb43f01 and load the seed before that column exists.
+MAIN_HEAD="$(python3 - "$MAIN_WT/migrations/versions" <<'PY'
+import pathlib, re, sys
+versions = pathlib.Path(sys.argv[1])
+revs, downs = {}, set()
+for f in versions.glob("*.py"):
+    text = f.read_text()
+    rm = re.search(r"^revision\s*=\s*['\"]([^'\"]+)['\"]", text, re.M)
+    dm = re.search(r"^down_revision\s*=\s*['\"]([^'\"]+)['\"]", text, re.M)
+    if rm:
+        revs[rm.group(1)] = True
+    if dm:
+        downs.add(dm.group(1))
+heads = [r for r in revs if r not in downs]
+if len(heads) != 1:
+    sys.exit(f"expected exactly one alembic head, got {heads!r}")
+print(heads[0])
+PY
+)"
+echo "  main alembic head: $MAIN_HEAD"
 $COMPOSE up -d app-main
-# app-main runs its migrations during create_app (before serving); wait until the
-# alembic bookkeeping table has a revision recorded.
-rev=""
-for _ in $(seq 1 80); do
-  rev="$(db_exec db "SELECT version_num FROM alembic_version" 2>/dev/null | tr -d '[:space:]' || true)"
-  [ -n "$rev" ] && break
-  sleep 3
-done
-[ -n "$rev" ] || { echo "ERROR: app-main never recorded an alembic revision"; $COMPOSE logs --tail 120 app-main; exit 1; }
-echo "  main schema at revision: $rev"
+poll "app-main alembic at main head ($MAIN_HEAD)" \
+  "SELECT version_num FROM alembic_version" "$MAIN_HEAD"
 
 echo "== Load main-era seed =="
 $COMPOSE exec -T db mysql -h127.0.0.1 -uhashview -phashview hashview < tests/migration/seed_main.sql

--- a/tests/run_migration_e2e.sh
+++ b/tests/run_migration_e2e.sh
@@ -82,33 +82,34 @@ wait_healthy db
 wait_healthy db-fresh
 
 echo "== app-main: create + migrate the main-era schema =="
-# Compute main's alembic head from the migration files in the main worktree.
-# Waiting for ANY revision (the old behavior) races the seed load against the
-# still-running migration chain -- e.g. the seed references settings.max_runtime_jobs,
-# added by 0fa1e1dc4069, but the poll can break on an earlier revision like
-# e57e9bb43f01 and load the seed before that column exists.
-MAIN_HEAD="$(python3 - "$MAIN_WT/migrations/versions" <<'PY'
-import pathlib, re, sys
-versions = pathlib.Path(sys.argv[1])
-revs, downs = {}, set()
-for f in versions.glob("*.py"):
-    text = f.read_text()
-    rm = re.search(r"^revision\s*=\s*['\"]([^'\"]+)['\"]", text, re.M)
-    dm = re.search(r"^down_revision\s*=\s*['\"]([^'\"]+)['\"]", text, re.M)
-    if rm:
-        revs[rm.group(1)] = True
-    if dm:
-        downs.add(dm.group(1))
-heads = [r for r in revs if r not in downs]
-if len(heads) != 1:
-    sys.exit(f"expected exactly one alembic head, got {heads!r}")
-print(heads[0])
-PY
-)"
-echo "  main alembic head: $MAIN_HEAD"
 $COMPOSE up -d app-main
-poll "app-main alembic at main head ($MAIN_HEAD)" \
-  "SELECT version_num FROM alembic_version" "$MAIN_HEAD"
+# Wait for app-main's alembic_version to STABILIZE (not just become non-empty).
+# The old behavior -- break on the first recorded revision -- races the seed
+# load against a still-running migration chain: e.g. the seed references
+# settings.max_runtime_jobs (added by 0fa1e1dc4069), but a poll that catches
+# an earlier revision like e57e9bb43f01 loads the seed before that column
+# exists (ERROR 1054). We can't just wait for the parsed alembic head either,
+# because on some main revs app-main crashes mid-chain (e.g. a wordlist FK
+# insert that requires an admin user not yet created) and never reaches head.
+# Instead, poll until version_num is the same across 4 consecutive checks
+# (~20s of no change) -- that covers both "clean success" and "app-main got
+# stuck partway" while still ensuring the seed lands on a settled schema.
+echo "  waiting for app-main alembic_version to stabilize..."
+last=""; stable=0; rev=""
+for _ in $(seq 1 100); do
+  rev="$(db_exec db "SELECT version_num FROM alembic_version" 2>/dev/null | tr -d '[:space:]' || true)"
+  if [ -n "$rev" ] && [ "$rev" = "$last" ]; then
+    stable=$((stable + 1))
+    [ "$stable" -ge 4 ] && break
+  else
+    stable=0
+  fi
+  last="$rev"
+  sleep 5
+done
+[ -n "$rev" ] || { echo "ERROR: app-main never recorded an alembic revision"; $COMPOSE logs --tail 120 app-main; exit 1; }
+[ "$stable" -ge 4 ] || { echo "ERROR: app-main alembic_version never stabilized (last: '$rev')"; $COMPOSE logs --tail 120 app-main; exit 1; }
+echo "  main schema settled at revision: $rev"
 
 echo "== Load main-era seed =="
 $COMPOSE exec -T db mysql -h127.0.0.1 -uhashview -phashview hashview < tests/migration/seed_main.sql


### PR DESCRIPTION
Adds a local .githooks/pre-push scanner (with allowlist) that inspects outgoing commits for sensitive keywords loaded from a per-clone .sensitive-keywords file, which is now gitignored.

Enable with: git config core.hooksPath .githooks