### PR TITLE
test: xfail specs (unit + e2e) for job task/group filter field (#392)

### DIFF
--- a/tests/e2e/test_job_task_filter.py
+++ b/tests/e2e/test_job_task_filter.py
@@ -1,0 +1,105 @@
+"""e2e (Playwright) spec for GitHub issue #392.
+
+Exercises the DESIRED live, client-side filtering behavior of the **Add Task**
+drawer on the job task-assignment step (``/jobs/<id>/tasks``): typing in the
+filter box narrows the selectable-task list, a non-matching query reveals a
+"no match" empty state, and clearing restores the full list.
+
+Marked ``@pytest.mark.xfail(strict=False)`` because the feature is not
+implemented yet: today there is no filter input, so the test fails at the
+"filter input exists" step and reports XFAIL. Once the feature lands it runs
+the full behavior and XPASSes, becoming a real regression guard.
+
+This complements the render-level unit tests in
+``tests/unit/test_issue_xfail_job_task_filter.py`` (which assert the static
+scaffolding) by verifying the JavaScript actually filters in a real browser.
+
+Requires the standard e2e prerequisites (HASHVIEW_E2E_BASE_URL + a seeded,
+logged-in session). It drives the seeded job from ``seed_e2e_db.py``
+(HASHVIEW_E2E_JOB_ID), whose Add Task drawer lists the default boot tasks.
+"""
+
+import os
+
+import pytest
+from playwright.sync_api import expect
+
+# A query no task name will contain, used to force the empty ("no match") state.
+NO_MATCH_QUERY = "zzz-no-such-task-zzz-392"
+
+
+def _open_add_task_drawer(page):
+    """Open the <details> drawer that holds the /assign_task/ forms."""
+    drawer = page.locator("details:has(form[action*='/assign_task/'])").first
+    drawer.evaluate("el => { el.open = true; }")
+    return drawer
+
+
+def _visible_task_buttons(drawer):
+    """Locator for the per-task submit buttons in the Add Task drawer.
+
+    action*='/assign_task/' matches the task forms but NOT the task-group
+    forms (those are '/assign_task_group/', which has no '/assign_task/'
+    substring), so this never picks up a group entry.
+    """
+    return drawer.locator("form[action*='/assign_task/'] button[type=submit]")
+
+
+@pytest.mark.e2e
+@pytest.mark.xfail(
+    reason="issue #392: Add Task list on jobs/<id>/tasks has no live filter yet",
+    strict=False,
+)
+def test_add_task_filter_narrows_selectable_tasks(page, live_server, login):
+    login()
+    if not page.get_by_role("link", name="Jobs").is_visible():
+        pytest.skip("Login failed against external server; set HASHVIEW_E2E_EMAIL/PASSWORD.")
+
+    job_id = os.getenv("HASHVIEW_E2E_JOB_ID")
+    if not job_id:
+        pytest.skip("Set HASHVIEW_E2E_JOB_ID (seed_e2e_db.py seeds this job).")
+
+    page.goto(f"{live_server}/jobs/{job_id}/tasks", wait_until="domcontentloaded")
+    expect(page.get_by_role("heading", name="Task Library")).to_be_visible()
+
+    drawer = _open_add_task_drawer(page)
+    buttons = _visible_task_buttons(drawer)
+    total = buttons.count()
+    if total == 0:
+        pytest.skip("No assignable tasks in the Add Task drawer to filter.")
+
+    # The filter input is the feature under test. Its absence is exactly the
+    # xfail condition — locating/using it fails today and passes once added.
+    filter_box = drawer.locator("input[placeholder*='filter']").first
+    expect(filter_box).to_be_visible()
+
+    # Capture a real task name and derive a substring that identifies it.
+    first_name = (buttons.first.inner_text()).strip()
+    assert first_name, "expected the first task button to have a visible label"
+    probe = first_name[: max(3, len(first_name) // 2)]
+
+    # 1) A non-matching query hides every task entry and shows the empty state.
+    filter_box.fill(NO_MATCH_QUERY)
+    for i in range(total):
+        expect(buttons.nth(i)).to_be_hidden()
+    expect(drawer.get_by_text("match that filter", exact=False)).to_be_visible()
+
+    # 2) A matching query brings back the matching task (and hides non-matches
+    #    when there is more than one task to distinguish).
+    filter_box.fill(probe)
+    matching = drawer.locator(
+        f"form[action*='/assign_task/']:has-text(\"{first_name}\") button[type=submit]"
+    ).first
+    expect(matching).to_be_visible()
+    if total > 1:
+        visible_now = sum(
+            1 for i in range(total) if buttons.nth(i).is_visible()
+        )
+        assert visible_now < total, (
+            "matching filter query should hide at least one non-matching task"
+        )
+
+    # 3) Clearing the filter restores the full list.
+    filter_box.fill("")
+    for i in range(total):
+        expect(buttons.nth(i)).to_be_visible()

--- a/tests/unit/test_issue_xfail_job_task_filter.py
+++ b/tests/unit/test_issue_xfail_job_task_filter.py
@@ -1,0 +1,228 @@
+"""xfail tests documenting GitHub issue #392.
+
+Feature request: add a live, client-side filter/search field to the job
+task-assignment wizard step (``GET /jobs/<id>/tasks``, rendered by
+``templates/jobs_assigned_tasks.html.j2``) so the selectable **Add Task** and
+**Add Task Group** lists can be narrowed by name — mirroring the filter that
+already exists on the ``/tasks`` listing page (``hvFilterTasks`` in
+``tasks.html.j2``) and inside the task-group builder (``hvGmFilter`` in
+``task_groups.html.j2``).
+
+Each test asserts the DESIRED end state and is marked
+``@pytest.mark.xfail(strict=False)`` so it documents the request without
+breaking the suite. When the feature lands these XPASS and become regression
+guards.
+
+Scope note: this is a purely client-side (template + JS) enhancement, so these
+render-level tests verify the *scaffolding* the JS filter needs — a filter
+input per list and a "no match" empty-state element per list, each scoped to
+the correct drawer. The live keystroke-by-keystroke filtering behavior is JS
+and belongs in an e2e/Playwright test; that can be added once the feature is
+implemented. The scaffolding contract here mirrors the two existing in-tree
+reference implementations.
+"""
+
+import re
+
+import pytest
+
+from hashview.models import (
+    Customers,
+    Jobs,
+    TaskGroups,
+    Tasks,
+    Users,
+    db,
+)
+
+# Distinctive names so substring assertions can't collide with boilerplate.
+TASK_NAME = "ZZTopFilterProbe"
+GROUP_NAME = "QXGroupFilterProbe"
+
+
+def _login(client, user_id):
+    with client.session_transaction() as sess:
+        sess["_user_id"] = str(user_id)
+        sess["_fresh"] = True
+
+
+def _seed_job_with_task_and_group():
+    """Seed an admin, customer, a job, one assignable Task and one TaskGroup.
+
+    Returns the job id. The task and group use distinctive names so the
+    rendered ``/jobs/<id>/tasks`` page shows exactly one selectable entry in
+    each of the Add Task / Add Task Group drawers.
+    """
+    admin = Users(
+        first_name="A",
+        last_name="D",
+        email_address="admin@example.com",
+        password="x" * 60,
+        admin=True,
+        api_key="k",
+    )
+    db.session.add(admin)
+    db.session.commit()
+
+    cust = Customers(name="FilterCo")
+    db.session.add(cust)
+    db.session.commit()
+
+    task = Tasks(name=TASK_NAME, owner_id=admin.id, hc_attackmode=0)
+    db.session.add(task)
+    db.session.commit()
+
+    # TaskGroups.tasks is a non-nullable comma-joined id string (see models.py).
+    group = TaskGroups(name=GROUP_NAME, owner_id=admin.id, tasks=str(task.id))
+    db.session.add(group)
+    db.session.commit()
+
+    job = Jobs(
+        name="FilterJob",
+        owner_id=admin.id,
+        customer_id=cust.id,
+        status="Not Started",
+    )
+    db.session.add(job)
+    db.session.commit()
+
+    return admin.id, job.id
+
+
+def _details_blocks(html):
+    """Return each top-level ``<details>...</details>`` block from the page.
+
+    The Add Task and Add Task Group drawers are non-nested ``<details>``
+    elements, so a non-greedy DOTALL match cleanly separates them.
+    """
+    return re.findall(r"<details\b.*?</details>", html, re.DOTALL | re.IGNORECASE)
+
+
+def _add_task_block(html):
+    """The drawer whose forms POST to /assign_task/<id> (NOT /assign_task_group/)."""
+    for block in _details_blocks(html):
+        if "/assign_task/" in block and "/assign_task_group/" not in block:
+            return block
+    return None
+
+
+def _add_task_group_block(html):
+    """The drawer whose forms POST to /assign_task_group/<id>."""
+    for block in _details_blocks(html):
+        if "/assign_task_group/" in block:
+            return block
+    return None
+
+
+def _has_filter_input(block):
+    """True if ``block`` contains a text ``<input>`` that looks like a filter box.
+
+    Matches the existing convention (a text input with a ``placeholder`` whose
+    text mentions "filter", e.g. ``placeholder="filter tasks…"``). Naming of
+    id/handler is left to the implementer, so we key off the placeholder.
+    """
+    for tag in re.findall(r"<input\b[^>]*>", block, re.IGNORECASE):
+        ph = re.search(r'placeholder\s*=\s*"([^"]*)"', tag, re.IGNORECASE)
+        if ph and "filter" in ph.group(1).lower():
+            return True
+    return False
+
+
+def _render_job_tasks_page(app, client):
+    admin_id, job_id = _seed_job_with_task_and_group()
+    _login(client, admin_id)
+    resp = client.get(f"/jobs/{job_id}/tasks")
+    assert resp.status_code == 200
+    return resp.get_data(as_text=True)
+
+
+@pytest.mark.xfail(
+    reason="issue #392: no filter/search field on the Add Task list of jobs/<id>/tasks",
+    strict=False,
+)
+def test_add_task_drawer_has_live_filter_input(app, client):
+    """The Add Task drawer should expose a filter input to narrow the list.
+
+    DESIRED: mirroring the /tasks page, the selectable-task list on
+    jobs/<id>/tasks carries a text filter input (placeholder mentions
+    "filter"). Currently there is none, so this xfails.
+    """
+    html = _render_job_tasks_page(app, client)
+    block = _add_task_block(html)
+    assert block is not None, "Add Task drawer (forms -> /assign_task/) not found"
+    assert _has_filter_input(block), (
+        "Add Task drawer has no filter input; expected a text <input> with a "
+        'placeholder mentioning "filter" (see hvFilterTasks in tasks.html.j2).'
+    )
+
+
+@pytest.mark.xfail(
+    reason="issue #392: Add Task list has no 'no results' empty state for filtering",
+    strict=False,
+)
+def test_add_task_drawer_has_no_match_empty_state(app, client):
+    """The Add Task drawer should include a hidden 'no match' placeholder.
+
+    DESIRED: like tasks.html.j2's ``#task-no-match`` row ("No tasks match that
+    filter."), the client filter needs an element to reveal when nothing
+    matches. We assert the drawer contains a "match that filter" message.
+    """
+    html = _render_job_tasks_page(app, client)
+    block = _add_task_block(html)
+    assert block is not None, "Add Task drawer (forms -> /assign_task/) not found"
+    assert "match that filter" in block.lower(), (
+        "Add Task drawer has no empty-state element for the filter; expected a "
+        'message like "No tasks match that filter." (cf. #task-no-match).'
+    )
+
+
+@pytest.mark.xfail(
+    reason="issue #392: no filter/search field on the Add Task Group list of jobs/<id>/tasks",
+    strict=False,
+)
+def test_add_task_group_drawer_has_live_filter_input(app, client):
+    """The Add Task Group drawer should expose its own filter input.
+
+    DESIRED: the Add Task Group list is the same unbounded, scrolling drawer as
+    Add Task (TaskGroups.query.all()), so it should get an equivalent filter
+    input. Currently there is none, so this xfails.
+    """
+    html = _render_job_tasks_page(app, client)
+    block = _add_task_group_block(html)
+    assert block is not None, (
+        "Add Task Group drawer (forms -> /assign_task_group/) not found"
+    )
+    assert _has_filter_input(block), (
+        "Add Task Group drawer has no filter input; expected a text <input> "
+        'with a placeholder mentioning "filter".'
+    )
+
+
+@pytest.mark.xfail(
+    reason="issue #392: Add Task Group list has no 'no results' empty state for filtering",
+    strict=False,
+)
+def test_add_task_group_drawer_has_no_match_empty_state(app, client):
+    """The Add Task Group drawer should include a hidden 'no match' placeholder."""
+    html = _render_job_tasks_page(app, client)
+    block = _add_task_group_block(html)
+    assert block is not None, (
+        "Add Task Group drawer (forms -> /assign_task_group/) not found"
+    )
+    assert "match that filter" in block.lower(), (
+        "Add Task Group drawer has no empty-state element for the filter; "
+        'expected a message like "No task groups match that filter."'
+    )
+
+
+def test_seeded_entries_render_without_filter(app, client):
+    """Sanity guard (NOT xfail): the seeded task and group already render in
+    their drawers today. This proves the seeding + drawer-scoping helpers work,
+    so the xfails above fail for the right reason (missing filter UI) rather
+    than because the page never showed the entries.
+    """
+    html = _render_job_tasks_page(app, client)
+    task_block = _add_task_block(html)
+    group_block = _add_task_group_block(html)
+    assert task_block is not None and TASK_NAME in task_block
+    assert group_block is not None and GROUP_NAME in group_block


### PR DESCRIPTION
Adds failing (xfail) tests that specify the feature requested in #392: a live, client-side filter on the job task-assignment wizard step (`GET /jobs/<id>/tasks`, rendered by `templates/jobs_assigned_tasks.html.j2`) to narrow the selectable **Add Task** and **Add Task Group** lists by name — mirroring the existing filter on the `/tasks` page (`hvFilterTasks` in `tasks.html.j2`) and the task-group builder (`hvGmFilter` in `task_groups.html.j2`).

No production code changes — this is the test-first spec for #392.

## Unit render tests — `tests/unit/test_issue_xfail_job_task_filter.py`

Rendering `GET /jobs/<id>/tasks`, scoped to each drawer (`/assign_task/` vs `/assign_task_group/`):

1. `test_add_task_drawer_has_live_filter_input` — Add Task drawer has a text filter input (placeholder mentions "filter").
2. `test_add_task_drawer_has_no_match_empty_state` — Add Task drawer has a "no match" empty-state element (cf. `#task-no-match`).
3. `test_add_task_group_drawer_has_live_filter_input` — same filter input for the Add Task Group drawer.
4. `test_add_task_group_drawer_has_no_match_empty_state` — same empty-state for the Add Task Group drawer.

All four are `@pytest.mark.xfail(strict=False)`, following the repo's `test_issue_xfail_*.py` convention. A fifth, non-xfail sanity guard (`test_seeded_entries_render_without_filter`) confirms the seeded task/group already render, so the xfails fail for the right reason (missing filter UI) rather than a broken page.

## e2e Playwright spec — `tests/e2e/test_job_task_filter.py`

`test_add_task_filter_narrows_selectable_tasks` drives the Add Task drawer in a real browser and asserts the live behavior the unit tests can't: a non-matching query hides every task entry and shows the "no match" empty state; a matching query brings the task back (and hides non-matches when >1 task exists); clearing restores the full list. Also `xfail(strict=False)`. Scoped to the Add Task drawer, which lists the default boot tasks on the seeded e2e job (`HASHVIEW_E2E_JOB_ID`), so it does not skip under strict e2e CI (xfail/xpass do not count against the skip gate).

## Verification

- `pytest tests/unit/test_issue_xfail_job_task_filter.py` → **1 passed, 4 xfailed**.
- Temporarily adding filter markup to both drawers flips all four unit xfails to **XPASS** (verified, then reverted) — confirming they detect the feature and fail for the right reason.
- e2e test: collects (`--collect-only` → 1 test) and `ruff` clean; selectors mirror the proven patterns in `test_job_creation.py`. I did **not** spin up the full docker e2e stack for it — against the current feature-less app it would only reproduce the expected XFAIL at the cost of a full image build, and cannot exercise the feature-present path; its green path runs in the e2e CI job once the feature lands.
- `ruff check` passes on both new files.

Implements the spec for #392.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
