### PR TITLE
test(unit): pin the Website Keywords "never serve a stale crawl" contract

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -99,6 +99,19 @@ background scheduler). `tests/unit/test_scheduler_integration.py` is the
 exception: it drives the real `data_retention_cleanup` entry point against a
 seeded DB to exercise the scheduled-cleanup path end to end.
 
+### Website Keywords staleness tests
+
+`tests/unit/test_website_keywords_no_stale.py` pins the "never serve a cached
+crawl" contract for the `(DYNAMIC) Website Keywords` wordlist: a fresh random
+`control/tmp/` file per regeneration, leftovers in `control/tmp/` never consumed,
+an empty crawl result blanking the live list, and back-to-back crawls replacing
+rather than unioning.
+
+Three tests in it are strict `xfail`s against **issue #377** — when
+`crawl_website_keywords` *raises*, the exception escapes
+`_generate_website_keywords` before the tmp file is written, so the previous job's
+words stay on disk and get served. Remove the markers when #377 is fixed.
+
 ## Running E2E tests locally (live host)
 
 Run the app and DB with Docker Compose, then execute pytest:

--- a/tests/unit/test_website_keywords_no_stale.py
+++ b/tests/unit/test_website_keywords_no_stale.py
@@ -1,0 +1,313 @@
+"""Regression tests: the Website Keywords crawl must never serve a stale list.
+
+The (DYNAMIC) Website Keywords wordlist is regenerated on every agent request:
+the crawl result is written to a randomly-named file under control/tmp and then
+atomically moved onto ``wordlist.path``. The contract these tests pin down:
+
+  1. Every regeneration writes a *fresh* random tmp file — a tmp file left over
+     from an earlier crawl is never read, reused, or served.
+  2. A crawl that yields nothing (every fetch failed, unreachable host, bad URL)
+     replaces the live wordlist with a *blank* file — the previous run's words
+     must not survive.
+  3. A crawl that *raises* likewise leaves a blank wordlist, not the previous
+     content, and the Wordlists row metadata (size/checksum) matches the blank
+     file so the agent isn't told a stale size.
+  4. Back-to-back crawls fully replace, never union or append.
+  5. The download endpoint serves the current crawl's bytes, not the prior gzip.
+
+Points 1, 2, 4 and 5-on-success already hold. The "crawl *raises*" half of point 3
+does not: the exception escapes _generate_website_keywords before the tmp file is
+written, so os.replace never runs and the previous job's words stay live and get
+served. Those three tests are strict xfails against issue #377 — remove the
+markers when it's fixed.
+
+Uses the in-memory SQLite app from tests/unit/conftest.py.
+"""
+
+import gzip
+import os
+from pathlib import Path
+
+import pytest
+
+from hashview.models import db, Users, Wordlists, Jobs, Tasks, JobTasks, Agents, Settings
+from hashview.utils.utils import update_dynamic_wordlist, get_filehash, get_linecount
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONTROL = REPO_ROOT / "hashview" / "control"
+WORDLISTS_DIR = CONTROL / "wordlists"
+TMP_DIR = CONTROL / "tmp"
+WL_NAME = "(DYNAMIC) Website Keywords"
+COOKIE_DOMAIN = "localhost.test"
+
+
+@pytest.fixture(autouse=True)
+def _clean_control_dirs():
+    """Remove any files these tests add to control/{wordlists,tmp}."""
+    def snap(d):
+        return set(os.listdir(d)) if d.exists() else set()
+    before = {WORDLISTS_DIR: snap(WORDLISTS_DIR), TMP_DIR: snap(TMP_DIR)}
+    yield
+    for d, names in before.items():
+        if not d.exists():
+            continue
+        for n in set(os.listdir(d)) - names:
+            try:
+                os.remove(d / n)
+            except OSError:
+                pass
+
+
+def _admin(api_key="stale-api-key"):
+    user = Users(first_name="A", last_name="D", email_address="a@e.com",
+                 password="x" * 60, admin=True, api_key=api_key)
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+def _settings():
+    db.session.add(Settings(retention_period=30, max_runtime_jobs=0, max_runtime_tasks=0))
+    db.session.commit()
+
+
+def _wordlist(user, initial=""):
+    path = WORDLISTS_DIR / "dynamic-website-keywords.txt"
+    path.write_text(initial)
+    wordlist = Wordlists(name=WL_NAME, owner_id=user.id, type="dynamic",
+                         path=str(path), checksum=get_filehash(str(path)),
+                         size=get_linecount(str(path)))
+    db.session.add(wordlist)
+    db.session.commit()
+    return wordlist, path
+
+
+def _running_agent_job(user, wordlist, url, uuid="agent-stale"):
+    agent = Agents(name="a", src_ip="127.0.0.1", uuid=uuid, status="Working")
+    db.session.add(agent)
+    job = Jobs(name="jr", status="Running", customer_id=1, owner_id=user.id, crawl_url=url)
+    db.session.add(job)
+    task = Tasks(name="tr", hc_attackmode=0, owner_id=user.id, wl_id=wordlist.id)
+    db.session.add(task)
+    db.session.commit()
+    db.session.add(JobTasks(job_id=job.id, task_id=task.id, status="Running",
+                            agent_id=agent.id))
+    db.session.commit()
+    return agent, job
+
+
+def _record_tmp_sources(monkeypatch):
+    """Capture the tmp path handed to os.replace on each regeneration."""
+    seen = []
+    real_replace = os.replace
+
+    def spy(src, dst, *a, **kw):
+        seen.append(str(src))
+        return real_replace(src, dst, *a, **kw)
+
+    monkeypatch.setattr(os, "replace", spy)
+    return seen
+
+
+# ---------------------------------------------------------------------------
+# 1. Fresh random tmp file per crawl; leftovers are never reused
+# ---------------------------------------------------------------------------
+
+def test_each_crawl_uses_a_new_random_tmp_file(app, monkeypatch):
+    """Two regenerations must stage through two different tmp filenames."""
+    user = _admin()
+    _settings()
+    wordlist, path = _wordlist(user)
+    job = Jobs(name="j", status="Running", customer_id=1, owner_id=user.id,
+               crawl_url="https://target.example")
+    db.session.add(job)
+    db.session.commit()
+
+    monkeypatch.setattr("hashview.utils.crawler.crawl_website_keywords",
+                        lambda url, settings: {"alpha"})
+    seen = _record_tmp_sources(monkeypatch)
+
+    update_dynamic_wordlist(wordlist.id, job_id=job.id)
+    update_dynamic_wordlist(wordlist.id, job_id=job.id)
+
+    assert len(seen) == 2, "each regeneration should stage through control/tmp"
+    assert seen[0] != seen[1], "tmp filename must be random per crawl, not reused"
+    for src in seen:
+        assert Path(src).parent == TMP_DIR
+        assert not os.path.exists(src), "tmp file must be moved, not left behind"
+
+
+def test_preexisting_tmp_file_is_never_read_or_served(app, monkeypatch):
+    """A stale control/tmp leftover must not influence the regenerated list."""
+    user = _admin()
+    _settings()
+    wordlist, path = _wordlist(user)
+    job = Jobs(name="j", status="Running", customer_id=1, owner_id=user.id,
+               crawl_url="https://target.example")
+    db.session.add(job)
+    db.session.commit()
+
+    stale_tmp = TMP_DIR / "deadbeefdeadbeef.txt"
+    stale_tmp.write_text("stalecachedword\n")
+
+    monkeypatch.setattr("hashview.utils.crawler.crawl_website_keywords",
+                        lambda url, settings: {"freshword"})
+    update_dynamic_wordlist(wordlist.id, job_id=job.id)
+
+    assert path.read_text().split() == ["freshword"]
+    assert "stalecachedword" not in path.read_text()
+    # and the leftover is untouched, i.e. it was neither consumed nor moved
+    assert stale_tmp.exists()
+
+
+# ---------------------------------------------------------------------------
+# 2/3. Failed crawl -> blank wordlist, never the previous content
+# ---------------------------------------------------------------------------
+
+def test_empty_crawl_result_blanks_the_previous_wordlist(app, monkeypatch):
+    user = _admin()
+    _settings()
+    wordlist, path = _wordlist(user, initial="previousrun\nanotherword\n")
+    job = Jobs(name="j", status="Running", customer_id=1, owner_id=user.id,
+               crawl_url="https://unreachable.invalid")
+    db.session.add(job)
+    db.session.commit()
+
+    monkeypatch.setattr("hashview.utils.crawler.crawl_website_keywords",
+                        lambda url, settings: set())
+    update_dynamic_wordlist(wordlist.id, job_id=job.id)
+
+    assert path.read_text() == "", "a crawl that found nothing must yield a blank list"
+    wordlist = Wordlists.query.get(wordlist.id)
+    assert wordlist.byte_size == 0
+    assert wordlist.size == get_linecount(str(path))
+    assert wordlist.checksum == get_filehash(str(path))
+
+
+@pytest.mark.xfail(strict=True, reason="issue #377: a raising crawl leaves the "
+                                       "previous run's wordlist live on disk")
+def test_crawl_exception_yields_blank_wordlist_not_stale_words(app, monkeypatch):
+    """If the crawler blows up, the agent must get a blank list, not last run's."""
+    user = _admin()
+    _settings()
+    wordlist, path = _wordlist(user, initial="previousrun\nanotherword\n")
+    job = Jobs(name="j", status="Running", customer_id=1, owner_id=user.id,
+               crawl_url="https://target.example")
+    db.session.add(job)
+    db.session.commit()
+
+    def boom(url, settings):
+        raise RuntimeError("DNS exploded mid-crawl")
+
+    monkeypatch.setattr("hashview.utils.crawler.crawl_website_keywords", boom)
+    update_dynamic_wordlist(wordlist.id, job_id=job.id)
+
+    text = path.read_text()
+    assert "previousrun" not in text and "anotherword" not in text
+    assert text == "", "a failed crawl must replace the wordlist with a blank file"
+    wordlist = Wordlists.query.get(wordlist.id)
+    assert wordlist.byte_size == 0, "metadata must describe the blank file, not the stale one"
+    assert wordlist.size == get_linecount(str(path))
+    assert wordlist.checksum == get_filehash(str(path))
+
+
+@pytest.mark.xfail(strict=True, reason="issue #377: the crawl exception escapes "
+                                       "update_dynamic_wordlist entirely")
+def test_crawl_exception_leaves_no_tmp_debris(app, monkeypatch):
+    user = _admin()
+    _settings()
+    wordlist, path = _wordlist(user, initial="previousrun\n")
+    job = Jobs(name="j", status="Running", customer_id=1, owner_id=user.id,
+               crawl_url="https://target.example")
+    db.session.add(job)
+    db.session.commit()
+
+    before = set(os.listdir(TMP_DIR))
+
+    def boom(url, settings):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("hashview.utils.crawler.crawl_website_keywords", boom)
+    update_dynamic_wordlist(wordlist.id, job_id=job.id)
+
+    assert set(os.listdir(TMP_DIR)) == before, "failed crawl must not leak tmp files"
+
+
+# ---------------------------------------------------------------------------
+# 4. Back-to-back crawls fully replace
+# ---------------------------------------------------------------------------
+
+def test_second_crawl_replaces_rather_than_unions(app, monkeypatch):
+    user = _admin()
+    _settings()
+    wordlist, path = _wordlist(user)
+    job = Jobs(name="j", status="Running", customer_id=1, owner_id=user.id,
+               crawl_url="https://target.example")
+    db.session.add(job)
+    db.session.commit()
+
+    results = [{"firstcrawl", "shared"}, {"secondcrawl", "shared"}]
+    monkeypatch.setattr("hashview.utils.crawler.crawl_website_keywords",
+                        lambda url, settings: results.pop(0))
+
+    update_dynamic_wordlist(wordlist.id, job_id=job.id)
+    assert path.read_text().split() == ["firstcrawl", "shared"]
+
+    update_dynamic_wordlist(wordlist.id, job_id=job.id)
+    assert path.read_text().split() == ["secondcrawl", "shared"]
+    assert "firstcrawl" not in path.read_text()
+
+
+def test_different_job_urls_do_not_share_results(app, monkeypatch):
+    """A second job's crawl must not inherit the first job's words."""
+    user = _admin()
+    _settings()
+    wordlist, path = _wordlist(user)
+    job_a = Jobs(name="a", status="Running", customer_id=1, owner_id=user.id,
+                 crawl_url="https://a.example")
+    job_b = Jobs(name="b", status="Running", customer_id=1, owner_id=user.id,
+                 crawl_url="https://b.example")
+    db.session.add_all([job_a, job_b])
+    db.session.commit()
+
+    by_url = {"https://a.example": {"awords"}, "https://b.example": set()}
+    monkeypatch.setattr("hashview.utils.crawler.crawl_website_keywords",
+                        lambda url, settings: by_url[url])
+
+    update_dynamic_wordlist(wordlist.id, job_id=job_a.id)
+    assert path.read_text().split() == ["awords"]
+
+    # job B's site yields nothing -> blank, NOT job A's leftovers
+    update_dynamic_wordlist(wordlist.id, job_id=job_b.id)
+    assert path.read_text() == ""
+
+
+# ---------------------------------------------------------------------------
+# 5. The download endpoint serves the current crawl
+# ---------------------------------------------------------------------------
+
+@pytest.mark.xfail(strict=True, reason="issue #377: /v1/wordlists serves the "
+                                       "cached previous crawl after a failed one")
+def test_download_after_failed_crawl_serves_blank_gzip(app, client, monkeypatch):
+    user = _admin()
+    _settings()
+    wordlist, path = _wordlist(user)
+    agent, job = _running_agent_job(user, wordlist, "https://target.example")
+    client.set_cookie("uuid", agent.uuid, domain=COOKIE_DOMAIN)
+
+    monkeypatch.setattr("hashview.utils.crawler.crawl_website_keywords",
+                        lambda url, settings: {"goodword"})
+    assert client.get(f"/v1/updateWordlist/{wordlist.id}").status_code == 200
+    first = client.get(f"/v1/wordlists/{wordlist.id}")
+    assert first.status_code == 200
+    assert gzip.decompress(first.data).split() == [b"goodword"]
+
+    def boom(url, settings):
+        raise RuntimeError("crawl failed on the next job")
+
+    monkeypatch.setattr("hashview.utils.crawler.crawl_website_keywords", boom)
+    assert client.get(f"/v1/updateWordlist/{wordlist.id}").status_code == 200
+    second = client.get(f"/v1/wordlists/{wordlist.id}")
+    assert second.status_code == 200
+    assert gzip.decompress(second.data) == b"", \
+        "download must serve the blank current list, not the cached previous crawl"


### PR DESCRIPTION
Tests only — no production code changes.

## Why

The `(DYNAMIC) Website Keywords` wordlist is supposed to be rebuilt from scratch on every agent request: crawl the job's `crawl_url`, write the words to a randomly-named file under `hashview/control/tmp/`, then atomically `os.replace` that onto `wordlist.path`. An agent must never receive a cached or stale list — serving one job's keywords to a different engagement's crack is a correctness *and* a scoping problem. Nothing was pinning that contract.

## What's here

`tests/unit/test_website_keywords_no_stale.py`, 8 tests.

**Five pass against current behavior**, locking in the parts that already work:

- `test_each_crawl_uses_a_new_random_tmp_file` — two regenerations stage through two *different* `control/tmp/<hex>.txt` names, and each is moved away rather than left behind (spies on `os.replace`).
- `test_preexisting_tmp_file_is_never_read_or_served` — a stale leftover in `control/tmp/` is neither consumed nor mixed into the regenerated list.
- `test_empty_crawl_result_blanks_the_previous_wordlist` — a crawl that finds nothing replaces the live list with a blank file and refreshes `size` / `checksum` / `byte_size`.
- `test_second_crawl_replaces_rather_than_unions`
- `test_different_job_urls_do_not_share_results` — job B's empty crawl yields blank, not job A's leftovers.

**Three are strict `xfail`s against #377**, following the repo's existing per-issue xfail convention (`tests/security/test_csrf_xfail.py`): they assert the safe behavior, prove it doesn't hold yet, and flip to hard failures the moment the fix lands.

- `test_crawl_exception_yields_blank_wordlist_not_stale_words`
- `test_crawl_exception_leaves_no_tmp_debris`
- `test_download_after_failed_crawl_serves_blank_gzip`

## The bug they document (#377)

`hashview/utils/utils.py:722` calls `crawl_website_keywords` unguarded. If it raises, the exception propagates out of `_generate_website_keywords` and out of `update_dynamic_wordlist`, so the tmp file is never written, `os.replace` never runs, and the metadata refresh at lines 788-798 never runs. `wordlist.path` still holds the previous job's crawl output, and `GET /v1/wordlists/<id>` gzips and serves it.

`crawler.py` swallows per-page `requests` errors, so this isn't the ordinary "site is down" case (which correctly produces an empty set and a blank list). It's reachable via anything escaping that per-page guard — a thread-pool failure, `MemoryError` on a large response, or an `OSError` writing the tmp file itself.

Fix per #377: degrade a raising crawl to `words = set()`, and unlink `tmp_path` in a `finally`.

## Also

`TESTING.md` gains a short section describing the new file and the #377 xfails, matching how the other per-issue xfails are documented.

## Verification

```
./.venv/bin/python -m pytest tests/unit -q
1370 passed, 2 skipped, 34 xfailed, 5 xpassed in 91.14s
```

The 5 xpassed are pre-existing non-strict markers elsewhere in the suite, unrelated to this branch.

## Not addressed

`_generate_website_keywords` also returns early and leaves the old file intact when no job URL resolves (the manual UI refresh from `hashview/wordlists/routes.py:252`), pinned by the existing `test_update_wordlist_no_job_url_leaves_file_unchanged`. If "never stale" should cover that path too it's a deliberate behavior change and a separate PR.

Closes nothing — #377 stays open until the fix lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)