### PR TITLE
fix(api): remove control/tmp scratch files after download responses

### DIFF
--- a/hashview/api/routes.py
+++ b/hashview/api/routes.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, jsonify, redirect, request, send_from_directory, current_app, url_for
+from flask import Blueprint, jsonify, redirect, request, send_from_directory, current_app, url_for, after_this_request
 from hashview.models import Agents, JobTasks, Tasks, Wordlists, Rules, Jobs, Hashes, Hashfiles, HashfileHashes, Users, HashNotifications, Settings, JobNotifications, Customers
 from hashview.utils.utils import get_md5_hash, get_linecount, get_filehash, update_dynamic_wordlist, update_job_task_status, import_hashfilehashes, validate_pwdump_hashfile, validate_netntlm_hashfile, validate_kerberos_hashfile, validate_shadow_hashfile, validate_user_hash_hashfile, validate_hash_only_hashfile, send_email, send_pushover, notify_admins, build_hashcat_command, ntlm_hash_hex
 from hashview.models import db
@@ -40,6 +40,20 @@ class AlchemyEncoder(json.JSONEncoder):
             return fields
 
         return json.JSONEncoder.default(self, obj)
+
+def remove_after_request(path):
+    """Delete a control/tmp scratch file once the response has been sent.
+
+    The download endpoints materialize a temp file just to stream it back; if
+    it is never removed control/tmp grows without bound.
+    """
+    @after_this_request
+    def _remove(response):
+        try:
+            os.remove(path)
+        except OSError:
+            current_app.logger.warning('Could not remove temp file %s', path)
+        return response
 
 def is_authorized(user, agent, request):
     isUser = False
@@ -332,6 +346,7 @@ def v1_api_get_rules_download(rules_id):
     gz_path = os.path.join(current_app.root_path, 'control/tmp', gz_name)
     with open(src_path, 'rb') as f_in, gzip.open(gz_path, 'wb', compresslevel=9) as f_out:
         shutil.copyfileobj(f_in, f_out)
+    remove_after_request(gz_path)
     return send_from_directory('control/tmp', gz_name, mimetype='application/octet-stream')
 
 # Provide wordlist info (really should be plural)
@@ -369,6 +384,7 @@ def v1_api_get_wordlist_download(wordlist_id):
     gz_path = os.path.join(current_app.root_path, 'control/tmp', gz_name)
     with open(src_path, 'rb') as f_in, gzip.open(gz_path, 'wb', compresslevel=9) as f_out:
         shutil.copyfileobj(f_in, f_out)
+    remove_after_request(gz_path)
     return send_from_directory('control/tmp', gz_name, mimetype='application/octet-stream')
 
 # Update Dynamic Wordlist
@@ -815,6 +831,7 @@ def v1_api_get_hashfile(hashfile_id):
         file_object.write(result[0].ciphertext + '\n')
     file_object.close()
 
+    remove_after_request(os.path.join(current_app.root_path, 'control/tmp', random_hex))
     return send_from_directory('control/tmp/', random_hex)
 
 # List hashfiles that contain hashes of a given hash_type, with per-file

--- a/tests/unit/test_api_tmp_file_cleanup.py
+++ b/tests/unit/test_api_tmp_file_cleanup.py
@@ -1,0 +1,91 @@
+"""Regression tests for #226: control/tmp files must not accumulate.
+
+The rules/wordlist download endpoints gzip into ``control/tmp`` and the
+hashfile endpoint generates a plaintext file there. Each response must remove
+its own temp file so the directory does not grow without bound.
+"""
+
+import os
+
+from hashview.models import Hashes, Hashfiles, HashfileHashes, Rules, Users, Wordlists, db
+
+
+def _api_user():
+    user = Users(first_name="A", last_name="B", email_address="a@e.com",
+                 password="x", admin=True, api_key="test-api-key")
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+def _tmp_listing(app):
+    return set(os.listdir(os.path.join(app.root_path, "control", "tmp")))
+
+
+def test_rules_download_removes_temp_gz(app, client):
+    user = _api_user()
+    src = os.path.join(app.root_path, "control", "rules", "cleanup_rule.txt")
+    with open(src, "wb") as fh:
+        fh.write(b"body\n")
+    rule = Rules(name="r", owner_id=user.id,
+                 path="control/rules/cleanup_rule.txt", checksum="x")
+    db.session.add(rule)
+    db.session.commit()
+    client.set_cookie("uuid", "test-api-key")
+    before = _tmp_listing(app)
+    try:
+        resp = client.get(f"/v1/rules/{rule.id}")
+        assert resp.status_code == 200
+        assert resp.data
+        assert _tmp_listing(app) == before
+    finally:
+        for path in (src, os.path.join(app.root_path, "control", "tmp",
+                                       "cleanup_rule.txt.gz")):
+            if os.path.exists(path):
+                os.remove(path)
+
+
+def test_wordlist_download_removes_temp_gz(app, client):
+    user = _api_user()
+    src = os.path.join(app.root_path, "control", "wordlists", "cleanup_wl.txt")
+    with open(src, "wb") as fh:
+        fh.write(b"body\n")
+    wordlist = Wordlists(name="w", owner_id=user.id, type="static", size=1,
+                         path="control/wordlists/cleanup_wl.txt", checksum="x")
+    db.session.add(wordlist)
+    db.session.commit()
+    client.set_cookie("uuid", "test-api-key")
+    before = _tmp_listing(app)
+    try:
+        resp = client.get(f"/v1/wordlists/{wordlist.id}")
+        assert resp.status_code == 200
+        assert resp.data
+        assert _tmp_listing(app) == before
+    finally:
+        if os.path.exists(src):
+            os.remove(src)
+        for name in _tmp_listing(app) - before:
+            os.remove(os.path.join(app.root_path, "control", "tmp", name))
+
+
+def test_hashfile_download_removes_temp_file(app, client):
+    user = _api_user()
+    hashfile = Hashfiles(name="h", owner_id=user.id, customer_id=1)
+    db.session.add(hashfile)
+    db.session.commit()
+    hash_row = Hashes(hash_type=1000, cracked=False, sub_ciphertext="",
+                      ciphertext="aad3b435b51404eeaad3b435b51404ee")
+    db.session.add(hash_row)
+    db.session.commit()
+    db.session.add(HashfileHashes(hashfile_id=hashfile.id, hash_id=hash_row.id))
+    db.session.commit()
+    client.set_cookie("uuid", "test-api-key")
+    before = _tmp_listing(app)
+    try:
+        resp = client.get(f"/v1/hashfiles/{hashfile.id}")
+        assert resp.status_code == 200
+        assert b"aad3b435b51404eeaad3b435b51404ee" in resp.data
+        assert _tmp_listing(app) == before
+    finally:
+        for name in _tmp_listing(app) - before:
+            os.remove(os.path.join(app.root_path, "control", "tmp", name))


### PR DESCRIPTION
Closes #226

The rules, wordlist, and hashfile download endpoints each write a file into `control/tmp` purely to stream it back, but never delete it, so the directory grows on every agent poll. Each one now registers an `after_this_request` hook that removes its own temp file once the response has been sent.

New `tests/unit/test_api_tmp_file_cleanup.py` asserts the `control/tmp` listing is unchanged across each of the three downloads; all three fail on current `main` and pass with the fix (`tests/unit`: 16 -> 19 passed).
