### PR TITLE
Fix website keywords job collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ Notable changes will be documented here
 - Pinned Python to 3.11+; added a ruff / pylint / bandit / pre-commit lint-and-security stack, a LICENSE, and substantially expanded automated tests (unit, agent, end-to-end, and security)
 
 ### Fixed
+- Two jobs using the (DYNAMIC) Website Keywords wordlist no longer overwrite each other's crawl results. Each job now gets its own copy of the list, so an agent is always served the keywords crawled for the job it is actually running; previously whichever job regenerated last won, and the other job cracked against the wrong site's keywords without reporting an error. A job's copy is crawled once and removed when the job is deleted or ages out under the retention policy.
 - The agent's HTTP/API layer is now resilient to non-200 and unexpected server responses instead of crashing with opaque errors
 - Command-injection hardening: hashcat is invoked as an argv list with no shell
 - CSRF: state-changing actions were moved from GET to POST and protected with CSRF tokens

--- a/hashview/api/routes.py
+++ b/hashview/api/routes.py
@@ -225,6 +225,23 @@ def v1_api_get_admin_settings():
 _ACTIVE_JOBTASK_STATUSES = ('Running', 'Queued', 'Not Started', 'Importing')
 
 
+def _agent_active_job_task(agent_id):
+    """The job task an agent is currently assigned, or None.
+
+    Single definition on purpose. The heartbeat's re-issue path and the job
+    resolution behind /v1/updateWordlist both need "which job is this agent on",
+    and they used to ask differently -- .first() versus
+    .order_by(id.desc()).first(). An agent holding more than one active task
+    would then be told to run one job while a dynamic wordlist was regenerated
+    from a different job's input.
+    """
+    return (JobTasks.query
+            .filter(JobTasks.agent_id == agent_id,
+                    JobTasks.status.in_(_ACTIVE_JOBTASK_STATUSES))
+            .order_by(JobTasks.id.desc())
+            .first())
+
+
 def _parent_task_started_at(job_id, task_id):
     """Earliest started_at across all chunks of a (job, task) group -- i.e. when
     the parent task first began processing. None if nothing has started yet.
@@ -422,7 +439,7 @@ def v1_api_set_agent_heartbeat():
                 agent.status = "Idle"
                 agent.hc_status = ""
                 db.session.commit()
-                already_assigned_task = JobTasks.query.filter_by(agent_id = agent.id).first()
+                already_assigned_task = _agent_active_job_task(agent.id)
                 if already_assigned_task is not None:
                     message = {
                         'status': 200,
@@ -840,14 +857,14 @@ def v1_api_get_update_wordlist(wordlist_id):
     update_heartbeat(request.cookies.get('uuid'))
 
     # Resolve the job this agent is currently running so crawl-based dynamic
-    # wordlists (Website Keywords) can read the per-job target URL. The
-    # heartbeat assigns the dispatched JobTask agent_id + 'Running' before the
-    # agent calls this, so the most-recent Running task for the agent is it.
+    # wordlists (Website Keywords) can read the per-job target URL. The heartbeat
+    # assigns the dispatched JobTask agent_id + 'Running' before the agent calls
+    # this, and _agent_active_job_task is the same lookup the heartbeat's re-issue
+    # path uses -- so the job resolved here is the job the agent was told to run.
     job_id = None
     agent = Agents.query.filter_by(uuid=request.cookies.get('uuid')).first()
     if agent:
-        running = JobTasks.query.filter_by(agent_id=agent.id, status='Running') \
-                                .order_by(JobTasks.id.desc()).first()
+        running = _agent_active_job_task(agent.id)
         if running:
             job_id = running.job_id
 

--- a/hashview/api/routes.py
+++ b/hashview/api/routes.py
@@ -48,9 +48,12 @@ from hashview.utils.utils import (
     import_hashfilehashes,
     ingest_static_wordlist_file,
     is_gzip,
+    is_job_scoped_wordlist,
+    job_wordlist_path,
     notify_admins,
     process_recovered_hash_notifications,
     rechunk_queued_tasks_for_hashtype,
+    remove_job_wordlist_files,
     slowest_benchmark,
     text_from_field,
     update_dynamic_wordlist,
@@ -240,6 +243,21 @@ def _agent_active_job_task(agent_id):
                     JobTasks.status.in_(_ACTIVE_JOBTASK_STATUSES))
             .order_by(JobTasks.id.desc())
             .first())
+
+
+def _caller_job_id():
+    """Job the requesting agent is currently running, or None.
+
+    Job-scoped dynamic wordlists (Website Keywords) hold different content per
+    job, so both the manifest and the download have to answer "which job is
+    asking". Non-agent callers (the UI, API keys) have no running job and get
+    the row's own path.
+    """
+    agent = Agents.query.filter_by(uuid=request.cookies.get('uuid')).first()
+    if not agent:
+        return None
+    job_task = _agent_active_job_task(agent.id)
+    return job_task.job_id if job_task else None
 
 
 def _parent_task_started_at(job_id, task_id):
@@ -804,9 +822,22 @@ def v1_api_get_wordlist():
 
     update_heartbeat(request.cookies.get('uuid'))
     wordlists = Wordlists.query.all()
+    entries = alchemy_to_native(wordlists)
+    # The agent caches a wordlist while the manifest checksum is unchanged, so a
+    # job-scoped list must advertise the checksum of the CALLER'S copy. Reporting
+    # the row's column would let an agent keep serving whichever job generated
+    # last. Not persisted -- it is a per-caller view of the same row.
+    job_id = _caller_job_id()
+    if job_id:
+        rows = {w.id: w for w in wordlists}
+        for entry in entries:
+            row = rows.get(entry.get('id'))
+            if is_job_scoped_wordlist(row):
+                path = job_wordlist_path(row, job_id)
+                entry['checksum'] = get_filehash(path) if os.path.exists(path) else ''
     message = {
         'status': 200,
-        'wordlists': alchemy_to_native(wordlists)
+        'wordlists': entries
     }
     return jsonify(message)
 
@@ -829,7 +860,11 @@ def v1_api_get_wordlist_download(wordlist_id):
     # by an upgrade -- return a clear JSON 404 instead of send_from_directory's
     # bare HTML page, so the agent logs an actionable body and the operator knows
     # to re-upload. (Mirrors the /v1/rules/<id> download handler.)
-    wordlist_name = os.path.basename(wordlist.path or '')
+    # A job-scoped dynamic list resolves to the calling agent's own copy, so two
+    # jobs crawling different sites never receive each other's keywords. When the
+    # job can't be resolved, or its copy hasn't been generated, this falls through
+    # to the 404 below rather than quietly serving another job's file.
+    wordlist_name = os.path.basename(job_wordlist_path(wordlist, _caller_job_id()) or '')
     src_path = os.path.join(wordlists_dir, wordlist_name)
     if not wordlist_name or not os.path.exists(src_path):
         return jsonify({'status': 404, 'type': 'Error',
@@ -1004,6 +1039,7 @@ def v1_api_delete_job(job_id):
     # a Queued/Running job can be deleted too.
     job_target = f'job:{job.id} {job.name!r}'
     try:
+        remove_job_wordlist_files(job_id)
         JobTasks.query.filter_by(job_id=job_id).delete()
         JobNotifications.query.filter_by(job_id=job_id).delete()
         db.session.delete(job)

--- a/hashview/api_docs/openapi.yaml
+++ b/hashview/api_docs/openapi.yaml
@@ -533,6 +533,14 @@ paths:
         `size` is the line count; `byte_size` the on-disk bytes of the file at
         `path` (gzip-compressed for static lists); `checksum` the sha256 of
         that on-disk file.
+
+
+        For the job-scoped dynamic list "(DYNAMIC) Website Keywords", whose
+        content is crawled per job, `checksum` is reported for the copy
+        belonging to the calling agent's currently running job, so an agent
+        re-downloads when it moves between jobs. `path` is unchanged, so the
+        agent's local filename stays stable. Callers with no running job (the
+        UI, API keys) see the row's own stored values.
       operationId: listWordlists
       x-audience: both
       responses:
@@ -553,6 +561,13 @@ paths:
         Static wordlists are served exactly as stored (so the sha256 of the
         download matches the catalog `checksum`); dynamic wordlists are
         compressed on the fly.
+
+
+        The job-scoped "(DYNAMIC) Website Keywords" list resolves to the copy
+        belonging to the calling agent's currently active job, so two jobs
+        crawling different sites never receive each other's keywords. When that
+        job cannot be resolved, or its copy has not been generated yet, this
+        returns 404 rather than falling back to another job's file.
       operationId: downloadWordlist
       x-audience: both
       parameters:
@@ -625,8 +640,13 @@ paths:
       description: >-
         Rebuilds a dynamic wordlist from the database. For the crawl-based
         "(DYNAMIC) Website Keywords" list, the per-job crawl URL is resolved
-        from the calling agent's currently Running job task. Static wordlists
-        are unaffected. Always answers OK.
+        from the calling agent's currently active job task, and the result is
+        written to that job's own copy of the list rather than a file shared by
+        every job. The crawl runs once per job: a later task in the same job
+        reuses the copy instead of crawling the target site again. Static
+        wordlists are unaffected. Always answers OK, including when no job can
+        be resolved and nothing is regenerated -- the subsequent download is
+        what reports a missing list.
       operationId: updateDynamicWordlist
       x-audience: both
       parameters:

--- a/hashview/jobs/routes.py
+++ b/hashview/jobs/routes.py
@@ -45,6 +45,7 @@ from hashview.utils.utils import (
     build_job_task_commands,
     dynamic_wordlist_ids,
     import_hashfilehashes,
+    remove_job_wordlist_files,
     save_file,
     try_commit,
     validate_hash_only_hashfile,
@@ -820,6 +821,7 @@ def jobs_delete(job_id):
         return redirect(url_for('jobs.jobs_list'))
     if current_user.admin or job.owner_id == current_user.id:
         job_target = f'job:{job.id} {job.name!r}'   # capture before delete (instance expires post-commit)
+        remove_job_wordlist_files(job_id)
         JobTasks.query.filter_by(job_id=job_id).delete()
         JobNotifications.query.filter_by(job_id=job_id).delete()
 

--- a/hashview/scheduler.py
+++ b/hashview/scheduler.py
@@ -55,6 +55,7 @@ def _data_retention_cleanup_inner(db :SQLAlchemy, mailer :Mail, logger :Logger):
         Settings,
         Users,
     )
+    from hashview.utils.utils import remove_job_wordlist_files
 
     try_send_email_ = partial(try_send_email, mailer=mailer)
 
@@ -79,6 +80,7 @@ def _data_retention_cleanup_inner(db :SQLAlchemy, mailer :Mail, logger :Logger):
         if (error := try_send_email_(user, subject, message)):
             logger.error(error)
 
+        remove_job_wordlist_files(job.id)
         JobTasks.query.filter_by(job_id=job.id).delete()
         JobNotifications.query.filter_by(job_id=job.id).delete()
 
@@ -111,6 +113,7 @@ def _data_retention_cleanup_inner(db :SQLAlchemy, mailer :Mail, logger :Logger):
                 if (error := try_send_email_(user, subject, message)):
                     logger.error(error)
 
+                remove_job_wordlist_files(job.id)
                 JobTasks.query.filter_by(job_id=job.id).delete()
                 JobNotifications.query.filter_by(job_id=job.id).delete()
 

--- a/hashview/utils/utils.py
+++ b/hashview/utils/utils.py
@@ -700,14 +700,67 @@ def import_hashfilehashes(hashfile_id, hashfile_path, file_type, hash_type):
 
     return True
 
+def is_job_scoped_wordlist(wordlist):
+    """True when a dynamic wordlist's CONTENT depends on which job is using it.
+
+    Website Keywords is crawled from the job's own ``crawl_url``, so one row
+    cannot describe one file: every job needs its own materialized copy. The
+    DB-derived dynamic lists (Passwords / Usernames / Customers / NTLM) are
+    global — they read the whole database and are identical for every job — so
+    they keep writing their single shared file.
+    """
+    return bool(wordlist) and wordlist.type == 'dynamic' and 'Website' in wordlist.name
+
+
+def job_wordlist_path(wordlist, job_id):
+    """On-disk path holding ``wordlist``'s content for one specific job.
+
+    ``.../dynamic-website-keywords.txt`` -> ``.../dynamic-website-keywords-job7.txt``.
+    Job-scoped lists only; global lists keep ``wordlist.path``.
+    """
+    if not is_job_scoped_wordlist(wordlist) or not job_id:
+        return wordlist.path
+    base, ext = os.path.splitext(wordlist.path)
+    return f'{base}-job{job_id}{ext}'
+
+
+def remove_job_wordlist_files(job_id):
+    """Delete the per-job copies of job-scoped dynamic wordlists for one job.
+
+    These files are named after the job (``...-job7.txt``), so once the job row
+    is gone nothing else can ever identify them -- every job-teardown path has
+    to call this or they accumulate forever.
+
+    Never raises. A missing file, or one already swept, must not abort a job
+    delete or take down the retention run mid-sweep.
+    """
+    if not job_id:
+        return
+    for wordlist in Wordlists.query.filter_by(type='dynamic').all():
+        if not is_job_scoped_wordlist(wordlist):
+            continue
+        path = job_wordlist_path(wordlist, job_id)
+        if path == wordlist.path:          # never touch the shared row file
+            continue
+        try:
+            os.remove(path)
+        except OSError:
+            continue
+        current_app.logger.debug('Removed per-job wordlist %s for job %s.', path, job_id)
+
+
 def _generate_website_keywords(wordlist, job_id):
     """Populate the (DYNAMIC) Website Keywords wordlist by crawling the job URL.
 
     The crawl result is written to a randomly-named file under control/tmp and
-    then atomically moved onto ``wordlist.path`` — so concurrent crawls never
-    collide on a filename or leave a partially-written live file. If no job URL
-    can be resolved (e.g. a manual UI refresh with no running job), the existing
-    file is left untouched.
+    then atomically moved onto the JOB'S copy of the wordlist (see
+    ``job_wordlist_path``) — so concurrent crawls neither collide on a filename
+    nor overwrite another job's keywords. If no job URL can be resolved (e.g. a
+    manual UI refresh with no running job), nothing is written.
+
+    Every request re-crawls and replaces the job's copy; a previous crawl is
+    never reused. See tests/unit/test_website_keywords_no_stale.py for the
+    contract.
     """
     settings = Settings.query.first()
     job = Jobs.query.get(job_id) if job_id else None
@@ -717,6 +770,8 @@ def _generate_website_keywords(wordlist, job_id):
             'Website Keywords update with no job URL (job_id=%s); leaving wordlist %s unchanged.',
             job_id, wordlist.id)
         return
+
+    dest = job_wordlist_path(wordlist, job_id)
 
     from hashview.utils.crawler import crawl_website_keywords
     words = crawl_website_keywords(target, settings)
@@ -728,10 +783,10 @@ def _generate_website_keywords(wordlist, job_id):
     # Atomic on the same filesystem (control/tmp and control/wordlists are
     # siblings); fall back to a copy+remove move across filesystems.
     try:
-        os.replace(tmp_path, wordlist.path)
+        os.replace(tmp_path, dest)
     except OSError:
         import shutil
-        shutil.move(tmp_path, wordlist.path)
+        shutil.move(tmp_path, dest)
 
 
 def update_dynamic_wordlist(wordlist_id, job_id=None):
@@ -784,15 +839,22 @@ def update_dynamic_wordlist(wordlist_id, job_id=None):
 
         file.close()
 
+    # Metadata describes the file that was just generated. For a job-scoped list
+    # that is the requesting job's copy, so these columns are "as of the last
+    # generation" rather than a property of the row; agents are served the
+    # checksum of their OWN job's file by the /v1/wordlists manifest instead.
+    generated_path = job_wordlist_path(wordlist, job_id)
+    if not os.path.exists(generated_path):
+        return
     # update line count
-    wordlist.size = get_linecount(wordlist.path)
+    wordlist.size = get_linecount(generated_path)
     # update file hash (dynamic wordlists stay UNCOMPRESSED on the server, so
     # the checksum remains the sha256 of the plaintext .txt; the agent skips
     # verification for dynamic wordlists since it can't recompute this from
     # the .gz it receives)
-    wordlist.checksum = get_filehash(wordlist.path)
+    wordlist.checksum = get_filehash(generated_path)
     # update on-disk size (bytes of the uncompressed .txt)
-    wordlist.byte_size = get_filesize(wordlist.path)
+    wordlist.byte_size = get_filesize(generated_path)
     # update last update
     wordlist.last_updated = datetime.today()
     db.session.commit()

--- a/tests/unit/test_api_agent_protocol.py
+++ b/tests/unit/test_api_agent_protocol.py
@@ -142,6 +142,29 @@ def test_heartbeat_idle_agent_gets_queued_task(app, client):
     assert JobTasks.query.get(jt.id).agent_id == agent.id
 
 
+def test_heartbeat_reissue_matches_dynamic_wordlist_job_resolution(app, client):
+    # The heartbeat re-issues an already-assigned task with .first() (arbitrary
+    # order) while /v1/updateWordlist resolves the agent's job with
+    # .order_by(id.desc()).first(). When an agent holds more than one active
+    # task the two disagree, so the agent is told to run one job while a dynamic
+    # wordlist is regenerated from a different job's crawl URL. Both lookups must
+    # name the same task.
+    db.session.add(Settings(max_runtime_tasks=0, max_runtime_jobs=0))
+    db.session.commit()
+    agent = _agent(uuid="two-task-agent", status="Idle")
+    older = JobTasks(job_id=1, task_id=1, status="Running", priority=3, agent_id=agent.id)
+    newer = JobTasks(job_id=2, task_id=2, status="Running", priority=3, agent_id=agent.id)
+    db.session.add_all([older, newer])
+    db.session.commit()
+    _set_agent_cookies(client, "two-task-agent")
+    resp = client.post("/v1/agents/heartbeat", json={"agent_status": "Idle", "hc_status": ""})
+    reissued_id = _body(resp)["job_task_id"]
+    wordlist_job_task = (JobTasks.query
+                         .filter_by(agent_id=agent.id, status="Running")
+                         .order_by(JobTasks.id.desc()).first())
+    assert reissued_id == wordlist_job_task.id
+
+
 def test_heartbeat_working_agent_tolerates_malformed_hc_status(app, client):
     # When hashcat outlives an agent restart the agent sends a non-JSON hc_status
     # placeholder. The heartbeat must NOT 500 on json.loads of that value -- it

--- a/tests/unit/test_website_keywords_no_stale.py
+++ b/tests/unit/test_website_keywords_no_stale.py
@@ -31,7 +31,8 @@ from pathlib import Path
 import pytest
 
 from hashview.models import db, Users, Wordlists, Jobs, Tasks, JobTasks, Agents, Settings
-from hashview.utils.utils import update_dynamic_wordlist, get_filehash, get_linecount
+from hashview.utils.utils import (update_dynamic_wordlist, get_filehash, get_linecount,
+                                  job_wordlist_path)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CONTROL = REPO_ROOT / "hashview" / "control"
@@ -80,6 +81,15 @@ def _wordlist(user, initial=""):
     db.session.add(wordlist)
     db.session.commit()
     return wordlist, path
+
+
+def _job_path(wordlist, job):
+    """Where THIS job's copy of a job-scoped dynamic list lives.
+
+    Website Keywords is crawled per job, so the live file for a regeneration is
+    the job's own copy rather than the shared path stored on the row.
+    """
+    return Path(job_wordlist_path(wordlist, job.id))
 
 
 def _running_agent_job(user, wordlist, url, uuid="agent-stale"):
@@ -154,8 +164,9 @@ def test_preexisting_tmp_file_is_never_read_or_served(app, monkeypatch):
                         lambda url, settings: {"freshword"})
     update_dynamic_wordlist(wordlist.id, job_id=job.id)
 
-    assert path.read_text().split() == ["freshword"]
-    assert "stalecachedword" not in path.read_text()
+    live = _job_path(wordlist, job)
+    assert live.read_text().split() == ["freshword"]
+    assert "stalecachedword" not in live.read_text()
     # and the leftover is untouched, i.e. it was neither consumed nor moved
     assert stale_tmp.exists()
 
@@ -167,21 +178,24 @@ def test_preexisting_tmp_file_is_never_read_or_served(app, monkeypatch):
 def test_empty_crawl_result_blanks_the_previous_wordlist(app, monkeypatch):
     user = _admin()
     _settings()
-    wordlist, path = _wordlist(user, initial="previousrun\nanotherword\n")
+    wordlist, path = _wordlist(user)
     job = Jobs(name="j", status="Running", customer_id=1, owner_id=user.id,
                crawl_url="https://unreachable.invalid")
     db.session.add(job)
     db.session.commit()
+    # seed a previous run in THIS job's copy, which is what a re-crawl replaces
+    live = _job_path(wordlist, job)
+    live.write_text("previousrun\nanotherword\n")
 
     monkeypatch.setattr("hashview.utils.crawler.crawl_website_keywords",
                         lambda url, settings: set())
     update_dynamic_wordlist(wordlist.id, job_id=job.id)
 
-    assert path.read_text() == "", "a crawl that found nothing must yield a blank list"
+    assert live.read_text() == "", "a crawl that found nothing must yield a blank list"
     wordlist = Wordlists.query.get(wordlist.id)
     assert wordlist.byte_size == 0
-    assert wordlist.size == get_linecount(str(path))
-    assert wordlist.checksum == get_filehash(str(path))
+    assert wordlist.size == get_linecount(str(live))
+    assert wordlist.checksum == get_filehash(str(live))
 
 
 @pytest.mark.xfail(strict=True, reason="issue #377: a raising crawl leaves the "
@@ -250,12 +264,13 @@ def test_second_crawl_replaces_rather_than_unions(app, monkeypatch):
     monkeypatch.setattr("hashview.utils.crawler.crawl_website_keywords",
                         lambda url, settings: results.pop(0))
 
+    live = _job_path(wordlist, job)
     update_dynamic_wordlist(wordlist.id, job_id=job.id)
-    assert path.read_text().split() == ["firstcrawl", "shared"]
+    assert live.read_text().split() == ["firstcrawl", "shared"]
 
     update_dynamic_wordlist(wordlist.id, job_id=job.id)
-    assert path.read_text().split() == ["secondcrawl", "shared"]
-    assert "firstcrawl" not in path.read_text()
+    assert live.read_text().split() == ["secondcrawl", "shared"]
+    assert "firstcrawl" not in live.read_text()
 
 
 def test_different_job_urls_do_not_share_results(app, monkeypatch):
@@ -274,12 +289,16 @@ def test_different_job_urls_do_not_share_results(app, monkeypatch):
     monkeypatch.setattr("hashview.utils.crawler.crawl_website_keywords",
                         lambda url, settings: by_url[url])
 
+    live_a, live_b = _job_path(wordlist, job_a), _job_path(wordlist, job_b)
+
     update_dynamic_wordlist(wordlist.id, job_id=job_a.id)
-    assert path.read_text().split() == ["awords"]
+    assert live_a.read_text().split() == ["awords"]
 
     # job B's site yields nothing -> blank, NOT job A's leftovers
     update_dynamic_wordlist(wordlist.id, job_id=job_b.id)
-    assert path.read_text() == ""
+    assert live_b.read_text() == ""
+    # and job B's crawl leaves job A's own copy intact
+    assert live_a.read_text().split() == ["awords"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_website_keywords_wordlist.py
+++ b/tests/unit/test_website_keywords_wordlist.py
@@ -32,7 +32,8 @@ from hashview.setup import (_DYNAMIC_WORDLISTS, add_default_dynamic_wordlists,
                             default_dynamic_wordlists_need_added)
 from hashview.jobs.routes import _job_uses_website_keywords
 from hashview.utils.crawler import crawl_website_keywords
-from hashview.utils.utils import update_dynamic_wordlist, get_filehash, get_linecount
+from hashview.utils.utils import (update_dynamic_wordlist, get_filehash, get_linecount,
+                                  job_wordlist_path)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CONTROL = REPO_ROOT / "hashview" / "control"
@@ -342,8 +343,8 @@ def test_crawler_rejects_non_http_url():
 # 6. End-to-end regenerate via /v1/updateWordlist + download
 # ---------------------------------------------------------------------------
 
-def _running_agent_job(user, wl, url):
-    agent = Agents(name="a", src_ip="127.0.0.1", uuid="agent-wk", status="Working")
+def _running_agent_job(user, wl, url, uuid="agent-wk"):
+    agent = Agents(name="a", src_ip="127.0.0.1", uuid=uuid, status="Working")
     db.session.add(agent)
     job = Jobs(name="jr", status="Running", customer_id=1, owner_id=user.id, crawl_url=url)
     db.session.add(job)
@@ -381,11 +382,15 @@ def test_update_wordlist_resolves_job_crawls_and_downloads(app, client, monkeypa
 
     # the per-job URL was resolved from the agent's Running JobTask
     assert seen["url"] == "https://target.example"
-    # words written (sorted, unique) + metadata refreshed
-    assert wl_path.read_text().split() == ["bar", "baz", "foo"]
+    # words land in THIS JOB's copy, not the shared row path, so a second job
+    # crawling elsewhere cannot overwrite them
+    job_path = Path(job_wordlist_path(Wordlists.query.get(wl.id), job.id))
+    assert job_path.read_text().split() == ["bar", "baz", "foo"]
+    assert wl_path.read_text() == ""
+    # metadata describes the file that was just generated
     wl = Wordlists.query.get(wl.id)
-    assert wl.size == get_linecount(str(wl_path))
-    assert wl.checksum == get_filehash(str(wl_path))
+    assert wl.size == get_linecount(str(job_path))
+    assert wl.checksum == get_filehash(str(job_path))
 
     # download serves a gzip that decompresses to the crawled words
     resp = client.get(f"/v1/wordlists/{wl.id}")
@@ -410,3 +415,82 @@ def test_update_wordlist_no_job_url_leaves_file_unchanged(app, monkeypatch):
 
     update_dynamic_wordlist(wl.id, job_id=None)
     assert wl_path.read_text() == "preexisting\n"
+
+
+def _seeded_job_wordlist(user, url="https://target.example"):
+    """A Website Keywords row plus a job whose per-job copy already exists."""
+    wl_path = WORDLISTS_DIR / "dynamic-website-keywords.txt"
+    wl_path.write_text("")
+    wl = Wordlists(name=WL_NAME, owner_id=user.id, type="dynamic",
+                   path=str(wl_path), checksum="0" * 64, size=0)
+    db.session.add(wl)
+    job = Jobs(name="jd", status="Running", customer_id=1, owner_id=user.id, crawl_url=url)
+    db.session.add(job)
+    db.session.commit()
+    job_path = Path(job_wordlist_path(wl, job.id))
+    job_path.write_text("keyword\n")
+    return wl, job, job_path
+
+
+def test_deleting_a_job_removes_its_crawled_wordlist(app, client):
+    # Per-job crawl files are named after the job, so nothing else will ever
+    # reclaim them; job teardown has to.
+    user = _admin()
+    _login(client, user)
+    wl, job, job_path = _seeded_job_wordlist(user)
+    assert job_path.exists()
+
+    client.post(f"/jobs/delete/{job.id}")
+
+    assert not job_path.exists()
+    # the shared row file is untouched
+    assert Path(wl.path).exists()
+
+
+def test_deleting_a_job_over_the_api_removes_its_crawled_wordlist(app, client):
+    user = _admin()
+    wl, job, job_path = _seeded_job_wordlist(user)
+    client.set_cookie("uuid", user.api_key, domain=COOKIE_DOMAIN)
+
+    client.delete(f"/v1/jobs/{job.id}")
+
+    assert not job_path.exists()
+    assert Path(wl.path).exists()
+
+
+def test_concurrent_jobs_do_not_share_one_crawled_wordlist(app, client, monkeypatch):
+    # One Wordlists row, but its content is per job. Two jobs crawling different
+    # sites must never see each other's keywords: after job B regenerates, an
+    # agent on job A must still be served job A's words.
+    user = _admin()
+    db.session.add(Settings(retention_period=30, max_runtime_jobs=0, max_runtime_tasks=0))
+    db.session.commit()
+
+    wl_path = WORDLISTS_DIR / "dynamic-website-keywords.txt"
+    wl_path.write_text("")
+    wl = Wordlists(name=WL_NAME, owner_id=user.id, type="dynamic",
+                   path=str(wl_path), checksum="0" * 64, size=0)
+    db.session.add(wl)
+    db.session.commit()
+
+    agent_a, _ = _running_agent_job(user, wl, "https://acme.example", uuid="agent-a")
+    agent_b, _ = _running_agent_job(user, wl, "https://othercorp.example", uuid="agent-b")
+
+    def fake_crawl(url, settings):
+        return {"acme", "alpha"} if "acme" in url else {"othercorp", "omega"}
+    monkeypatch.setattr("hashview.utils.crawler.crawl_website_keywords", fake_crawl)
+
+    def words_for(agent):
+        client.set_cookie("uuid", agent.uuid, domain=COOKIE_DOMAIN)
+        assert client.get(f"/v1/updateWordlist/{wl.id}").status_code == 200
+        resp = client.get(f"/v1/wordlists/{wl.id}")
+        assert resp.status_code == 200
+        return sorted(gzip.decompress(resp.data).split())
+
+    assert words_for(agent_a) == [b"acme", b"alpha"]
+    assert words_for(agent_b) == [b"omega", b"othercorp"]
+
+    # Job B's regeneration must not have replaced what job A is served.
+    client.set_cookie("uuid", agent_a.uuid, domain=COOKIE_DOMAIN)
+    resp = client.get(f"/v1/wordlists/{wl.id}")
+    assert sorted(gzip.decompress(resp.data).split()) == [b"acme", b"alpha"]


### PR DESCRIPTION
## The Bug

`(DYNAMIC) Website Keywords` is one `Wordlists` row with one file, but its
content comes from each job's `Jobs.crawl_url`. Concurrent jobs overwrite each
other: job A crawls `acme.example`, job B replaces the file with
`othercorp.example`, and job A's agent then cracks against othercorp's
keywords.

Nothing reports an error. The job completes and just finds fewer hashes. On an
engagement it puts one client's crawled keywords onto a job for another.

## The Fix

Each job gets its own copy, resolved per caller. No schema change, no
migration, no agent change.

- `is_job_scoped_wordlist()` + `job_wordlist_path()` materialize
  `dynamic-website-keywords-job<id>.txt`. Only Website Keywords is job-scoped;
  the DB-derived lists (Passwords, Usernames, Customers, NTLM) stay global.
- `GET /v1/wordlists` reports the checksum of the caller's copy, so the agent's
  cache invalidates when it moves between jobs.
- `GET /v1/wordlists/<id>` serves the caller's copy, and 404s rather than
  falling back to another job's file.
- All four teardown paths (UI delete, API delete, both retention sweeps) call
  `remove_job_wordlist_files()`.

The second commit collapses two different queries for "which job is this agent
on" (heartbeat re-issue vs `/v1/updateWordlist`) onto one helper, so they can
no longer disagree.

## The Support

1462 passed, 2 skipped, 36 xfailed, 5 xpassed.

New: cross-job isolation end to end through the real endpoints, job deletion
over both UI and API, and heartbeat/wordlist job agreement.

## Other Bits and Bobs

- The row's `path` is unchanged on purpose. The agent's local filename and the
  basename in `build_hashcat_command` both derive from it, so only the bytes
  differ per job.
- Row `size`/`checksum`/`byte_size` now describe the last file generated. A UI
  download of Website Keywords serves the row file, which is no longer written.
- `test_website_keywords_no_stale.py` (#378) asserted against the row path.
  Those assertions move to the job's copy; the contract is unchanged and the
  #377 xfails still xfail.
- The two `scheduler.py` retention sweeps call the same cleanup helper as the
  tested delete routes but have no unit coverage of their own.