### PR TITLE
test: broaden hostile-filename coverage for save_file

### DIFF
--- a/tests/unit/test_utils_misc.py
+++ b/tests/unit/test_utils_misc.py
@@ -69,7 +69,22 @@ def test_save_file_ignores_attacker_controlled_filename(app):
 
     control_tmp = os.path.realpath(os.path.join(app.root_path, "control", "tmp"))
     for evil in ["$(id)/x.txt", "../../../../tmp/evil/y.txt", "a;touch pwned;.txt",
-                 "`whoami`/z", "|nc attacker 1234/x"]:
+                 "`whoami`/z", "|nc attacker 1234/x",
+                 # Windows-style traversal: os.path.split on POSIX treats "\"
+                 # as an ordinary character, so a secure_filename-style fix
+                 # must strip it too.
+                 "..\\..\\..\\evil.txt",
+                 # Absolute path: os.path.join(base, "/abs") DISCARDS base.
+                 "/etc/cron.d/evil.txt",
+                 # Embedded NUL: open() raises ValueError if it reaches a path.
+                 "evil\x00.txt",
+                 # CRLF: header injection if a name flows into Content-Disposition.
+                 "evil\r\n.txt",
+                 # Degenerate names secure_filename collapses to "".
+                 "", ".", "..",
+                 # Fullwidth solidus (U+FF0F) and RTL override (U+202E):
+                 # bypass naive separator checks / spoof displayed names.
+                 "／..／etc／passwd", "‮gnp.evil.txt"]:
         path = u.save_file("control/tmp", _EvilFile(evil))
         try:
             base = os.path.basename(path)


### PR DESCRIPTION
Follow-up to #336, which randomized `save_file()` on-disk names so attacker-controlled upload filenames never reach disk.

This extends the regression test with additional hostile-filename classes so a future reintroduction of filename reuse (e.g. a `secure_filename`-style refactor) is caught:

- `..\..\..\evil.txt` — Windows-style traversal; POSIX `os.path.split` treats `\` as an ordinary character
- `/etc/cron.d/evil.txt` — absolute path, guarding the `os.path.join` base-discard foot-gun
- `evil\x00.txt` — embedded NUL byte (`open()` raises `ValueError` if it reaches a path)
- `evil\r\n.txt` — CRLF, relevant if a name ever flows into a `Content-Disposition` header
- `""`, `"."`, `".."` — degenerate names `secure_filename` collapses to empty
- Fullwidth solidus (U+FF0F) and RTL override (U+202E) — Unicode separator bypass / display spoofing

Test-only change; all cases assert the stored name is exactly `<16-hex>.txt` and the resolved path stays inside the target directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)