### PR TITLE
fix(analytics): stop /analytics hanging the browser (50MB response) and miscounting shared passwords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ Notable changes will be documented here
 - Pinned Python to 3.11+; added a ruff / pylint / bandit / pre-commit lint-and-security stack, a LICENSE, and substantially expanded automated tests (unit, agent, end-to-end, and security)
 
 ### Fixed
+- The Analytics page no longer hangs the browser on large datasets: the Shared Passwords and Username = Password cards render a capped preview (with the full total shown) instead of one form per group, and the complete lists remain available from the download buttons
+- Analytics counted a password as "shared" when a single account's hash appeared in more than one hashfile, or when the rows had no username at all; shared passwords are now grouped by distinct named account
 - The agent's HTTP/API layer is now resilient to non-200 and unexpected server responses instead of crashing with opaque errors
 - Command-injection hardening: hashcat is invoked as an argv list with no shell
 - CSRF: state-changing actions were moved from GET to POST and protected with CSRF tokens

--- a/hashview/analytics/routes.py
+++ b/hashview/analytics/routes.py
@@ -39,6 +39,16 @@ analytics = Blueprint('analytics', __name__)
 
 BLANK_LABEL = 'Blank (unset)'
 
+# Max rows the Shared Passwords and Username = Password cards put in the HTML.
+# These two lists are the only ones on the page whose length scales with the
+# size of the dataset rather than with a fixed number of buckets, and each
+# shared row is a whole <form>. Rendering them in full on a production hashfile
+# produced a ~50MB response and tens of thousands of DOM nodes, which locked up
+# the browser even though the server responded in under two seconds. The cards
+# show the highest-value rows and report the true total; the download endpoints
+# still serve the complete set.
+PREVIEW_LIMIT = 100
+
 
 def _scoped_hash_query(customer_id, hashfile_id, cracked=None):
     """Hashes joined to their HashfileHashes (account) rows, narrowed to the
@@ -482,11 +492,13 @@ def get_analytics():
         reused_pct=reused_pct,
         unique_pct=unique_pct,
         top_reuse_count=top_reuse_count,
-        shared=shared,
+        shared=shared[:PREVIEW_LIMIT],
+        shared_total=len(shared),
         masks=masks,
         length_dist=length_dist,
         class_buckets=class_buckets,
-        user_eq_pass=user_eq_pass,
+        user_eq_pass=user_eq_pass[:PREVIEW_LIMIT],
+        user_eq_pass_total=len(user_eq_pass),
         timeline=timeline,
         complexity_hist=complexity_hist,
         complexity_total=total_cracked,

--- a/hashview/analytics/routes.py
+++ b/hashview/analytics/routes.py
@@ -332,7 +332,11 @@ def get_analytics():
     total_cracked = len(corpus)
 
     freq = Counter()
-    shared_map = defaultdict(list)
+    # {plaintext: {username, ...}} -- a SET so one account is counted once no
+    # matter how many hashfiles its hash appears in. The Hashes -> HashfileHashes
+    # join is one-to-many, so a list here made every plaintext on a hash that
+    # lives in two hashfiles look like a shared password.
+    shared_map = defaultdict(set)
     length_counter = Counter()
     mask_counter = Counter()
     class_counts = [0, 0, 0, 0]          # index 0 -> 1 class ... index 3 -> 4 classes
@@ -342,7 +346,10 @@ def get_analytics():
     for plaintext, username in corpus:
         pword = plaintext or ''
         freq[pword] += 1
-        shared_map[pword].append(username)
+        # An unnamed row identifies no account, so it can never establish that a
+        # password is shared between people.
+        if username:
+            shared_map[pword].add(username)
         length_counter[len(pword)] += 1
         mask_counter[_mask(pword)] += 1
 
@@ -367,7 +374,7 @@ def get_analytics():
 
     shared = sorted(
         ({'plain': pw or BLANK_LABEL, 'plain_raw': pw, 'count': len(users),
-          'users': [_local_part(user) for user in users if user]}
+          'users': sorted(_local_part(user) for user in users)}
          for pw, users in shared_map.items() if len(users) > 1),
         key=lambda item: item['count'], reverse=True)
 
@@ -786,11 +793,13 @@ def _shared_groups(customer_id, hashfile_id):
     """{plaintext: [usernames]} for recovered passwords shared by >1 account in scope."""
     rows = (_scoped_hash_query(customer_id, hashfile_id, cracked=True)
             .with_entities(Hashes.plaintext, HashfileHashes.username).all())
-    groups = defaultdict(list)
+    groups = defaultdict(set)
     for plaintext, username in rows:
         if username:
-            groups[plaintext or ''].append(username)
-    return {pword: users for pword, users in groups.items() if len(users) > 1}
+            groups[plaintext or ''].add(username)
+    # Sets, not lists: the same account reached through two hashfiles is still
+    # one account and must not make a password look shared (matches the card).
+    return {pword: sorted(users) for pword, users in groups.items() if len(users) > 1}
 
 
 @analytics.route('/analytics/download/shared', methods=['POST'])

--- a/hashview/templates/analytics.html.j2
+++ b/hashview/templates/analytics.html.j2
@@ -547,7 +547,7 @@ function hvRotMode(m){
         <div class="card-head">
             <span class="dot-led {{ 'run' if shared else 'idle' }}"></span><h3>Shared Passwords</h3>
             <div style="margin-left:auto;display:flex;gap:8px;align-items:center;">
-                <span class="mono" style="font-size:10.5px;color:var(--text-mute);">{{ shared | length }} groups</span>
+                <span class="mono" style="font-size:10.5px;color:var(--text-mute);">{{ shared_total }} groups</span>
                 {% if shared %}<a class="icon-btn no-print" title="Download a txt per group, zipped" href="/analytics/download/shared_zip?{{ scope_qs[1:] }}">{{ icon('download', size=15) }}</a>{% endif %}
             </div>
         </div>
@@ -568,6 +568,11 @@ function hvRotMode(m){
                 </form>
                 {% endfor %}
             </div>
+            {% if shared_total > shared | length %}
+            <div class="mono" style="margin-top:9px;font-size:10.5px;color:var(--text-mute);">
+                showing the top {{ shared | length }} of {{ shared_total }} groups — use the download button for all of them
+            </div>
+            {% endif %}
             {% endif %}
         </div>
     </div>
@@ -578,7 +583,7 @@ function hvRotMode(m){
     <div class="card-head">
         <span class="dot-led {{ 'off' if user_eq_pass else 'idle' }}"></span><h3>Username = Password</h3>
         <div style="margin-left:auto;display:flex;gap:8px;align-items:center;">
-            <span class="badge {{ 'red' if user_eq_pass else 'dim' }}" style="font-size:9.5px;">{{ user_eq_pass | length }} accounts</span>
+            <span class="badge {{ 'red' if user_eq_pass else 'dim' }}" style="font-size:9.5px;">{{ user_eq_pass_total }} accounts</span>
             {% if user_eq_pass %}<a class="icon-btn no-print" title="Download usernames" href="/analytics/download/fig8?{{ scope_qs[1:] }}">{{ icon('download', size=15) }}</a>{% endif %}
         </div>
     </div>
@@ -588,13 +593,18 @@ function hvRotMode(m){
             <thead><tr><th>Account</th><th>Password</th></tr></thead>
             <tbody>
                 {% for e in user_eq_pass %}
-                <tr>
+                <tr class="userpass-row">
                     <td class="mono" style="color:var(--text);">{{ e.u }}</td>
                     <td class="mono" style="color:var(--red);">{{ e.p }}</td>
                 </tr>
                 {% endfor %}
             </tbody>
         </table>
+        {% if user_eq_pass_total > user_eq_pass | length %}
+        <div class="mono" style="margin-top:9px;font-size:10.5px;color:var(--text-mute);">
+            showing {{ user_eq_pass | length }} of {{ user_eq_pass_total }} accounts — use the download button for all of them
+        </div>
+        {% endif %}
         {% endif %}
     </div>
 </div>

--- a/tests/unit/test_analytics_view.py
+++ b/tests/unit/test_analytics_view.py
@@ -406,3 +406,102 @@ def test_recovery_by_task_deleted_task_labelled(app, client):
     _login(client, admin)
     html = client.get("/analytics?customer_id=%d&hashfile_id=%d" % (cust.id, hf.id)).get_data(as_text=True)
     assert "(Task Deleted)" in html
+
+
+# --- payload bounding: the page must not render one DOM node per group ------
+# A production hashfile yields tens of thousands of shared-password groups and
+# username==password accounts. Rendering all of them produced a ~50MB response
+# that locked up the browser; the card now shows a capped preview and defers the
+# full set to the existing download endpoints.
+
+def _seed_many(n_shared=300, n_userpass=300):
+    """A customer whose scope has n_shared shared-password groups (2 accounts
+    each) and n_userpass accounts whose password equals their username."""
+    cust = Customers(name="Bulk Corp")
+    db.session.add(cust)
+    db.session.commit()
+    hf = Hashfiles(name="bulk_dump", customer_id=cust.id, owner_id=1, runtime=1)
+    db.session.add(hf)
+    db.session.commit()
+    for i in range(n_shared):
+        h = _hash(f"share{i}", f"Shared{i}!", True)
+        db.session.add(HashfileHashes(hash_id=h.id, hashfile_id=hf.id, username=f"u{i}a"))
+        db.session.add(HashfileHashes(hash_id=h.id, hashfile_id=hf.id, username=f"u{i}b"))
+    for i in range(n_userpass):
+        h = _hash(f"same{i}", f"selfuser{i}", True)
+        db.session.add(HashfileHashes(hash_id=h.id, hashfile_id=hf.id, username=f"selfuser{i}"))
+    db.session.commit()
+    return cust.id, hf.id
+
+
+def test_shared_and_userpass_cards_cap_rendered_rows(app, client):
+    """Only SHARED_PREVIEW_LIMIT rows reach the HTML, however many groups exist."""
+    from hashview.analytics.routes import PREVIEW_LIMIT
+
+    user = _admin(); _login(client, user)
+    customer_id, _hf = _seed_many()
+    resp = client.get(f"/analytics?customer_id={customer_id}")
+    assert resp.status_code == 200
+    html = resp.get_data(as_text=True)
+
+    # one <form> per rendered shared-password group
+    assert html.count('action="/analytics/download/shared"') == PREVIEW_LIMIT
+    # one <tr> per rendered username==password account
+    assert html.count('class="userpass-row"') == PREVIEW_LIMIT
+
+
+def test_capped_cards_report_the_full_totals(app, client):
+    """The capped cards still tell the operator the true totals, so the numbers
+    stay trustworthy and match what the download endpoints return."""
+    user = _admin(); _login(client, user)
+    customer_id, _hf = _seed_many()
+    html = client.get(f"/analytics?customer_id={customer_id}").get_data(as_text=True)
+    assert "300 groups" in html          # all shared groups counted, not just rendered
+    assert "300 accounts" in html        # all username==password accounts counted
+
+
+def test_analytics_response_stays_small_on_bulk_data(app, client):
+    """Regression guard on the hang itself: the rendered page must stay far
+    below the multi-megabyte payload that locked up the browser."""
+    user = _admin(); _login(client, user)
+    customer_id, _hf = _seed_many(n_shared=1500, n_userpass=1500)
+    resp = client.get(f"/analytics?customer_id={customer_id}")
+    assert resp.status_code == 200
+    assert len(resp.data) < 1_000_000, f"analytics page is {len(resp.data)} bytes"
+
+
+def test_shared_groups_need_two_distinct_named_accounts(app, client):
+    """A hash that appears in several hashfiles is still ONE account: it must not
+    register as a shared password, and rows with no username can't form a group.
+
+    This is the miscount that made every plaintext in a real dataset look
+    'shared' -- the group size counted join rows, not distinct usernames.
+    """
+    user = _admin(); _login(client, user)
+    cust = Customers(name="Dup Corp")
+    db.session.add(cust); db.session.commit()
+    hf1 = Hashfiles(name="f1", customer_id=cust.id, owner_id=1, runtime=1)
+    hf2 = Hashfiles(name="f2", customer_id=cust.id, owner_id=1, runtime=1)
+    db.session.add_all([hf1, hf2]); db.session.commit()
+
+    # same account, same hash, present in both hashfiles -> not shared
+    dup = _hash("dup", "DupPass1", True)
+    db.session.add(HashfileHashes(hash_id=dup.id, hashfile_id=hf1.id, username="dave"))
+    db.session.add(HashfileHashes(hash_id=dup.id, hashfile_id=hf2.id, username="dave"))
+    # two rows with no username at all -> not shared
+    anon = _hash("anon", "AnonPass1", True)
+    db.session.add(HashfileHashes(hash_id=anon.id, hashfile_id=hf1.id, username=None))
+    db.session.add(HashfileHashes(hash_id=anon.id, hashfile_id=hf2.id, username=None))
+    # genuinely shared by two different people -> counted
+    for ct, uname in (("realA", "erin"), ("realB", "frank")):
+        h = _hash(ct, "RealShared1", True)
+        db.session.add(HashfileHashes(hash_id=h.id, hashfile_id=hf1.id, username=uname))
+    db.session.commit()
+
+    html = client.get(f"/analytics?customer_id={cust.id}").get_data(as_text=True)
+    assert "1 groups" in html
+    # Assert against the shared card's own POST forms -- the plaintexts also
+    # appear in Top Passwords, which is a different (and correct) figure.
+    assert 'name="plaintext" value="RealShared1"' in html
+    assert 'name="plaintext" value="DupPass1"' not in html
+    assert 'name="plaintext" value="AnonPass1"' not in html


### PR DESCRIPTION
## The hang

On a production-sized hashfile, `/analytics` locked the browser up. The server wasn't the problem — it produced the page in 1.6s. The response was **50.2MB and roughly 350k DOM nodes**.

The Shared Passwords and Username = Password cards are the only lists on the page whose length scales with the dataset (everything else is a fixed number of buckets), and each shared row is a whole `<form>` with three hidden inputs. Against a 34,449-hash dataset the page rendered 34,449 forms.

Two separate defects produced that number, so this is two commits.

### 1. Shared passwords were counted per join row, not per account

`Hashes -> HashfileHashes` is one-to-many, so a hash belonging to two hashfiles yields two rows for the *same* account. `shared_map` collected those in a list, so every password on a two-hashfile hash looked like it was "shared" — by one account with itself. Rows with no username at all were counted too, even though an unnamed row identifies no account and can't establish sharing.

`shared_map` and `_shared_groups()` (the zip download) now collect usernames in a **set** and skip unnamed rows, so the card and the download agree and a single account can't share a password with itself.

This is a slice of the same root cause as #385, which covers the rest of the page — the counters this PR doesn't touch still count join rows.

### 2. The cards rendered every row

Both cards now render at most `PREVIEW_LIMIT` (100) rows, report the **true** total in the header, and say how many are shown. The full sets are unchanged and still available from the existing `shared_zip` / `fig8` download buttons.

Same dataset after both fixes: **0.14MB**.

## Verification

- `pytest tests/unit tests/security tests/agent_unit` — 1518 passed, 2 skipped, 39 xfailed, 5 xpassed (the xpasses are pre-existing on `v0.8.3-dev`)
- `ruff check hashview/ hashview.py` clean; `pylint` 9.63/10, unchanged
- 99 lines of new unit coverage in `tests/unit/test_analytics_view.py` pinning both behaviours: a shared group counts distinct named accounts, unnamed rows never form a group, and each card renders at most `PREVIEW_LIMIT` rows while reporting the full total
- Built a docker image from this branch and ran the `/analytics` docker suite from #390 against it: the `test_shared_card_caps_rendered_rows_but_reports_the_true_total` strict xfail flips to **XPASS**, which is the signal that the fix works

## Stack

#390 (the `/analytics` docker bug suite) is stacked **on top of** this branch, and drops that test's xfail because the cap lands here. Merge this one first; GitHub will retarget #390 to `v0.8.3-dev` automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
