### PR TITLE
fix: UTF-8 hashfile downloads + latin-1 cleanups (#357)

### DIFF
--- a/.githooks/safe-allowlist.txt
+++ b/.githooks/safe-allowlist.txt
@@ -46,6 +46,10 @@ src_ip="127\.0\.0\.1"
 # test fixture api_key literal in the download tests (not a real secret)
 api_key="dl-key"
 
+# The above-U+00FF password literal the password-hash tests hash and verify
+# (tests/unit/test_password_hash_encoding.py) — a test fixture, not a credential.
+NON_LATIN1_PASSWORD =
+
 # --- CI workflow false positives (.github/workflows/*) ---
 # The scanner reads whole changed files, so editing a workflow surfaces its
 # CI-only test values, template variables and comment substrings. None are

--- a/.githooks/safe-allowlist.txt
+++ b/.githooks/safe-allowlist.txt
@@ -43,6 +43,9 @@ password="hashed-pw"
 api_key="user-api-key-admin"
 src_ip="127\.0\.0\.1"
 
+# test fixture api_key literal in the download tests (not a real secret)
+api_key="dl-key"
+
 # --- CI workflow false positives (.github/workflows/*) ---
 # The scanner reads whole changed files, so editing a workflow surfaces its
 # CI-only test values, template variables and comment substrings. None are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Notable changes will be documented here
 - Task/job max-runtime is enforced on the parent task rather than per chunk
 - Cracked-hash import compares hashes case-insensitively and normalizes the lookup so records stored (lowercased) by the hashfile import path match regardless of the submitted hash's case
 - Analytics decode `$HEX[...]` values before length/complexity analysis
+- Hashfile export downloads are UTF-8 encoded, so cracked plaintext/usernames containing non-Latin-1 characters (emoji, CJK, Cyrillic) are exported intact instead of being silently corrupted to `?`
 - Agents survive a server restart mid-task, and a bug where agent status could show as empty was fixed
 - Create/edit forms surface validation errors inside their modal instead of redirecting away
 - Several data-retention cleanup failures and hash-type/validator parsing bugs (e.g. PKZIP `$pkzip$`/`$pkzip2$`)

--- a/hashview/auth/service.py
+++ b/hashview/auth/service.py
@@ -92,7 +92,7 @@ def resolve_or_provision_azure_user(claims, settings):
     if not email:
         raise AzureLoginDenied('no usable email/UPN claim to provision an account')
     given, family = _names_from_claims(claims)
-    random_pw = bcrypt.generate_password_hash(secrets.token_urlsafe(32)).decode('latin-1')
+    random_pw = bcrypt.generate_password_hash(secrets.token_urlsafe(32)).decode('utf-8')
     user = Users(
         first_name=given,
         last_name=family,

--- a/hashview/hashfiles/routes.py
+++ b/hashview/hashfiles/routes.py
@@ -268,8 +268,11 @@ def hashfiles_download(hashfile_id, fmt):
             lines.append(_decode_hex(h.plaintext))
 
     body = ('\n'.join(lines) + '\n') if lines else ''
-    buf = io.BytesIO(body.encode('latin-1', errors='replace'))
+    # UTF-8 (not latin-1): plaintext/usernames are stored as real Unicode, so
+    # any code point > U+00FF (emoji, CJK, Cyrillic) must survive the export
+    # rather than being lossily replaced with '?'.
+    buf = io.BytesIO(body.encode('utf-8'))
     buf.seek(0)
     safe = secure_filename(hashfile.name) or 'hashfile'
-    return send_file(buf, mimetype='text/plain', as_attachment=True,
+    return send_file(buf, mimetype='text/plain; charset=utf-8', as_attachment=True,
                      download_name=f"{safe}_{fmt}.txt")

--- a/hashview/jobs/routes.py
+++ b/hashview/jobs/routes.py
@@ -722,8 +722,6 @@ def jobs_assign_notifications(job_id):
     job = Jobs.query.get(job_id)
 
     # Moving task check to /summary. Otherwise this will always skip /notifications now that notifications are before tasks
-    # populate the forms dynamically with the choices in the database
-    # form.hashes.choices = [(str(c[0].id), str(bytes.fromhex(c[1].username).decode('latin-1')) + ':' + c[0].ciphertext) for c in db.session.query(Hashes, HashfileHashes).outerjoin(HashfileHashes, Hashes.id==HashfileHashes.hash_id).filter(Hashes.cracked == '0').filter(HashfileHashes.hashfile_id==job.hashfile_id).all()]
 
     if form.validate_on_submit():
         if form.job_completion_email.data == True:

--- a/hashview/users/routes.py
+++ b/hashview/users/routes.py
@@ -192,7 +192,7 @@ def users_add():
 
     form = UsersForm()
     if form.validate_on_submit():
-        hashed_password = bcrypt.generate_password_hash(form.password.data).decode('latin-1')
+        hashed_password = bcrypt.generate_password_hash(form.password.data).decode('utf-8')
         # Pushover isn't collected at creation — the user sets it themselves from
         # their profile after logging in.
         user = Users(first_name=form.first_name.data, last_name=form.last_name.data, email_address=form.email.data, admin=form.is_admin.data, password=hashed_password)
@@ -262,7 +262,7 @@ def users_edit(user_id):
         if password != confirm:
             flash('Passwords do not match.', 'danger')
             return redirect(url_for('users.users_list'))
-        user.password = bcrypt.generate_password_hash(password).decode('latin-1')
+        user.password = bcrypt.generate_password_hash(password).decode('utf-8')
 
     user.first_name = first
     user.last_name = last

--- a/tests/unit/test_downloads.py
+++ b/tests/unit/test_downloads.py
@@ -94,6 +94,28 @@ def test_hashfile_export_plains_only(app, client):
     assert "aaa111" not in body and "bbb222" not in body
 
 
+def test_hashfile_export_preserves_non_latin1_plaintext(app, client):
+    """A cracked plaintext containing characters above U+00FF (emoji, CJK,
+    Cyrillic -- the international-pwdump case) must round-trip through the
+    download unchanged. The old latin-1/errors='replace' encode silently
+    turned these into '?', corrupting the exported password file."""
+    user = _admin(); _login(client, user)
+    hf = Hashfiles(name="intl dump", customer_id=1, owner_id=user.id)
+    db.session.add(hf); db.session.commit()
+    plain = "пароль-密码-🔒"          # Cyrillic + CJK + emoji, all > U+00FF
+    h = Hashes(sub_ciphertext="0" * 8, ciphertext="ddd444", hash_type=0,
+               cracked=True, plaintext=plain)
+    db.session.add(h); db.session.commit()
+    db.session.add(HashfileHashes(hash_id=h.id, hashfile_id=hf.id))
+    db.session.commit()
+
+    resp = client.get(f"/hashfiles/download/{hf.id}/plains")
+    assert resp.status_code == 200
+    body = resp.data.decode("utf-8")
+    assert plain in body
+    assert "?" not in body                # no lossy replacement occurred
+
+
 def test_hashfile_export_invalid_format_404(app, client):
     user = _admin(); _login(client, user)
     hf = _make_hashfile_with_hashes(user.id)

--- a/tests/unit/test_password_hash_encoding.py
+++ b/tests/unit/test_password_hash_encoding.py
@@ -1,0 +1,137 @@
+"""Password-hash storage round trips for the three bcrypt sites in this branch.
+
+``bcrypt.generate_password_hash(...).decode(...)`` moved from latin-1 to utf-8 in
+hashview/users/routes.py (add + edit) and hashview/auth/service.py (Azure JIT).
+The decode itself is not observable -- a modular-crypt bcrypt digest is pure
+ASCII, so both codecs produce the identical string; the change is consistency,
+not a bug fix. What these tests pin is the behaviour that *is* observable and was
+previously untested at all: a password whose characters live above U+00FF is
+hashed and stored such that the login check later accepts it, and the Azure JIT
+row gets a hash nothing can log in with.
+
+The ``password`` column is a String(60) sized exactly for a bcrypt digest, so a
+site that ever stored something wider than ASCII would truncate here and lock
+the account out. That is the regression these guard against.
+"""
+
+import re
+
+from hashview.models import Users, db
+from tests.unit.helpers import login, make_admin
+
+# Emoji + CJK + Cyrillic: every character is above U+00FF, i.e. exactly what
+# latin-1 cannot represent.
+NON_LATIN1_PASSWORD = "пароль-密码-🔒-ok"
+BCRYPT_DIGEST = re.compile(r"^\$2[aby]\$\d{2}\$[./A-Za-z0-9]{53}$")
+
+
+def _bcrypt():
+    """The app's single Bcrypt instance (created in users/routes.py, init_app'd
+    by the factory) -- the same object the login route checks against."""
+    from hashview.users.routes import bcrypt
+
+    return bcrypt
+
+
+def test_users_add_stores_an_ascii_bcrypt_digest_for_a_non_latin1_password(app, client):
+    admin = make_admin()
+    login(client, admin)
+
+    resp = client.post("/users/add", data={
+        "first_name": "Intl", "last_name": "User",
+        "email": "intl@example.com",
+        "password": NON_LATIN1_PASSWORD,
+        "confirm_password": NON_LATIN1_PASSWORD,
+        "submit": "Register",
+    }, follow_redirects=False)
+    assert resp.status_code in (301, 302)
+
+    user = Users.query.filter_by(email_address="intl@example.com").first()
+    assert user is not None
+    assert BCRYPT_DIGEST.match(user.password), user.password
+    # Fits the String(60) column with nothing lost.
+    assert len(user.password) == 60
+
+
+def test_users_add_password_verifies_on_login(app, client):
+    """The whole point of the stored form: the login check must accept it."""
+    admin = make_admin()
+    login(client, admin)
+    client.post("/users/add", data={
+        "first_name": "Intl", "last_name": "User",
+        "email": "intl-login@example.com",
+        "password": NON_LATIN1_PASSWORD,
+        "confirm_password": NON_LATIN1_PASSWORD,
+        "submit": "Register",
+    })
+
+    user = Users.query.filter_by(email_address="intl-login@example.com").first()
+    assert _bcrypt().check_password_hash(user.password, NON_LATIN1_PASSWORD)
+    assert not _bcrypt().check_password_hash(user.password, "wrong-password-xx")
+
+
+def test_users_edit_password_change_stores_a_verifiable_digest(app, client):
+    admin = make_admin()
+    login(client, admin)
+    target = Users(first_name="T", last_name="U", email_address="edit@example.com",
+                   password="x" * 60, admin=False)
+    db.session.add(target)
+    db.session.commit()
+    target_id = target.id
+
+    resp = client.post(f"/users/edit/{target_id}", data={
+        "first_name": "T", "last_name": "U", "email": "edit@example.com",
+        "password": NON_LATIN1_PASSWORD,
+        "confirm_password": NON_LATIN1_PASSWORD,
+    }, follow_redirects=False)
+    assert resp.status_code in (301, 302)
+
+    updated = Users.query.get(target_id)
+    assert BCRYPT_DIGEST.match(updated.password), updated.password
+    assert _bcrypt().check_password_hash(updated.password, NON_LATIN1_PASSWORD)
+
+
+def test_azure_jit_provisioned_user_gets_an_unusable_ascii_digest(app):
+    """The Azure JIT path (hashview/auth/service.py) had no test at all.
+
+    Its account can never password-login, so the assertion is twofold: the
+    column holds a well-formed bcrypt digest, and no empty/blank password
+    satisfies it.
+    """
+    from hashview.auth.service import resolve_or_provision_azure_user
+
+    class _Settings:
+        azure_allowed_groups = None
+
+    claims = {
+        "oid": "00000000-0000-0000-0000-00000000abcd",
+        "email": "jit@example.com",
+        "given_name": "Jit",
+        "family_name": "User",
+    }
+
+    user = resolve_or_provision_azure_user(claims, _Settings())
+
+    assert user.id is not None
+    assert user.auth_source == "azure"
+    assert user.admin is False
+    assert BCRYPT_DIGEST.match(user.password), user.password
+    assert len(user.password) == 60
+    for guess in ("", " ", "password"):
+        assert not _bcrypt().check_password_hash(user.password, guess)
+
+
+def test_azure_jit_password_is_random_per_account(app):
+    """Two provisioned accounts must not share a digest -- a fixed one would be
+    a shared credential the moment any hash is recovered."""
+    from hashview.auth.service import resolve_or_provision_azure_user
+
+    class _Settings:
+        azure_allowed_groups = None
+
+    first = resolve_or_provision_azure_user(
+        {"oid": "oid-1", "email": "jit1@example.com"}, _Settings())
+    second = resolve_or_provision_azure_user(
+        {"oid": "oid-2", "email": "jit2@example.com"}, _Settings())
+
+    assert first.password != second.password


### PR DESCRIPTION
Fixes the latin-1 findings from the audit in #357.

## HIGH — data corruption on hashfile download
`hashview/hashfiles/routes.py` encoded export bodies with `latin-1`/`errors='replace'`, silently turning any code point > U+00FF (emoji, CJK, Cyrillic — the international-pwdump case) into `?`. Now UTF-8 encoded with an explicit response charset, so stored Unicode round-trips intact.

**Test (TDD):** added `test_hashfile_export_preserves_non_latin1_plaintext` — stores `"пароль-密码-🔒"`, downloads `/plains`, asserts the exact string survives and no `?` replacement occurred. Confirmed RED (`'??????-??-?'`) → GREEN.

## LOW — misleading dead code
Removed the commented-out `bytes.fromhex(username).decode('latin-1')` snippet in `jobs/routes.py` that contradicts the current UTF-8 username storage.

## INFO — consistency
Aligned three bcrypt `.decode('latin-1')` sites (`auth/service.py`, `users/routes.py` ×2) to `.decode('utf-8')` to match `setup/__init__.py`. Behavior-preserving — bcrypt output is pure ASCII.

## Not changed (audited, confirmed correct)
`utils.py:585` ($HEX latin-1 fallback), `utils.py:457/488` (UTF-16LE NTLM), the surrogateescape ingest path, and the `latin1` MySQL charset in the drift-reconciliation migration.

## Verification
Full unit suite: **1331 passed, 2 skipped, 36 xfailed, 5 xpassed**.

Refs #357

🤖 Generated with [Claude Code](https://claude.com/claude-code)