### PR TITLE
fix(security): remove OS command injection in wordlist/rules download…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,9 @@ Notable changes will be documented here
 - Fixed several template rendering errors from unresolved merge conflicts in settings, jobs, and other pages
 - Fixed several hash import parsing issues
 
+### Security
+- Fixed an authenticated OS command injection (remote code execution) in the wordlist and rules download API (`GET /v1/rules/<id>`, `GET /v1/wordlists/<id>`): files are now compressed in-process instead of via a shell, and uploaded filenames are no longer reused to build on-disk paths (also closes a path-traversal write). CWE-78 / CWE-22. Reported by tonghuaroot.
+
 ## [v0.8.1-Beta] - 2023-08-18
 ### Added
 - Added support for max runtimes both for Jobs and Tasks. Admins can set the value (in hours) with = 0 being indefinate. 

--- a/hashview/api/routes.py
+++ b/hashview/api/routes.py
@@ -12,6 +12,8 @@ import json
 import secrets
 import hashlib
 import binascii
+import gzip
+import shutil
 
 api = Blueprint('api', __name__)
 
@@ -318,13 +320,19 @@ def v1_api_get_rules_download(rules_id):
 
     update_heartbeat(request.cookies.get('uuid'))
     rules = Rules.query.get(rules_id)
-    rules_name = rules.path.split('/')[-1]
-    cmd = "gzip -9 -k -c hashview/control/rules/" + rules_name + " > hashview/control/tmp/" + rules_name + ".gz"
-
-    # What command injection?!
-    # TODO
-    os.system(cmd)
-    return send_from_directory('control/tmp', rules_name + '.gz', mimetype = 'application/octet-stream')
+    if not rules:
+        return jsonify({'status': 404, 'type': 'Rules', 'msg': 'Rules file not found'}), 404
+    # rules.path is DB-controlled and must NEVER reach a shell (CWE-78). Resolve
+    # to a bare basename, gzip it in-process (no os.system), and stream the gz.
+    rules_name = os.path.basename(rules.path or '')
+    src_path = os.path.join(current_app.root_path, 'control/rules', rules_name)
+    if not rules_name or not os.path.isfile(src_path):
+        return jsonify({'status': 404, 'type': 'Rules', 'msg': 'Rules file missing on disk'}), 404
+    gz_name = rules_name + '.gz'
+    gz_path = os.path.join(current_app.root_path, 'control/tmp', gz_name)
+    with open(src_path, 'rb') as f_in, gzip.open(gz_path, 'wb', compresslevel=9) as f_out:
+        shutil.copyfileobj(f_in, f_out)
+    return send_from_directory('control/tmp', gz_name, mimetype='application/octet-stream')
 
 # Provide wordlist info (really should be plural)
 @api.route('/v1/wordlists', methods=['GET'])
@@ -348,14 +356,20 @@ def v1_api_get_wordlist_download(wordlist_id):
 
     update_heartbeat(request.cookies.get('uuid'))
     wordlist = Wordlists.query.get(wordlist_id)
-    wordlist_name = wordlist.path.split('/')[-1]
+    if not wordlist:
+        return jsonify({'status': 404, 'type': 'Wordlists', 'msg': 'Wordlist not found'}), 404
+    # wordlist.path is DB-controlled and must NEVER reach a shell (CWE-78).
+    # Resolve to a bare basename, gzip it in-process (no os.system), stream the gz.
+    wordlist_name = os.path.basename(wordlist.path or '')
+    src_path = os.path.join(current_app.root_path, 'control/wordlists', wordlist_name)
+    if not wordlist_name or not os.path.isfile(src_path):
+        return jsonify({'status': 404, 'type': 'Wordlists', 'msg': 'Wordlist file missing on disk'}), 404
     random_hex = secrets.token_hex(8)
-    cmd = "gzip -9 -k -c hashview/control/wordlists/" + wordlist_name + " > hashview/control/tmp/" + wordlist_name + "_" + random_hex + ".gz"
-
-    # What command injection?!
-    # TODO
-    os.system(cmd)
-    return send_from_directory('control/tmp', wordlist_name + "_" + random_hex + ".gz", mimetype = 'application/octet-stream')
+    gz_name = wordlist_name + "_" + random_hex + ".gz"
+    gz_path = os.path.join(current_app.root_path, 'control/tmp', gz_name)
+    with open(src_path, 'rb') as f_in, gzip.open(gz_path, 'wb', compresslevel=9) as f_out:
+        shutil.copyfileobj(f_in, f_out)
+    return send_from_directory('control/tmp', gz_name, mimetype='application/octet-stream')
 
 # Update Dynamic Wordlist
 @api.route('/v1/updateWordlist/<int:wordlist_id>', methods=['GET'])

--- a/hashview/utils/utils.py
+++ b/hashview/utils/utils.py
@@ -16,10 +16,19 @@ from flask_mail import Message
 
 
 def save_file(path, form_file):
-    """Function to safe file from form submission"""
+    """Save an uploaded file under a randomized, non-attacker-controlled name.
 
+    The uploaded filename comes straight from the multipart Content-Disposition
+    header and is fully attacker-controlled, so it is NOT used to build the
+    on-disk name: the file is stored as ``<random_hex>.txt`` inside ``path``.
+    Reusing any part of ``form_file.filename`` here previously let path
+    separators and shell metacharacters reach the on-disk name, which fed the
+    os.system() download sinks (CWE-78) and allowed path-traversal writes
+    (CWE-22). Legitimate uploads are unaffected (they already resolved to
+    ``<hex>.txt``); display names are stored separately by the callers.
+    """
     random_hex = secrets.token_hex(8)
-    file_name = random_hex + os.path.split(form_file.filename)[0] + '.txt'
+    file_name = random_hex + '.txt'
     file_path = os.path.join(current_app.root_path, path, file_name)
     form_file.save(file_path)
     return file_path

--- a/tests/unit/test_security_filename_command_injection.py
+++ b/tests/unit/test_security_filename_command_injection.py
@@ -1,0 +1,112 @@
+"""Security regression tests for the wordlist/rules filename command-injection
+report (GHSA / tonghuaroot).
+
+Two layers are covered:
+
+* ``save_file`` must never let an attacker-controlled upload filename reach the
+  on-disk name (CWE-22 path traversal / CWE-78 command-injection source).
+* the ``/v1/rules/<id>`` and ``/v1/wordlists/<id>`` download endpoints must gzip
+  the file WITHOUT invoking a shell, so a malicious stored path cannot execute
+  commands (CWE-78 sink).
+
+The download tests plant a source file whose basename is a shell
+command-substitution payload and assert the sentinel command never runs.
+"""
+
+import gzip
+import os
+import re
+
+import hashview.utils.utils as u
+from hashview.models import Rules, Users, Wordlists, db
+
+
+def _api_user():
+    user = Users(first_name="A", last_name="B", email_address="a@e.com",
+                 password="x", admin=True, api_key="test-api-key")
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+def _seed_source(app, subdir, payload_name, content=b"body\n"):
+    src = os.path.join(app.root_path, "control", subdir, payload_name)
+    with open(src, "wb") as f:
+        f.write(content)
+    return src
+
+
+# --- save_file source hardening --------------------------------------------
+
+def test_save_file_ignores_attacker_controlled_filename(app):
+    """The uploaded filename is attacker-controlled and must be discarded: the
+    on-disk name is a random ``<hex>.txt`` and the write stays inside the target
+    directory (no traversal), regardless of separators/metacharacters."""
+    class _EvilFile:
+        def __init__(self, filename):
+            self.filename = filename
+
+        def save(self, dst):
+            with open(dst, "wb") as fh:
+                fh.write(b"payload")
+
+    control_tmp = os.path.realpath(os.path.join(app.root_path, "control", "tmp"))
+    for evil in ["$(id)/x.txt", "../../../../tmp/evil/y.txt", "a;touch pwned;.txt",
+                 "`whoami`/z", "|nc attacker 1234/x"]:
+        path = u.save_file("control/tmp", _EvilFile(evil))
+        try:
+            assert re.fullmatch(r"[0-9a-f]{16}\.txt", os.path.basename(path)), path
+            assert os.path.realpath(path).startswith(control_tmp + os.sep)
+            assert os.path.exists(path)
+        finally:
+            if os.path.exists(path):
+                os.remove(path)
+
+
+# --- download sinks must not reach a shell (CWE-78) -------------------------
+
+def test_rules_download_does_not_execute_shell(app, client):
+    user = _api_user()
+    sentinel = "pwned_rules_sentinel"
+    payload_name = "$(touch " + sentinel + ").txt"
+    src = _seed_source(app, "rules", payload_name)
+    rule = Rules(name="evil", owner_id=user.id,
+                 path="control/rules/" + payload_name, checksum="x")
+    db.session.add(rule)
+    db.session.commit()
+    client.set_cookie("uuid", "test-api-key")
+    gz_leftover = os.path.join(app.root_path, "control", "tmp", payload_name + ".gz")
+    try:
+        resp = client.get(f"/v1/rules/{rule.id}")
+        assert resp.status_code == 200
+        assert not os.path.exists(sentinel)                 # no shell command executed
+        assert gzip.decompress(resp.data) == b"body\n"       # served the gz of the source
+    finally:
+        for p in (src, gz_leftover, sentinel):
+            if os.path.exists(p):
+                os.remove(p)
+
+
+def test_wordlist_download_does_not_execute_shell(app, client):
+    user = _api_user()
+    sentinel = "pwned_wl_sentinel"
+    payload_name = "$(touch " + sentinel + ").txt"
+    src = _seed_source(app, "wordlists", payload_name)
+    wl = Wordlists(name="evil", owner_id=user.id, size=0,
+                   path="control/wordlists/" + payload_name, checksum="x")
+    db.session.add(wl)
+    db.session.commit()
+    client.set_cookie("uuid", "test-api-key")
+    tmp_dir = os.path.join(app.root_path, "control", "tmp")
+    try:
+        resp = client.get(f"/v1/wordlists/{wl.id}")
+        assert resp.status_code == 200
+        assert not os.path.exists(sentinel)
+        assert gzip.decompress(resp.data) == b"body\n"
+    finally:
+        for fn in os.listdir(tmp_dir):                       # gz name has a random suffix
+            if fn.startswith(payload_name):
+                os.remove(os.path.join(tmp_dir, fn))
+        for p in (src, sentinel):
+            if os.path.exists(p):
+                os.remove(p)


### PR DESCRIPTION
… (CWE-78)

The /v1/rules/<id> and /v1/wordlists/<id> download endpoints built a shell command by string-concatenating the stored file path and ran it via os.system(), so a filename containing shell metacharacters achieved arbitrary command execution as the hashview process user (root in the Docker image). The path originated from save_file(), which embedded the attacker-controlled multipart upload filename (os.path.split(filename)[0]) into the stored name unsanitized.

- api/routes.py: gzip the file IN-PROCESS (gzip + shutil.copyfileobj) with no shell; resolve it via os.path.basename() and stream the result. The served filename shape is preserved so the agent download flow is unchanged. Missing rows/files now return a clean 404 instead of crashing.
- utils.py: save_file() no longer reuses any part of the uploaded filename; files are stored as <random_hex>.txt (also closes a path-traversal write, CWE-22). Legitimate uploads are unaffected (they already resolved to <hex>.txt); display names are stored separately by callers.
- test: save_file neutralization + route-level regression proving the download endpoints never invoke a shell (verified to fail against the vulnerable code).

Reported by tonghuaroot (GHSA). Affected <= 0.8.2.