### PR TITLE
fix(security): prevent command injection via task mask/rules on agent…

### DIFF
--- a/hashview/tasks/forms.py
+++ b/hashview/tasks/forms.py
@@ -3,6 +3,7 @@ from flask_wtf import FlaskForm
 from wtforms import StringField, SubmitField, SelectField
 from wtforms.validators import DataRequired, InputRequired, ValidationError
 from hashview.models import Tasks
+from hashview.utils.utils import validate_hashcat_combinator_rule, validate_hashcat_mask
 
 
 class TasksForm(FlaskForm):
@@ -26,3 +27,21 @@ class TasksForm(FlaskForm):
         task = Tasks.query.filter_by(name = name.data).first()
         if task:
             raise ValidationError('That task name is taken. Please choose a different one.')
+
+    def validate_mask(self, field):
+        try:
+            validate_hashcat_mask(field.data)
+        except ValueError as exc:
+            raise ValidationError(str(exc)) from exc
+
+    def validate_j_rule(self, field):
+        try:
+            validate_hashcat_combinator_rule(field.data)
+        except ValueError as exc:
+            raise ValidationError(str(exc)) from exc
+
+    def validate_k_rule(self, field):
+        try:
+            validate_hashcat_combinator_rule(field.data)
+        except ValueError as exc:
+            raise ValidationError(str(exc)) from exc

--- a/hashview/utils/utils.py
+++ b/hashview/utils/utils.py
@@ -3,6 +3,7 @@ import os
 import secrets
 import hashlib
 import re
+import shlex
 import struct
 import binascii
 import _md5
@@ -340,6 +341,33 @@ def update_dynamic_wordlist(wordlist_id):
     wordlist.last_updated = datetime.today()
     db.session.commit()
 
+_HASHCAT_MASK_BAD = re.compile(r'[;&|`$()\n\r<>\\#]')
+_HASHCAT_RULE_BAD = re.compile(r'[;&|`()\n\r<>\\#]')
+
+
+def validate_hashcat_mask(value):
+    """Reject shell metacharacters in user-supplied hashcat masks (CWE-78)."""
+    if value is None or value == '':
+        return
+    if _HASHCAT_MASK_BAD.search(value):
+        raise ValueError('Mask contains disallowed shell metacharacters')
+
+
+def validate_hashcat_combinator_rule(value):
+    """Reject shell metacharacters in combinator -j/-k rules (CWE-78)."""
+    if value is None or value == '':
+        return
+    if _HASHCAT_RULE_BAD.search(value):
+        raise ValueError('Rule contains disallowed shell metacharacters')
+
+
+def _normalize_task_rule(value):
+    """Tasks.j_rule/k_rule were occasionally stored as 1-tuples; normalize."""
+    if isinstance(value, tuple):
+        value = value[0] if value else None
+    return value if isinstance(value, str) else None
+
+
 def build_hashcat_command(job_id, task_id):
     """Function to build the main hashcat cmd we use to crack"""
 
@@ -400,23 +428,36 @@ def build_hashcat_command(job_id, task_id):
             cmd += ' ' + target_file + ' ' + relative_wordlist_path
     # combinator
     elif attackmode == 1:
-        if isinstance(task.j_rule, str):
-            j_rule = " -j '" + task.j_rule + "' "
+        j_rule_str = _normalize_task_rule(task.j_rule)
+        if j_rule_str:
+            validate_hashcat_combinator_rule(j_rule_str)
+            j_rule = ' -j ' + shlex.quote(j_rule_str) + ' '
         else:
             j_rule = ' '
-        
-        if isinstance(task.k_rule, str):
-            k_rule = " -k '" + task.k_rule + "' "
+
+        k_rule_str = _normalize_task_rule(task.k_rule)
+        if k_rule_str:
+            validate_hashcat_combinator_rule(k_rule_str)
+            k_rule = ' -k ' + shlex.quote(k_rule_str) + ' '
         else:
             k_rule = ' '
         cmd += ' ' + ' -a 1 ' + target_file + ' ' + relative_wordlist_path + j_rule + relative_wordlist_path + k_rule
     # maskmode
     elif attackmode == 3:
+        if mask:
+            validate_hashcat_mask(mask)
+            mask = shlex.quote(mask)
         cmd += ' ' + ' -a 3 ' + target_file + ' ' + mask
     # Hybrid (Wordlist + Mask)
     elif attackmode == 6:
+        if mask:
+            validate_hashcat_mask(mask)
+            mask = shlex.quote(mask)
         cmd += ' ' + ' -a 6 ' + target_file + ' ' + relative_wordlist_path + ' ' + mask
     elif attackmode == 7:
+        if mask:
+            validate_hashcat_mask(mask)
+            mask = shlex.quote(mask)
         cmd += ' ' + ' -a 7 ' + target_file + ' ' + mask + ' ' + relative_wordlist_path
 
     # Mask mode

--- a/install/hashview-agent/hashview-agent.py
+++ b/install/hashview-agent/hashview-agent.py
@@ -12,6 +12,9 @@ import signal
 import builtins
 import time
 import subprocess
+import shlex
+import gzip
+import shutil
 from contextlib import suppress
 from threading import Thread
 from datetime import datetime, timedelta
@@ -103,27 +106,49 @@ if not os.path.exists('agent/config.conf'):
 
     config.close()
 
-from agent.api import api    
-    
-def run_command(command):
-    try:
-        cmd = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        #cmd = subprocess.Popen(["python", file],stdout=subprocess.PIPE,stderr=subprocess.PIPE)
-        output, error = cmd.communicate()
+from agent.api import api
 
-        if(error):
-            print(error)
-            if 'hashfile is empty or corrupt' not in str(error):
-                if 'Terminated' in str(error):
-                    sys.exit()
-                else:
-                    api.sendError(str(error))
-                    os.kill(os.getpid(), signal.SIGINT)
-    except OSError as e: 
+
+def _handle_subprocess_error(error):
+    if error:
+        print(error)
+        if b'hashfile is empty or corrupt' not in error:
+            if b'Terminated' in error:
+                sys.exit()
+            else:
+                api.sendError(error.decode('utf-8', errors='replace'))
+                os.kill(os.getpid(), signal.SIGINT)
+
+
+def run_command(command):
+    """Run a subprocess without invoking a shell (CWE-78)."""
+    try:
+        if isinstance(command, (list, tuple)):
+            argv = list(command)
+        else:
+            argv = shlex.split(command)
+        cmd = subprocess.Popen(argv, shell=False, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        output, error = cmd.communicate()
+        _handle_subprocess_error(error)
+        return output
+    except OSError as e:
         print("inside exception", e)
         api.sendError(str(e))
-        #sys.exit()
         os.kill(os.getpid(), signal.SIGINT)
+
+
+def _gunzip_file(gz_path):
+    """Decompress a .gz file in place, returning the output path."""
+    out_path = gz_path[:-3] if gz_path.endswith('.gz') else gz_path + '.out'
+    with gzip.open(gz_path, 'rb') as gz_file:
+        with open(out_path, 'wb') as out_file:
+            shutil.copyfileobj(gz_file, out_file)
+    os.remove(gz_path)
+    return out_path
+
+
+def _move_file(src, dest):
+    shutil.move(src, dest)
 
 def send_heartbeat(agent_status, hc_status):
     return api.heartbeat(agent_status, hc_status)
@@ -176,8 +201,7 @@ def sync_rules():
                 with open(tmp_gz, 'wb') as f:
                     f.write(compressed)
 
-                run_command(f'gunzip {tmp_gz}')
-                tmp_file = os.path.join('control/tmp', random_hex)
+                tmp_file = _gunzip_file(tmp_gz)
 
                 sha256 = hashlib.sha256()
                 with open(tmp_file, 'rb') as f:
@@ -188,7 +212,7 @@ def sync_rules():
 
                 if local_checksum == remote_checksum:
                     dest = os.path.join('control/rules', filename)
-                    run_command(f'mv {tmp_file} {dest}')
+                    _move_file(tmp_file, dest)
                     new_manifest[rule_id] = {'checksum': local_checksum, 'filename': filename}
                 else:
                     print('Checksum verification failed for rule', rule_id)
@@ -204,8 +228,7 @@ def sync_rules():
             with open(tmp_gz, 'wb') as f:
                 f.write(compressed)
 
-            run_command(f'gunzip {tmp_gz}')
-            tmp_file = os.path.join('control/tmp', random_hex)
+            tmp_file = _gunzip_file(tmp_gz)
 
             sha256 = hashlib.sha256()
             with open(tmp_file, 'rb') as f:
@@ -216,7 +239,7 @@ def sync_rules():
 
             if local_checksum == remote_checksum:
                 dest = os.path.join('control/rules', filename)
-                run_command(f'mv {tmp_file} {dest}')
+                _move_file(tmp_file, dest)
                 new_manifest[rule_id] = {'checksum': local_checksum, 'filename': filename}
             else:
                 print('Checksum verification failed for new rule', rule_id)
@@ -261,8 +284,7 @@ def sync_wordlists():
                 with open(tmp_gz, 'wb') as f:
                     f.write(compressed)
 
-                run_command(f'gunzip {tmp_gz}')
-                tmp_file = os.path.join('control/tmp', random_hex)
+                tmp_file = _gunzip_file(tmp_gz)
 
                 sha256 = hashlib.sha256()
                 with open(tmp_file, 'rb') as f:
@@ -273,7 +295,7 @@ def sync_wordlists():
 
                 if local_checksum == remote_checksum:
                     dest = os.path.join('control/wordlists', filename)
-                    run_command(f'mv {tmp_file} {dest}')
+                    _move_file(tmp_file, dest)
                     new_manifest[wl_id] = {'checksum': local_checksum, 'filename': filename}
                 else:
                     print('Checksum verification failed for wordlist', wl_id)
@@ -289,8 +311,7 @@ def sync_wordlists():
             with open(tmp_gz, 'wb') as f:
                 f.write(compressed)
 
-            run_command(f'gunzip {tmp_gz}')
-            tmp_file = os.path.join('control/tmp', random_hex)
+            tmp_file = _gunzip_file(tmp_gz)
 
             sha256 = hashlib.sha256()
             with open(tmp_file, 'rb') as f:
@@ -300,7 +321,7 @@ def sync_wordlists():
 
             if local_checksum == remote_checksum:
                 dest = os.path.join('control/wordlists', filename)
-                run_command(f'mv {tmp_file} {dest}')
+                _move_file(tmp_file, dest)
                 new_manifest[wl_id] = {'checksum': local_checksum, 'filename': filename}
             else:
                 print('Checksum verification failed for new wordlist', wl_id)
@@ -339,9 +360,36 @@ def replaceHashcatBinPath(cmd):
     from agent.config import Config
     return cmd.replace('@HASHCATBINPATH@', Config.HC_BIN_PATH)
 
-def run_hashcat(cmd):
-    run_command(cmd)
-    #os.system(cmd)
+def run_hashcat(command, status_output_path):
+    """Run hashcat without a shell; stream JSON status lines to a file."""
+    argv = shlex.split(replaceHashcatBinPath(command))
+    argv.append('--status-json')
+    print(' '.join(argv))
+    try:
+        proc = subprocess.Popen(
+            argv,
+            shell=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        stderr_data = []
+
+        def drain_stderr():
+            stderr_data.append(proc.stderr.read())
+
+        stderr_thread = Thread(target=drain_stderr)
+        stderr_thread.start()
+        with open(status_output_path, 'wb') as status_file:
+            for chunk in iter(lambda: proc.stdout.read(4096), b''):
+                status_file.write(chunk)
+                status_file.flush()
+        proc.wait()
+        stderr_thread.join()
+        _handle_subprocess_error(b''.join(stderr_data))
+    except OSError as e:
+        print("inside exception", e)
+        api.sendError(str(e))
+        os.kill(os.getpid(), signal.SIGINT)
 
 def time_difference(future_timestamp):
     # Get the current time and calculate the difference
@@ -531,11 +579,11 @@ if __name__ == '__main__':
                 # Download our hashfile. File name will be generated to match that of whats expected by the jobtask cmd.
                 download_hashfile(job['id'], job_task['task_id'], job['hashfile_id'])
 
-                cmd = replaceHashcatBinPath(job_task['command']) + ' --status-json | tee control/outfiles/hcoutput_' + str(job['id']) + '_' + str(job_task['id']) + '.txt'
-                print(cmd)
+                status_output_path = 'control/outfiles/hcoutput_' + str(job['id']) + '_' + str(job_task['id']) + '.txt'
+                print(replaceHashcatBinPath(job_task['command']) + ' --status-json')
 
                 # run in thread
-                thread = Thread(target=run_hashcat, args=(cmd,))
+                thread = Thread(target=run_hashcat, args=(job_task['command'], status_output_path))
                 thread.start()
                 
                 while thread.is_alive():

--- a/tests/agent_unit/conftest.py
+++ b/tests/agent_unit/conftest.py
@@ -1,0 +1,47 @@
+"""Unit tests for the hashview agent (install/hashview-agent).
+
+The agent ships as a script tree rather than an installed package, so its root
+goes on sys.path here. Importing the ``agent`` package has a side effect:
+``agent/http/http.py`` does ``from agent.config import Config``, and
+agent/config.py reads ``agent/config.conf`` relative to the CWD at class
+definition time, raising KeyError when that file is absent. We pre-seed
+sys.modules with a stub ``agent.config`` so the real module is never imported.
+
+The parent tests/conftest.py declares autouse fixtures that need Playwright and
+a live server; they're overridden below so these tests stay offline.
+"""
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+AGENT_ROOT = Path(__file__).resolve().parents[2] / "install" / "hashview-agent"
+if str(AGENT_ROOT) not in sys.path:
+    sys.path.insert(0, str(AGENT_ROOT))
+
+if "agent.config" not in sys.modules:
+    _config_stub = types.ModuleType("agent.config")
+
+    class Config:
+        HASHVIEW_SERVER = "hashview.test"
+        HASHVIEW_PORT = "8443"
+        USE_SSL = "True"
+        NAME = "test-agent"
+        UUID = "00000000-0000-0000-0000-000000000000"
+        HC_BIN_PATH = "/usr/bin/hashcat"
+
+    _config_stub.Config = Config
+    sys.modules["agent.config"] = _config_stub
+
+
+@pytest.fixture(autouse=True)
+def ensure_setup():
+    """Override parent autouse so live_server isn't requested."""
+    return
+
+
+@pytest.fixture(autouse=True)
+def configure_page():
+    """Override parent autouse so the Playwright `page` fixture isn't pulled."""
+    return

--- a/tests/agent_unit/test_agent_no_shell.py
+++ b/tests/agent_unit/test_agent_no_shell.py
@@ -1,0 +1,323 @@
+"""Agent-side half of the CWE-78 fix (install/hashview-agent/hashview-agent.py).
+
+The server now validates and ``shlex.quote``s task masks/rules, but the string it
+stores on ``JobTasks.command`` is only safe if the agent stops handing it to a
+shell. These tests pin the agent end of that contract:
+
+  * ``run_command`` / ``run_hashcat`` spawn with ``shell=False`` on an argv list.
+  * a quoted argument built by the server survives ``shlex.split`` as ONE argv
+    entry (the round trip that makes server-side quoting meaningful).
+  * the rule/wordlist sync no longer shells out to ``gunzip``/``mv`` at all, so a
+    server-supplied filename carrying shell metacharacters is just a filename.
+  * no call anywhere in the script passes a truthy ``shell=``.
+"""
+import ast
+import gzip
+import importlib.util
+import json
+import os
+import shlex
+import sys
+import types
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+AGENT_ROOT = Path(__file__).resolve().parents[2] / "install" / "hashview-agent"
+AGENT_SCRIPT = AGENT_ROOT / "hashview-agent.py"
+
+
+def _load_agent_main():
+    """Import hashview-agent.py as a module.
+
+    At import it parses argv, builds a Config from agent/config.conf and imports
+    psutil, so argv is stubbed, os.path.exists is patched to claim the config
+    file exists, and psutil is stubbed if the host lacks it.
+    """
+    if "psutil" not in sys.modules:
+        stub = types.ModuleType("psutil")
+
+        class _PsutilError(Exception):
+            pass
+
+        stub.Error = _PsutilError
+        stub.NoSuchProcess = type("NoSuchProcess", (_PsutilError,), {})
+        stub.AccessDenied = type("AccessDenied", (_PsutilError,), {})
+        stub.ZombieProcess = type("ZombieProcess", (_PsutilError,), {})
+        stub.process_iter = lambda *a, **k: []
+        sys.modules["psutil"] = stub
+
+    real_exists = os.path.exists
+    with mock.patch.object(sys, "argv", ["hashview-agent.py"]), \
+         mock.patch(
+             "os.path.exists",
+             side_effect=lambda p: True if str(p).endswith("agent/config.conf") else real_exists(p),
+         ):
+        spec = importlib.util.spec_from_file_location("hashview_agent_main_no_shell", AGENT_SCRIPT)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+    return mod
+
+
+agent_main = _load_agent_main()
+
+
+class _FakeProc:
+    """Stands in for a Popen handle; records nothing itself."""
+
+    def __init__(self, stdout=b"", stderr=b""):
+        self._stdout = stdout
+        self.stdout = _Reader(stdout)
+        self.stderr = _Reader(stderr)
+
+    def communicate(self):
+        return self._stdout, b""
+
+    def wait(self):
+        return 0
+
+
+class _Reader:
+    def __init__(self, data):
+        self._data = data
+        self._done = False
+
+    def read(self, size=-1):
+        if self._done:
+            return b""
+        self._done = True
+        return self._data
+
+
+@pytest.fixture()
+def spawns(monkeypatch):
+    """Capture every Popen call instead of running it."""
+    calls = []
+
+    def fake_popen(argv, **kwargs):
+        calls.append((argv, kwargs))
+        return _FakeProc()
+
+    monkeypatch.setattr(agent_main.subprocess, "Popen", fake_popen)
+    return calls
+
+
+# --------------------------------------------------------------------------- #
+# run_command: argv, never a shell string                                     #
+# --------------------------------------------------------------------------- #
+
+
+def test_run_command_spawns_argv_without_a_shell(spawns):
+    agent_main.run_command("gunzip control/tmp/abc.gz")
+
+    (argv, kwargs), = spawns
+    assert argv == ["gunzip", "control/tmp/abc.gz"]
+    assert kwargs["shell"] is False
+
+
+def test_run_command_does_not_interpret_shell_metacharacters(spawns):
+    """The payload becomes literal argv entries; there is no shell to run it."""
+    agent_main.run_command("gunzip 'evil; touch pwned' `id`")
+
+    (argv, kwargs), = spawns
+    assert kwargs["shell"] is False
+    assert argv == ["gunzip", "evil; touch pwned", "`id`"]
+    assert not os.path.exists("pwned")
+
+
+def test_run_command_passes_a_list_through_unchanged(spawns):
+    agent_main.run_command(["mv", "a b", "c;d"])
+
+    (argv, kwargs), = spawns
+    assert argv == ["mv", "a b", "c;d"]
+    assert kwargs["shell"] is False
+
+
+# --------------------------------------------------------------------------- #
+# run_hashcat: the sink for the server-built command string                    #
+# --------------------------------------------------------------------------- #
+
+
+def test_run_hashcat_spawns_argv_without_a_shell(spawns, tmp_path):
+    status = tmp_path / "status.json"
+    agent_main.run_hashcat("@HASHCATBINPATH@ -m 1000 -a 3 hashes.txt '?l?l ?d'", str(status))
+
+    (argv, kwargs), = spawns
+    assert kwargs["shell"] is False
+    assert argv[0] == "/usr/bin/hashcat"      # from the stubbed Config
+    assert argv[-1] == "--status-json"
+
+
+def test_run_hashcat_keeps_a_server_quoted_mask_as_one_argument(spawns, tmp_path):
+    """The other half of the server's ``shlex.quote``.
+
+    ``build_hashcat_command`` quotes hc_mask, so a mask containing a space
+    arrives as ``'?l?l ?d?d'``. shlex.split must hand hashcat exactly one
+    positional argument — and an injection payload, had one been stored by a
+    pre-fix server, arrives as inert text rather than a command.
+    """
+    status = tmp_path / "status.json"
+    mask = "?l?l ?d?d"
+    payload = "?a;touch pwned;#"
+    command = (
+        "@HASHCATBINPATH@ -m 1000 -a 3 hashes.txt "
+        + shlex.quote(mask) + " " + shlex.quote(payload)
+    )
+
+    agent_main.run_hashcat(command, str(status))
+
+    (argv, _kwargs), = spawns
+    assert mask in argv
+    assert payload in argv                    # one inert token, not a command
+    assert not os.path.exists("pwned")
+
+
+# --------------------------------------------------------------------------- #
+# sync_rules / sync_wordlists: no gunzip/mv subprocesses at all                #
+# --------------------------------------------------------------------------- #
+
+RULE_BODY = b":\nu\nl\n"
+
+
+def _sha256(data):
+    import hashlib
+
+    return hashlib.sha256(data).hexdigest()
+
+
+@pytest.fixture()
+def agent_cwd(tmp_path, monkeypatch):
+    """A throwaway agent working tree with fresh, empty manifests."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "control" / "rules").mkdir(parents=True)
+    (tmp_path / "control" / "wordlists").mkdir()
+    (tmp_path / "control" / "tmp").mkdir()
+    monkeypatch.setattr(agent_main, "rules_manifest",
+                        agent_main.Manifest(str(tmp_path / "control" / "rules_manifest.json")))
+    return tmp_path
+
+
+@pytest.fixture()
+def no_spawn(monkeypatch):
+    """Any attempt to spawn a process during a sync is a hard failure."""
+    def forbidden(*args, **kwargs):
+        raise AssertionError(f"sync spawned a process: {args!r} {kwargs!r}")
+
+    monkeypatch.setattr(agent_main.subprocess, "Popen", forbidden)
+    monkeypatch.setattr(agent_main.os, "system", forbidden, raising=False)
+
+
+def _serve_one_rule(monkeypatch, path, body=RULE_BODY, checksum=None):
+    """Stub the server side: one rule whose file is the gzip of ``body``."""
+    entry = {"id": 7, "path": path, "checksum": checksum or _sha256(body)}
+    monkeypatch.setattr(agent_main.api, "rules_list", lambda: json.dumps([entry]))
+    monkeypatch.setattr(agent_main.api, "get_rules_file", lambda rule_id: gzip.compress(body))
+    return entry
+
+
+def test_rules_sync_installs_a_rule_without_spawning_anything(agent_cwd, no_spawn, monkeypatch):
+    _serve_one_rule(monkeypatch, "control/rules/best64.rule")
+
+    agent_main.sync_rules()
+
+    assert (agent_cwd / "control" / "rules" / "best64.rule").read_bytes() == RULE_BODY
+    assert agent_main.rules_manifest.data["7"]["filename"] == "best64.rule"
+    # the temp download is consumed, not left behind in control/tmp
+    assert list((agent_cwd / "control" / "tmp").iterdir()) == []
+
+
+def test_rules_sync_treats_shell_metacharacters_as_a_literal_filename(agent_cwd, no_spawn,
+                                                                     monkeypatch):
+    """``mv {tmp_file} {dest}`` under shell=True ran the server-supplied path.
+
+    With no shell in the loop the payload can only ever be an (ugly) filename.
+    """
+    payload = "evil; touch pwned #`id`$(id)"
+    _serve_one_rule(monkeypatch, f"control/rules/{payload}")
+
+    agent_main.sync_rules()
+
+    rules_dir = agent_cwd / "control" / "rules"
+    assert (rules_dir / payload).read_bytes() == RULE_BODY
+    assert not (agent_cwd / "pwned").exists()
+    assert not (rules_dir / "pwned").exists()
+
+
+def test_rules_sync_discards_a_checksum_mismatch(agent_cwd, no_spawn, monkeypatch):
+    _serve_one_rule(monkeypatch, "control/rules/abc123", checksum="0" * 64)
+
+    agent_main.sync_rules()
+
+    assert agent_main.rules_manifest.data == {}
+    assert list((agent_cwd / "control" / "rules").iterdir()) == []
+    assert list((agent_cwd / "control" / "tmp").iterdir()) == []
+
+
+# --------------------------------------------------------------------------- #
+# _gunzip_file replaced `run_command(f'gunzip {tmp_gz}')`                      #
+# --------------------------------------------------------------------------- #
+
+
+def test_gunzip_file_decompresses_in_process_and_removes_the_archive(tmp_path, no_spawn):
+    gz_path = tmp_path / "payload.gz"
+    gz_path.write_bytes(gzip.compress(RULE_BODY))
+
+    out_path = agent_main._gunzip_file(str(gz_path))
+
+    assert Path(out_path) == tmp_path / "payload"
+    assert Path(out_path).read_bytes() == RULE_BODY
+    assert not gz_path.exists()
+
+
+def test_gunzip_file_handles_a_name_with_shell_metacharacters(tmp_path, no_spawn):
+    """A filename that would have been a command substitution under the old
+    ``gunzip {tmp_gz}`` is now just a path."""
+    gz_path = tmp_path / "a b;`id`.gz"
+    gz_path.write_bytes(gzip.compress(RULE_BODY))
+
+    out_path = agent_main._gunzip_file(str(gz_path))
+
+    assert Path(out_path).read_bytes() == RULE_BODY
+    assert not (tmp_path / "pwned").exists()
+
+
+def test_gunzip_file_raises_on_a_corrupt_archive(tmp_path, no_spawn):
+    """The failure is a normal exception, not an unnoticed non-zero exit code
+    from a shelled-out gunzip."""
+    gz_path = tmp_path / "corrupt.gz"
+    gz_path.write_bytes(b"not gzip at all")
+
+    with pytest.raises(gzip.BadGzipFile):
+        agent_main._gunzip_file(str(gz_path))
+
+
+# --------------------------------------------------------------------------- #
+# Nothing may re-add a shell                                                  #
+# --------------------------------------------------------------------------- #
+
+
+def test_agent_script_never_passes_shell_true():
+    """Checked via the AST rather than a substring so prose about the old
+    behaviour in comments/docstrings doesn't trip it."""
+    tree = ast.parse(AGENT_SCRIPT.read_text())
+    shell_calls = [
+        ast.dump(node) for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        for kw in node.keywords
+        if kw.arg == "shell" and not (isinstance(kw.value, ast.Constant) and not kw.value.value)
+    ]
+    assert shell_calls == [], f"agent spawns a process through a shell: {shell_calls!r}"
+
+
+def test_agent_script_does_not_call_os_system():
+    tree = ast.parse(AGENT_SCRIPT.read_text())
+    os_system_calls = [
+        node for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "system"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "os"
+    ]
+    assert os_system_calls == [], "agent uses os.system (a shell) to spawn a process"

--- a/tests/unit/test_security_agent_task_cmdi.py
+++ b/tests/unit/test_security_agent_task_cmdi.py
@@ -1,0 +1,105 @@
+"""Security regression tests for agent task command injection (CWE-78).
+
+User-controlled task masks and combinator rules were concatenated into a shell
+command string on the server, stored on JobTasks.command, and executed by the
+agent with shell=True (including a ``| tee`` pipeline). These tests cover input
+validation, safe command construction, and rejection of known PoC payloads.
+"""
+
+import shlex
+
+import pytest
+
+import hashview.utils.utils as u
+from hashview.models import Customers, HashfileHashes, Hashes, Jobs, Tasks, Users, db
+
+
+def _seed_mask_task(app, mask):
+    user = Users(
+        first_name="A",
+        last_name="B",
+        email_address="agent-cmdi@example.com",
+        password="x",
+        admin=True,
+    )
+    customer = Customers(name="lab")
+    db.session.add_all([user, customer])
+    db.session.commit()
+
+    hash_entry = Hashes(
+        sub_ciphertext="deadbeef",
+        ciphertext="00000000000000000000000000000000",
+        hash_type=0,
+        cracked=False,
+    )
+    db.session.add(hash_entry)
+    db.session.commit()
+
+    hashfile_id = 1
+    db.session.add(
+        HashfileHashes(hash_id=hash_entry.id, hashfile_id=hashfile_id, username=None)
+    )
+    job = Jobs(
+        name="cmdi-job",
+        status="Queued",
+        hashfile_id=hashfile_id,
+        customer_id=customer.id,
+        owner_id=user.id,
+    )
+    task = Tasks(
+        name="cmdi-task",
+        owner_id=user.id,
+        hc_attackmode=3,
+        hc_mask=mask,
+    )
+    db.session.add_all([job, task])
+    db.session.commit()
+    return job, task
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "?a;touch /tmp/hv_cmdi_proof;#",
+        "?a;id>/tmp/hv_cmdi_id;#",
+        "$(touch pwned)",
+        "`id`",
+    ],
+)
+def test_validate_hashcat_mask_rejects_injection(payload):
+    with pytest.raises(ValueError, match="disallowed"):
+        u.validate_hashcat_mask(payload)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "$();touch pwned",
+        "x;id",
+        "`whoami`",
+    ],
+)
+def test_validate_hashcat_combinator_rule_rejects_injection(payload):
+    with pytest.raises(ValueError, match="disallowed"):
+        u.validate_hashcat_combinator_rule(payload)
+
+
+def test_validate_hashcat_mask_allows_normal_masks():
+    u.validate_hashcat_mask("?l?l?l?d?d?d")
+    u.validate_hashcat_mask("password?d?d")
+
+
+def test_build_hashcat_command_quotes_safe_mask(app):
+    safe_mask = "?l?l?l?d?d"
+    job, task = _seed_mask_task(app, safe_mask)
+    cmd = u.build_hashcat_command(job.id, task.id)
+    argv = shlex.split(cmd.replace("@HASHCATBINPATH@", "/usr/bin/hashcat"))
+    assert argv[-1] == safe_mask
+    assert "-a" in argv
+    assert "3" in argv
+
+
+def test_build_hashcat_command_rejects_malicious_mask(app):
+    job, task = _seed_mask_task(app, "?a;touch /tmp/x;#")
+    with pytest.raises(ValueError, match="disallowed"):
+        u.build_hashcat_command(job.id, task.id)

--- a/tests/unit/test_security_agent_task_cmdi.py
+++ b/tests/unit/test_security_agent_task_cmdi.py
@@ -11,7 +11,16 @@ import shlex
 import pytest
 
 import hashview.utils.utils as u
-from hashview.models import Customers, HashfileHashes, Hashes, Jobs, Tasks, Users, db
+from hashview.models import (
+    Customers,
+    Hashes,
+    HashfileHashes,
+    Jobs,
+    Tasks,
+    Users,
+    Wordlists,
+    db,
+)
 
 
 def _seed_mask_task(app, mask):
@@ -103,3 +112,165 @@ def test_build_hashcat_command_rejects_malicious_mask(app):
     job, task = _seed_mask_task(app, "?a;touch /tmp/x;#")
     with pytest.raises(ValueError, match="disallowed"):
         u.build_hashcat_command(job.id, task.id)
+
+
+# --------------------------------------------------------------------------- #
+# The form is the real boundary: a mask/rule that never reaches the DB can     #
+# never reach JobTasks.command. build_hashcat_command's validate call is the   #
+# backstop for rows that predate the fix.                                      #
+# --------------------------------------------------------------------------- #
+
+
+def _task_form(app, **fields):
+    """A bound TasksForm with CSRF off and the SelectField choices the route
+    populates at request time (they're empty on the class)."""
+    from werkzeug.datastructures import MultiDict
+
+    from hashview.tasks.forms import TasksForm
+
+    data = {"name": "form-task", "hc_attackmode": "3", "wl_id": "1",
+            "wl_id_2": "1", "rule_id": "None"}
+    data.update(fields)
+    with app.test_request_context():
+        form = TasksForm(formdata=MultiDict(data), meta={"csrf": False})
+    form.wl_id.choices = [("1", "wl")]
+    form.wl_id_2.choices = [("1", "wl")]
+    form.rule_id.choices = [("None", "None")]
+    return form
+
+
+@pytest.mark.parametrize("field", ["mask", "j_rule", "k_rule"])
+def test_tasks_form_rejects_injection_in_mask_and_rules(app, field):
+    form = _task_form(app, **{field: "?a;touch /tmp/hv_cmdi_proof;#"})
+    assert not form.validate()
+    assert "disallowed" in " ".join(form.errors[field])
+
+
+def test_tasks_form_accepts_a_normal_mask_and_rules(app):
+    form = _task_form(app, mask="?l?l?l?d?d?d", j_rule="$-", k_rule="$!")
+    assert form.validate(), form.errors
+
+
+def test_tasks_form_accepts_empty_mask_and_rules(app):
+    """The fields are optional; blank input must not be treated as an attack."""
+    form = _task_form(app, mask="", j_rule="", k_rule="")
+    assert form.validate(), form.errors
+
+
+# --------------------------------------------------------------------------- #
+# Every attackmode that interpolates user input, not just maskmode (3).        #
+# --------------------------------------------------------------------------- #
+
+
+def _seed_task(app, **task_fields):
+    """Seed a job + task with a real wordlist, for any attackmode."""
+    user = Users(
+        first_name="A",
+        last_name="B",
+        email_address="agent-cmdi-modes@example.com",
+        password="x",
+        admin=True,
+    )
+    customer = Customers(name="lab")
+    db.session.add_all([user, customer])
+    db.session.commit()
+
+    hash_entry = Hashes(
+        sub_ciphertext="deadbeef",
+        ciphertext="00000000000000000000000000000000",
+        hash_type=0,
+        cracked=False,
+    )
+    db.session.add(hash_entry)
+    db.session.commit()
+    db.session.add(HashfileHashes(hash_id=hash_entry.id, hashfile_id=1, username=None))
+
+    wordlist = Wordlists(
+        name="wl",
+        owner_id=user.id,
+        type="static",
+        path="control/wordlists/rockyou.txt",
+        size=1,
+        checksum="0" * 64,
+    )
+    job = Jobs(
+        name="cmdi-job",
+        status="Queued",
+        hashfile_id=1,
+        customer_id=customer.id,
+        owner_id=user.id,
+    )
+    db.session.add_all([wordlist, job])
+    db.session.commit()
+
+    task = Tasks(name="cmdi-task", owner_id=user.id, wl_id=wordlist.id, **task_fields)
+    db.session.add(task)
+    db.session.commit()
+    return job, task
+
+
+def _argv(cmd):
+    return shlex.split(cmd.replace("@HASHCATBINPATH@", "/usr/bin/hashcat"))
+
+
+@pytest.mark.parametrize("attackmode", [3, 6, 7])
+def test_build_hashcat_command_rejects_malicious_mask_in_every_mask_mode(app, attackmode):
+    """Maskmode (3) and both hybrid modes (6, 7) interpolate hc_mask."""
+    job, task = _seed_task(app, hc_attackmode=attackmode, hc_mask="?a;id>/tmp/hv;#")
+    with pytest.raises(ValueError, match="disallowed"):
+        u.build_hashcat_command(job.id, task.id)
+
+
+@pytest.mark.parametrize("attackmode", [3, 6, 7])
+def test_build_hashcat_command_keeps_a_spaced_mask_as_one_argument(app, attackmode):
+    """shlex.quote, not just validation, is what makes the command safe.
+
+    A space is legal in a mask and passes the validator, so it is the case that
+    proves the value is *quoted*: unquoted, the agent's shlex.split would tear
+    ``?l?l ?d`` into two argv entries and hashcat would be handed a bogus
+    positional argument.
+    """
+    mask = "?l?l ?d?d"
+    job, task = _seed_task(app, hc_attackmode=attackmode, hc_mask=mask)
+    argv = _argv(u.build_hashcat_command(job.id, task.id))
+    assert mask in argv
+    assert argv[argv.index("-a") + 1] == str(attackmode)
+
+
+def test_build_hashcat_command_rejects_malicious_combinator_rules(app):
+    job, task = _seed_task(app, hc_attackmode=1, j_rule="$-;touch pwned", k_rule="$!")
+    with pytest.raises(ValueError, match="disallowed"):
+        u.build_hashcat_command(job.id, task.id)
+
+    task.j_rule = "$-"
+    task.k_rule = "`id`"
+    db.session.commit()
+    with pytest.raises(ValueError, match="disallowed"):
+        u.build_hashcat_command(job.id, task.id)
+
+
+def test_build_hashcat_command_quotes_combinator_rules(app):
+    """-j/-k rules arrive as their own argv tokens, spaces and all."""
+    job, task = _seed_task(app, hc_attackmode=1, j_rule="$- $x", k_rule="$!")
+    argv = _argv(u.build_hashcat_command(job.id, task.id))
+    assert argv[argv.index("-j") + 1] == "$- $x"
+    assert argv[argv.index("-k") + 1] == "$!"
+
+
+def test_build_hashcat_command_omits_absent_combinator_rules(app):
+    """No j/k rule set (the common case) must not emit an empty -j/-k."""
+    job, task = _seed_task(app, hc_attackmode=1)
+    argv = _argv(u.build_hashcat_command(job.id, task.id))
+    assert "-j" not in argv and "-k" not in argv
+
+
+def test_normalize_task_rule_unwraps_legacy_tuple_values():
+    """Some rows stored j_rule/k_rule as a 1-tuple. Those must reduce to the
+    inner string (so it gets validated and quoted) rather than being rendered as
+    ``('$-',)``; anything that isn't a string is dropped instead of stringified.
+    """
+    assert u._normalize_task_rule(("$-",)) == "$-"
+    assert u._normalize_task_rule(()) is None
+    assert u._normalize_task_rule(None) is None
+    assert u._normalize_task_rule(123) is None
+    assert u._normalize_task_rule("$-") == "$-"


### PR DESCRIPTION
## Summary
- Fixes CWE-78 command injection where task mask / combinator rules were concatenated into a shell command executed by hashview-agent with `shell=True`.
- Adds form + server-side validation and `shlex.quote()` for user-controlled hashcat fragments.
- Agent runs hashcat with `shell=False` and streams status output in Python instead of `| tee`.

## Impact
Any authenticated user who can create tasks and queue jobs on an agent could execute arbitrary commands on the agent host.

## Related
- Complements PR #337 (download path / os.system hardening on the server).

## Test plan
- [ ] `pytest tests/unit/test_security_agent_task_cmdi.py -v`
- [ ] `pytest tests/unit/test_security_filename_command_injection.py -v`
- [ ] Create a normal mask-mode task (`?l?l?l?d?d`) and confirm job still queues
- [ ] Confirm malicious mask `?a;touch /tmp/x;#` is rejected at task create
- [ ] Deploy patched agent; confirm hashcat job runs and status file updates