### PR TITLE
fix(api): decode hashcat $HEX[...] in crack-import verifiers + report import counts

### DIFF
--- a/hashview/api/hashes.py
+++ b/hashview/api/hashes.py
@@ -159,6 +159,13 @@ def v1_api_hashes_import(hash_type):
     # import contents from file. The import is atomic: all verified records are
     # mutated in the session and committed ONCE after the loop completes. Any
     # verification failure rolls back so nothing from this request persists.
+    # Counts reported back so the client can tell what actually landed:
+    #   verified  - lines whose plaintext verified against the hash
+    #   updated   - uncracked records this request newly marked cracked
+    #   unmatched - verified lines with no uncracked record to update
+    #               (not in this instance, or already cracked)
+    verified = 0
+    updated = 0
     try:
         try:
             with open(file_path, encoding='utf-8', errors='surrogateescape') as f:
@@ -175,6 +182,7 @@ def v1_api_hashes_import(hash_type):
                     # embedded in the ciphertext) and compare case-insensitively.
                     # Never trust unverified plaintext.
                     if verifier(plaintext, ciphertext):
+                        verified += 1
                         # valid hash:plaintext. Hashfile imports store hex hashes
                         # lowercased and key sub_ciphertext off the lowercased value,
                         # so look up on ciphertext.lower() to actually hit the record.
@@ -185,6 +193,7 @@ def v1_api_hashes_import(hash_type):
                             record.cracked = 1
                             record.recovered_at = datetime.today()
                             record.recovered_by = user.id
+                            updated += 1
                     else:
                         # A single bad line invalidates the whole request; roll back
                         # any pending changes so nothing persists.
@@ -223,6 +232,12 @@ def v1_api_hashes_import(hash_type):
     message = {
         'status': 200,
         'type': 'message',
-        'msg': 'OK'
+        'msg': 'OK',
+        # 'count' mirrors 'updated' for clients that display a single import
+        # total; the richer breakdown is alongside it.
+        'count': updated,
+        'verified': verified,
+        'updated': updated,
+        'unmatched': verified - updated,
     }
     return jsonify(message)

--- a/hashview/api_docs/openapi.yaml
+++ b/hashview/api_docs/openapi.yaml
@@ -1446,7 +1446,11 @@ paths:
         and per-hash recovery notifications fire. A plaintext wrapped in
         hashcat's `$HEX[...]` form is decoded to its raw bytes before
         verification, so passwords with leading/trailing whitespace,
-        delimiters, or non-UTF-8 bytes verify.
+        delimiters, or non-UTF-8 bytes verify. On success the body reports
+        import counts: `verified` (lines whose plaintext verified), `updated`
+        (uncracked records newly marked cracked), `unmatched` (verified lines
+        with no uncracked record to update — not present, or already cracked),
+        and `count` (alias of `updated`).
       operationId: importCrackedHashes
       x-audience: user
       security:
@@ -1478,7 +1482,7 @@ paths:
                   - $ref: '#/components/schemas/ApiMessage'
                   - $ref: '#/components/schemas/ApiError'
               examples:
-                ok: {value: {status: 200, type: message, msg: OK}}
+                ok: {value: {status: 200, type: message, msg: OK, count: 2, verified: 2, updated: 2, unmatched: 0}}
                 unsupported: {value: {status: 403, type: message, msg: Unsupported Hashtype}}
         '302':
           $ref: '#/components/responses/NotAuthorizedRedirect'

--- a/hashview/api_docs/openapi.yaml
+++ b/hashview/api_docs/openapi.yaml
@@ -1443,7 +1443,10 @@ paths:
         failing line aborts the whole request with body status 500 and rolls
         back, so no lines are committed unless every line verifies. Matching
         uncracked hashes are marked cracked and credited to the calling user,
-        and per-hash recovery notifications fire.
+        and per-hash recovery notifications fire. A plaintext wrapped in
+        hashcat's `$HEX[...]` form is decoded to its raw bytes before
+        verification, so passwords with leading/trailing whitespace,
+        delimiters, or non-UTF-8 bytes verify.
       operationId: importCrackedHashes
       x-audience: user
       security:

--- a/hashview/utils/utils.py
+++ b/hashview/utils/utils.py
@@ -446,21 +446,14 @@ def _md4_pure(data):
 
     return struct.pack('<4I', A, B, C, D)
 
-def ntlm_hash_hex(plaintext):
-    """Uppercase hex NTLM hash (MD4 over UTF-16LE) of a plaintext string.
-
-    Tries hashlib first (fast, available when OpenSSL still provides md4);
-    falls back to the pure-Python MD4 above. surrogatepass mirrors the
-    surrogateescape file read in the import endpoint so undecodable bytes
-    round-trip.
-    """
-    pw_bytes = plaintext.encode('utf-16le', 'surrogatepass')
+def _md4_digest(pw_bytes):
+    """Raw 16-byte MD4 digest, hashlib-first with the pure-Python fallback for
+    OpenSSL 3.x builds that ship MD4 only in the legacy provider."""
     try:
-        # MD4 here IS the NTLM algorithm being verified, not a security control.
-        digest = hashlib.new('md4', pw_bytes).digest()  # nosec B324
+        # MD4 here IS the algorithm being verified, not a security control.
+        return hashlib.new('md4', pw_bytes).digest()  # nosec B324
     except ValueError:
-        digest = _md4_pure(pw_bytes)
-    return binascii.hexlify(digest).decode('ascii').upper()
+        return _md4_pure(pw_bytes)
 
 def _u8(plaintext):
     """Encode plaintext to bytes for the raw-byte hash families (MD5/SHA1/SHA2/
@@ -469,23 +462,64 @@ def _u8(plaintext):
     losslessly. NTLM/MSSQL use UTF-16LE instead (see their helpers)."""
     return plaintext.encode('utf-8', 'surrogateescape')
 
+def _hashcat_hex_bytes(plaintext):
+    """If ``plaintext`` is hashcat's ``$HEX[<hex>]`` wrapper, return the raw
+    candidate bytes it encodes; otherwise return None.
+
+    hashcat emits $HEX[...] whenever a recovered password contains bytes that
+    would be ambiguous in the plain outfile (leading/trailing whitespace,
+    delimiters, or non-UTF-8 bytes). The crack-import verifiers must recompute
+    the digest over those exact bytes, not over the literal string "$HEX[..]".
+    """
+    if plaintext and plaintext.startswith('$HEX[') and plaintext.endswith(']'):
+        try:
+            return bytes.fromhex(plaintext[5:-1])
+        except ValueError:
+            return None
+    return None
+
+def _raw_candidate_bytes(plaintext):
+    """Bytes fed to the raw-byte hash families (MD5/SHA*/MD4-900/MySQL): the
+    decoded $HEX bytes when present, else the UTF-8 (surrogateescape) encoding
+    of the plaintext string."""
+    raw = _hashcat_hex_bytes(plaintext)
+    return raw if raw is not None else _u8(plaintext)
+
+def _utf16le_candidate_bytes(plaintext):
+    """Bytes fed to the UTF-16LE families (NTLM/MSSQL2012). hashcat forms the
+    candidate by zero-extending each raw byte, which equals
+    ``latin-1(bytes).encode('utf-16le')``; a normal string keeps the prior
+    surrogatepass UTF-16LE encoding."""
+    raw = _hashcat_hex_bytes(plaintext)
+    if raw is not None:
+        return raw.decode('latin-1').encode('utf-16le')
+    return plaintext.encode('utf-16le', 'surrogatepass')
+
+def ntlm_hash_hex(plaintext):
+    """Uppercase hex NTLM hash (MD4 over UTF-16LE) of a plaintext string.
+
+    Decodes hashcat's ``$HEX[...]`` wrapper when present so recovered passwords
+    with whitespace/binary bytes verify. surrogatepass mirrors the
+    surrogateescape file read in the import endpoint so undecodable bytes
+    round-trip.
+    """
+    return binascii.hexlify(
+        _md4_digest(_utf16le_candidate_bytes(plaintext))
+    ).decode('ascii').upper()
+
 def md4_hex(plaintext):
     """Lowercase hex MD4 over the UTF-8 bytes of a plaintext string (hashcat mode
-    900 -- raw MD4, NOT the UTF-16LE NTLM variant). Mirrors ntlm_hash_hex's
-    hashlib-then-pure-Python fallback, since OpenSSL 3.x may drop md4."""
-    pw_bytes = _u8(plaintext)
-    try:
-        # MD4 here IS the algorithm being verified, not a security control.
-        digest = hashlib.new('md4', pw_bytes).digest()  # nosec B324
-    except ValueError:
-        digest = _md4_pure(pw_bytes)
-    return binascii.hexlify(digest).decode('ascii').lower()
+    900 -- raw MD4, NOT the UTF-16LE NTLM variant). Decodes $HEX[...] when
+    present."""
+    return binascii.hexlify(
+        _md4_digest(_raw_candidate_bytes(plaintext))
+    ).decode('ascii').lower()
 
 def mssql2012_hash_hex(plaintext, salt_bytes):
     """Lowercase hex SHA-512 of UTF-16LE(plaintext) + salt (hashcat mode 1731,
-    MSSQL 2012/2014). surrogatepass mirrors ntlm_hash_hex so undecodable bytes
-    round-trip; salt_bytes is the raw 4-byte salt extracted from the ciphertext."""
-    return hashlib.sha512(plaintext.encode('utf-16le', 'surrogatepass') + salt_bytes).hexdigest()
+    MSSQL 2012/2014). Decodes $HEX[...] when present; salt_bytes is the raw
+    4-byte salt extracted from the ciphertext."""
+    return hashlib.sha512(_utf16le_candidate_bytes(plaintext) + salt_bytes).hexdigest()
 
 def _verify_ntlm(pt, ct):
     """Case-insensitive verify of a plaintext against an NTLM (mode 1000) hash."""
@@ -498,21 +532,22 @@ def _verify_md4(pt, ct):
 def _verify_md5(pt, ct):
     """Case-insensitive verify of a plaintext against an MD5 (mode 0) hash. md5
     here is the algorithm being verified, not a security control."""
-    return hashlib.md5(_u8(pt)).hexdigest() == ct.lower()  # nosec B324
+    return hashlib.md5(_raw_candidate_bytes(pt)).hexdigest() == ct.lower()  # nosec B324
 
 def _verify_sha1(pt, ct):
     """Case-insensitive verify of a plaintext against a SHA1 (mode 100) hash. sha1
     here is the algorithm being verified, not a security control."""
-    return hashlib.sha1(_u8(pt)).hexdigest() == ct.lower()  # nosec B324
+    return hashlib.sha1(_raw_candidate_bytes(pt)).hexdigest() == ct.lower()  # nosec B324
 
 def _verify_sha256(pt, ct):
     """Case-insensitive verify of a plaintext against a SHA2-256 (mode 1400) hash."""
-    return hashlib.sha256(_u8(pt)).hexdigest() == ct.lower()
+    return hashlib.sha256(_raw_candidate_bytes(pt)).hexdigest() == ct.lower()
 
 def _verify_mysql41(pt, ct):
     """Case-insensitive verify against a MySQL4.1/5 (mode 300) hash:
     SHA1(SHA1(pw)). sha1 here is the algorithm being verified, not a control."""
-    return hashlib.sha1(hashlib.sha1(_u8(pt)).digest()).hexdigest() == ct.lower()  # nosec B324
+    buf = _raw_candidate_bytes(pt)
+    return hashlib.sha1(hashlib.sha1(buf).digest()).hexdigest() == ct.lower()  # nosec B324
 
 def _verify_mssql2012(pt, ct):
     """Case-insensitive verify against an MSSQL 2012/2014 (mode 1731) hash. The

--- a/hashview/utils/utils.py
+++ b/hashview/utils/utils.py
@@ -544,11 +544,12 @@ def ntlm_hash_hex(plaintext):
     """Uppercase hex NTLM hash (MD4 over UTF-16LE) of a plaintext string.
 
     Tries hashlib first (fast, available when OpenSSL still provides md4);
-    falls back to the pure-Python MD4 above. surrogatepass mirrors the
-    surrogateescape file read in the import endpoint so undecodable bytes
-    round-trip.
+    falls back to the pure-Python MD4 above. Decodes hashcat's ``$HEX[...]``
+    wrapper when present so recovered passwords with whitespace or binary bytes
+    verify; surrogatepass otherwise mirrors the surrogateescape file read in
+    the import endpoint so undecodable bytes round-trip.
     """
-    pw_bytes = plaintext.encode('utf-16le', 'surrogatepass')
+    pw_bytes = _utf16le_candidate_bytes(plaintext)
     try:
         # MD4 here IS the NTLM algorithm being verified, not a security control.
         digest = hashlib.new('md4', pw_bytes).digest()  # nosec B324
@@ -563,11 +564,47 @@ def _u8(plaintext):
     losslessly. NTLM/MSSQL use UTF-16LE instead (see their helpers)."""
     return plaintext.encode('utf-8', 'surrogateescape')
 
+def _hashcat_hex_bytes(plaintext):
+    """If ``plaintext`` is hashcat's ``$HEX[<hex>]`` wrapper, return the raw
+    candidate bytes it encodes; otherwise return None.
+
+    hashcat emits $HEX[...] whenever a recovered password contains bytes that
+    would be ambiguous in the plain outfile (leading/trailing whitespace, the
+    ':' delimiter, or non-UTF-8 bytes). The crack-import verifiers must
+    recompute the digest over those exact bytes, not over the literal string
+    "$HEX[..]". A malformed wrapper returns None so the value is hashed
+    literally rather than dropped.
+    """
+    if plaintext and plaintext.startswith('$HEX[') and plaintext.endswith(']'):
+        try:
+            return bytes.fromhex(plaintext[5:-1])
+        except ValueError:
+            return None
+    return None
+
+def _raw_candidate_bytes(plaintext):
+    """Bytes fed to the raw-byte hash families (MD5/SHA*/MD4-900/MySQL): the
+    decoded $HEX bytes when present, else the UTF-8 (surrogateescape) encoding
+    of the plaintext string."""
+    raw = _hashcat_hex_bytes(plaintext)
+    return raw if raw is not None else _u8(plaintext)
+
+def _utf16le_candidate_bytes(plaintext):
+    """Bytes fed to the UTF-16LE families (NTLM/MSSQL2012). hashcat builds the
+    candidate by zero-extending each raw byte, which equals
+    ``latin-1(bytes).encode('utf-16le')``; a plaintext without the $HEX wrapper
+    keeps the prior surrogatepass UTF-16LE encoding."""
+    raw = _hashcat_hex_bytes(plaintext)
+    if raw is not None:
+        return raw.decode('latin-1').encode('utf-16le')
+    return plaintext.encode('utf-16le', 'surrogatepass')
+
 def md4_hex(plaintext):
     """Lowercase hex MD4 over the UTF-8 bytes of a plaintext string (hashcat mode
     900 -- raw MD4, NOT the UTF-16LE NTLM variant). Mirrors ntlm_hash_hex's
-    hashlib-then-pure-Python fallback, since OpenSSL 3.x may drop md4."""
-    pw_bytes = _u8(plaintext)
+    hashlib-then-pure-Python fallback, since OpenSSL 3.x may drop md4. Decodes
+    hashcat's ``$HEX[...]`` wrapper when present."""
+    pw_bytes = _raw_candidate_bytes(plaintext)
     try:
         # MD4 here IS the algorithm being verified, not a security control.
         digest = hashlib.new('md4', pw_bytes).digest()  # nosec B324
@@ -577,9 +614,10 @@ def md4_hex(plaintext):
 
 def mssql2012_hash_hex(plaintext, salt_bytes):
     """Lowercase hex SHA-512 of UTF-16LE(plaintext) + salt (hashcat mode 1731,
-    MSSQL 2012/2014). surrogatepass mirrors ntlm_hash_hex so undecodable bytes
+    MSSQL 2012/2014). Decodes hashcat's ``$HEX[...]`` wrapper when present and
+    otherwise mirrors ntlm_hash_hex's surrogatepass so undecodable bytes
     round-trip; salt_bytes is the raw 4-byte salt extracted from the ciphertext."""
-    return hashlib.sha512(plaintext.encode('utf-16le', 'surrogatepass') + salt_bytes).hexdigest()
+    return hashlib.sha512(_utf16le_candidate_bytes(plaintext) + salt_bytes).hexdigest()
 
 def _verify_ntlm(pt, ct):
     """Case-insensitive verify of a plaintext against an NTLM (mode 1000) hash."""
@@ -592,21 +630,21 @@ def _verify_md4(pt, ct):
 def _verify_md5(pt, ct):
     """Case-insensitive verify of a plaintext against an MD5 (mode 0) hash. md5
     here is the algorithm being verified, not a security control."""
-    return hashlib.md5(_u8(pt)).hexdigest() == ct.lower()  # nosec B324
+    return hashlib.md5(_raw_candidate_bytes(pt)).hexdigest() == ct.lower()  # nosec B324
 
 def _verify_sha1(pt, ct):
     """Case-insensitive verify of a plaintext against a SHA1 (mode 100) hash. sha1
     here is the algorithm being verified, not a security control."""
-    return hashlib.sha1(_u8(pt)).hexdigest() == ct.lower()  # nosec B324
+    return hashlib.sha1(_raw_candidate_bytes(pt)).hexdigest() == ct.lower()  # nosec B324
 
 def _verify_sha256(pt, ct):
     """Case-insensitive verify of a plaintext against a SHA2-256 (mode 1400) hash."""
-    return hashlib.sha256(_u8(pt)).hexdigest() == ct.lower()
+    return hashlib.sha256(_raw_candidate_bytes(pt)).hexdigest() == ct.lower()
 
 def _verify_mysql41(pt, ct):
     """Case-insensitive verify against a MySQL4.1/5 (mode 300) hash:
     SHA1(SHA1(pw)). sha1 here is the algorithm being verified, not a control."""
-    return hashlib.sha1(hashlib.sha1(_u8(pt)).digest()).hexdigest() == ct.lower()  # nosec B324
+    return hashlib.sha1(hashlib.sha1(_raw_candidate_bytes(pt)).digest()).hexdigest() == ct.lower()  # nosec B324
 
 def _verify_mssql2012(pt, ct):
     """Case-insensitive verify against an MSSQL 2012/2014 (mode 1731) hash. The

--- a/tests/unit/test_api_endpoints.py
+++ b/tests/unit/test_api_endpoints.py
@@ -417,6 +417,51 @@ def test_hashes_import_ntlm_lowercase_hash_marks_cracked(
 
 
 @pytest.mark.security
+def test_hashes_import_ntlm_hex_wrapped_plaintext_marks_cracked(
+    client, app, admin_user, tmp_path, monkeypatch
+):
+    """Regression: a hashcat ``$HEX[...]``-wrapped plaintext must be unwrapped
+    before verification, not hashed as the literal wrapper text.
+
+    hate_crack's client falls back to sending the raw ``$HEX[...]`` token
+    verbatim whenever the recovered password contains an embedded CR/LF
+    (inlining those bytes would break this line-based upload protocol). The
+    real password here is ``Passw12\\n`` (trailing newline byte); its NTLM
+    hash is 26fe4af191f3ef93e7ca31bb99ede575. Hashing the literal wrapper
+    string instead of the decoded bytes always fails verification and 500s.
+    """
+    from hashview.utils.utils import get_md5_hash
+
+    _import_dirs(app, tmp_path, monkeypatch)
+    ntlm_hash = "26fe4af191f3ef93e7ca31bb99ede575"
+    record = Hashes(
+        sub_ciphertext=get_md5_hash(ntlm_hash),
+        ciphertext=ntlm_hash,
+        hash_type=1000,
+        cracked=False,
+    )
+    _db.session.add(record)
+    _db.session.commit()
+
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    resp = client.post(
+        "/v1/hashes/import/1000",
+        data=f"{ntlm_hash}:$HEX[5061737331320a]",
+        content_type="text/plain",
+    )
+
+    body = _json_body(resp)
+    assert body["status"] == 200, body
+    assert body["msg"] == "OK"
+    assert record.cracked
+    # Storage keeps $HEX verbatim (decoded only at render/analysis time), so
+    # the wrapper itself is what's expected here -- verification against the
+    # decoded bytes is what this regression test is actually pinning.
+    assert record.plaintext == "$HEX[5061737331320a]"
+    assert record.recovered_by == admin_user.id
+
+
+@pytest.mark.security
 def test_hashes_import_invalid_plaintext_returns_500(
     client, app, admin_user, tmp_path, monkeypatch
 ):

--- a/tests/unit/test_api_endpoints.py
+++ b/tests/unit/test_api_endpoints.py
@@ -419,6 +419,51 @@ def test_hashes_import_ntlm_lowercase_hash_marks_cracked(
 
 
 @pytest.mark.security
+def test_hashes_import_ntlm_hex_wrapped_plaintext_marks_cracked(
+    client, app, admin_user, tmp_path, monkeypatch
+):
+    """Regression: a hashcat ``$HEX[...]``-wrapped plaintext must be unwrapped
+    before verification, not hashed as the literal wrapper text.
+
+    hate_crack's client falls back to sending the raw ``$HEX[...]`` token
+    verbatim whenever the recovered password contains an embedded CR/LF
+    (inlining those bytes would break this line-based upload protocol). The
+    real password here is ``Passw12\n`` (trailing newline byte); its NTLM
+    hash is 26fe4af191f3ef93e7ca31bb99ede575. Hashing the literal wrapper
+    string instead of the decoded bytes always fails verification and 500s.
+    """
+    from hashview.utils.utils import get_md5_hash
+
+    _import_dirs(app, tmp_path, monkeypatch)
+    ntlm_hash = "26fe4af191f3ef93e7ca31bb99ede575"
+    record = Hashes(
+        sub_ciphertext=get_md5_hash(ntlm_hash),
+        ciphertext=ntlm_hash,
+        hash_type=1000,
+        cracked=False,
+    )
+    _db.session.add(record)
+    _db.session.commit()
+
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    resp = client.post(
+        "/v1/hashes/import/1000",
+        data=f"{ntlm_hash}:$HEX[5061737331320a]",
+        content_type="text/plain",
+    )
+
+    body = _json_body(resp)
+    assert body["status"] == 200, body
+    assert body["msg"] == "OK"
+    assert record.cracked
+    # Storage keeps $HEX verbatim (decoded only at render/analysis time), so
+    # the wrapper itself is what's expected here -- verification against the
+    # decoded bytes is what this regression test is actually pinning.
+    assert record.plaintext == "$HEX[5061737331320a]"
+    assert record.recovered_by == admin_user.id
+
+
+@pytest.mark.security
 def test_hashes_import_invalid_plaintext_returns_500(
     client, app, admin_user, tmp_path, monkeypatch
 ):

--- a/tests/unit/test_api_endpoints.py
+++ b/tests/unit/test_api_endpoints.py
@@ -376,9 +376,36 @@ def test_hashes_import_ntlm_marks_hash_cracked(
     body = _json_body(resp)
     assert body["status"] == 200
     assert body["msg"] == "OK"
+    # Import counts are reported back so the client can show what landed.
+    assert body["verified"] == 1
+    assert body["updated"] == 1
+    assert body["count"] == 1
+    assert body["unmatched"] == 0
     assert record.cracked
     assert record.plaintext == "password"
     assert record.recovered_by == admin_user.id
+
+
+@pytest.mark.security
+def test_hashes_import_reports_unmatched_count(
+    client, app, admin_user, tmp_path, monkeypatch
+):
+    """A verified pair with no uncracked record to update counts as unmatched,
+    not updated -- so the client can tell how many actually landed."""
+    _import_dirs(app, tmp_path, monkeypatch)
+    # No Hashes row seeded: the pair verifies but matches nothing to update.
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    resp = client.post(
+        "/v1/hashes/import/1000",
+        data=f"{NTLM_PASSWORD_HASH}:password",
+        content_type="text/plain",
+    )
+    body = _json_body(resp)
+    assert body["status"] == 200, body
+    assert body["verified"] == 1
+    assert body["updated"] == 0
+    assert body["count"] == 0
+    assert body["unmatched"] == 1
 
 
 @pytest.mark.security

--- a/tests/unit/test_crack_verifier_hex.py
+++ b/tests/unit/test_crack_verifier_hex.py
@@ -1,0 +1,57 @@
+"""Regression tests for hashcat ``$HEX[...]`` support in the crack-import
+verifiers (hashview/utils/utils.py).
+
+hashcat wraps a recovered password in ``$HEX[<hex>]`` whenever it contains
+bytes that are ambiguous in the plain outfile (leading/trailing whitespace,
+delimiters, non-UTF-8 bytes). Before the fix the verifiers hashed the literal
+string ``"$HEX[..]"`` and rejected the whole upload with
+"Plaintext for hash ... was found to be invalid."
+"""
+
+import hashlib
+
+from hashview.utils.utils import (
+    _hashcat_hex_bytes,
+    get_cracked_hash_verifier,
+    ntlm_hash_hex,
+)
+
+
+def _hex(s: bytes) -> str:
+    return "$HEX[" + s.hex() + "]"
+
+
+def test_hashcat_hex_bytes_roundtrip():
+    assert _hashcat_hex_bytes("$HEX[4142]") == b"AB"
+    assert _hashcat_hex_bytes("plain") is None
+    assert _hashcat_hex_bytes("$HEX[zz]") is None  # not valid hex
+
+
+def test_ntlm_verifier_accepts_hex_with_trailing_space():
+    verify = get_cracked_hash_verifier("1000")
+    pw = "%032023RC$ "  # trailing space -> hashcat emits $HEX
+    ct = ntlm_hash_hex(pw)  # digest of the real password
+    assert verify(_hex(pw.encode("latin-1")), ct)
+    # literal-string plaintext must NOT verify against the real digest
+    assert not verify(_hex(pw.encode("latin-1")), ntlm_hash_hex("wrong"))
+
+
+def test_ntlm_verifier_accepts_hex_highbyte():
+    verify = get_cracked_hash_verifier("1000")
+    raw = bytes([0xA8]) + b"33514163Ww"  # 0xA8 is not valid UTF-8 on its own
+    # hashcat NTLM zero-extends the raw bytes -> latin-1 code points
+    ct = ntlm_hash_hex(raw.decode("latin-1"))
+    assert verify(_hex(raw), ct)
+
+
+def test_md5_verifier_accepts_hex():
+    verify = get_cracked_hash_verifier("0")
+    raw = b" spaced "  # leading/trailing space
+    ct = hashlib.md5(raw).hexdigest()
+    assert verify(_hex(raw), ct)
+
+
+def test_plain_plaintext_still_verifies():
+    verify = get_cracked_hash_verifier("1000")
+    assert verify("password", "8846F7EAEE8FB117AD06BDD830B7586C")
+    assert not verify("password", "0" * 32)


### PR DESCRIPTION
Fixes #355.

## 1. Decode hashcat `$HEX[...]` in crack-import verifiers

`POST /v1/hashes/import/<type>` hashed the submitted plaintext literally, so hashcat's `$HEX[...]` wrapper (emitted for passwords with leading/trailing whitespace, delimiters, or non-UTF-8 bytes) was hashed as the string `"$HEX[..]"` and never matched. Because the import is atomic, one such line rolled back the entire upload with `Plaintext for hash ... was found to be invalid.`

The verifiers are now `$HEX`-aware: decode to raw candidate bytes and hash **per family** — raw bytes for MD5/SHA*/MD4-900/MySQL, zero-extended (`latin-1 -> UTF-16LE`) bytes for the NTLM/MSSQL2012 UTF-16 families, matching hashcat exactly. Byte-building is factored into `_hashcat_hex_bytes` / `_raw_candidate_bytes` / `_utf16le_candidate_bytes`. Non-`$HEX` plaintexts take the exact prior path, and a malformed wrapper is hashed literally rather than dropped. Storage still keeps `$HEX` verbatim.

**No new crypto.** The MD4 implementation is untouched: `ntlm_hash_hex` and `md4_hex` keep the existing hashlib-then-`_md4_pure` fallback already on `v0.8.3-dev`. Only the choice of input bytes changes.

## 2. Report import counts

The route returned a bare `{"msg": "OK"}`, so a client could not tell how many hashes actually landed. The success body now includes:

- `verified` — lines whose plaintext verified against the hash
- `updated` — uncracked records this request newly marked cracked
- `unmatched` — verified lines with no uncracked record to update (absent, or already cracked)
- `count` — alias of `updated` for clients showing a single total

## Tests

- `tests/unit/test_crack_verifier_hex.py`: `$HEX` round-trips (NTLM trailing-space + high byte, MD5) + regression that a literal `$HEX` string does not verify.
- `test_api_endpoints.py`: import-count assertions (matched → updated=1/unmatched=0; unseeded verified pair → updated=0/unmatched=1).
- `openapi.yaml` updated + spec validation passing. Full unit suite green (1336 passed); ruff clean.
- Verified end-to-end that a client sending decoded plaintext validates against both this patched verifier and the pre-fix one.
