### PR TITLE
Server-side name filters on the listing pages; paginate and sort /rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ Notable changes will be documented here
 - New "Website Keywords" dynamic wordlist that crawls a per-job URL to build a targeted wordlist
 
 ### Changed
+- The Rules listing is paginated (20 per page) with sortable Name / Rules / Owner / Last Updated columns and a server-side name filter, matching the Tasks listing
 - Reintroduced distributed chunking: eligible mask/wordlist tasks are split into per-agent chunks sized from each agent's benchmark, and a chunked task now appears as a single attack in the job editor
 - Wordlists are stored gzip-compressed at rest; agents sync and verify the compressed files
 - `/v1` list and detail endpoints now return native JSON instead of a JSON-encoded string, so clients no longer double-parse
@@ -59,6 +60,7 @@ Notable changes will be documented here
 - Pinned Python to 3.11+; added a ruff / pylint / bandit / pre-commit lint-and-security stack, a LICENSE, and substantially expanded automated tests (unit, agent, end-to-end, and security)
 
 ### Fixed
+- The name filter on the Tasks and Jobs listings now searches every task/job instead of only the rows on the current page, so a match on a later page is no longer reported as "no match"
 - The agent's HTTP/API layer is now resilient to non-200 and unexpected server responses instead of crashing with opaque errors
 - Command-injection hardening: hashcat is invoked as an argv list with no shell
 - CSRF: state-changing actions were moved from GET to POST and protected with CSRF tokens

--- a/hashview/jobs/routes.py
+++ b/hashview/jobs/routes.py
@@ -42,6 +42,7 @@ from hashview.models import (
 )
 from hashview.utils.audit import log_event
 from hashview.utils.utils import (
+    apply_name_filter,
     build_job_task_commands,
     dynamic_wordlist_ids,
     import_hashfilehashes,
@@ -93,11 +94,17 @@ def jobs_list():
     # Check if filtering by current user
     show_only_mine = request.args.get('show_only_mine', 'false')
 
+    # Name filter. Applied server-side, before pagination, so it searches every
+    # job rather than only the ones rendered on the current page.
+    name_filter = request.args.get('q', '', type=str).strip()
+
     # Build query based on filter
+    query = Jobs.query
     if show_only_mine == 'true':
-        pagination = Jobs.query.filter_by(owner_id=current_user.id).order_by(Jobs.created_at.desc()).paginate(page=page, per_page=per_page, error_out=False)
-    else:
-        pagination = Jobs.query.order_by(Jobs.created_at.desc()).paginate(page=page, per_page=per_page, error_out=False)
+        query = query.filter_by(owner_id=current_user.id)
+    query = apply_name_filter(query, Jobs.name, name_filter)
+    pagination = query.order_by(Jobs.created_at.desc()).paginate(
+        page=page, per_page=per_page, error_out=False)
 
     jobs = pagination.items
 
@@ -202,7 +209,8 @@ def jobs_list():
         job_task_count=job_task_count,
         job_notifs=job_notifs,
         pagination=pagination,
-        show_only_mine=show_only_mine
+        show_only_mine=show_only_mine,
+        name_filter=name_filter
     )
 
 @jobs.route("/jobs/add", methods=['GET', 'POST'])

--- a/hashview/rules/routes.py
+++ b/hashview/rules/routes.py
@@ -14,10 +14,16 @@ from flask import (
 from flask_login import current_user, login_required
 from werkzeug.utils import secure_filename
 
-from hashview.models import Hashes, Jobs, JobTasks, Rules, Tasks, Users, Wordlists, db
+from hashview.models import Hashes, JobTasks, Rules, Tasks, Users, Wordlists, db
 from hashview.rules.forms import RulesForm
 from hashview.utils.audit import log_event
-from hashview.utils.utils import get_filehash, get_linecount, save_file, try_commit
+from hashview.utils.utils import (
+    apply_name_filter,
+    get_filehash,
+    get_linecount,
+    save_file,
+    try_commit,
+)
 
 rules = Blueprint('rules', __name__)
 
@@ -43,13 +49,49 @@ def _rule_ttype(task):
 @rules.route("/rules", methods=['GET'])
 @login_required
 def rules_list():
-    rules = Rules.query.all()
-    tasks = Tasks.query.all()
-    jobs = Jobs.query.all()
-    jobtasks = JobTasks.query.all()
+    # Pagination, sorting, and filtering mirror /tasks. The filter is applied
+    # to the query before .paginate() so it searches every rule rather than
+    # only the ones this page happens to render.
+    page = request.args.get('page', 1, type=int) or 1
+    per_page = 20
+
+    sort_by = request.args.get('sort_by', 'name', type=str)
+    sort_order = request.args.get('sort_order', 'asc', type=str)
+    descending = sort_order == 'desc'
+    name_filter = request.args.get('q', '', type=str).strip()
+
+    if sort_by == 'size':
+        query = Rules.query.order_by(
+            Rules.size.desc() if descending else Rules.size.asc())
+    elif sort_by == 'owner':
+        query = Rules.query.join(Users, Rules.owner_id == Users.id).order_by(
+            Users.first_name.desc() if descending else Users.first_name.asc())
+    elif sort_by == 'last_updated':
+        query = Rules.query.order_by(
+            Rules.last_updated.desc() if descending else Rules.last_updated.asc())
+    else:
+        # Default (and any unrecognised sort_by): by rule name.
+        sort_by = 'name'
+        query = Rules.query.order_by(
+            Rules.name.desc() if descending else Rules.name.asc())
+
+    query = apply_name_filter(query, Rules.name, name_filter)
+    pagination = query.paginate(page=page, per_page=per_page, error_out=False)
+    rules = pagination.items
+
     users = Users.query.all()
 
-    # --- per-rule info-modal data ---
+    # --- per-rule info-modal data, for the rules on this page only ---
+    # Scoped to pagination.items so the cost is bounded by page size rather
+    # than by the size of the rules table.
+    rule_ids = [r.id for r in rules]
+    tasks = (Tasks.query.filter(Tasks.rule_id.in_(rule_ids)).all()
+             if rule_ids else [])
+    tasks_by_rule = {}
+    for t in tasks:
+        tasks_by_rule.setdefault(t.rule_id, []).append(t)
+
+    task_ids = [t.id for t in tasks]
     wl_names = {w.id: w.name for w in Wordlists.query.all()}
     user_names = {u.id: (((u.first_name or '') + ' ' + (u.last_name or '')).strip() or '—')
                   for u in users}
@@ -57,11 +99,13 @@ def rules_list():
         row.task_id: row.recovered_count
         for row in Hashes.query.with_entities(
             Hashes.task_id, db.func.count(Hashes.id).label('recovered_count')
-        ).filter(Hashes.cracked == '1').group_by(Hashes.task_id).all()
-    }
+        ).filter(Hashes.cracked == '1',
+                 Hashes.task_id.in_(task_ids)).group_by(Hashes.task_id).all()
+    } if task_ids else {}
     jobs_by_task = {}
-    for jt in jobtasks:
-        jobs_by_task.setdefault(jt.task_id, set()).add(jt.job_id)
+    if task_ids:
+        for jt in JobTasks.query.filter(JobTasks.task_id.in_(task_ids)).all():
+            jobs_by_task.setdefault(jt.task_id, set()).add(jt.job_id)
 
     rule_used_tasks = {}   # rule.id -> [{name, wordlist, type, hits}]
     rule_hits = {}         # rule.id -> summed historical hits
@@ -69,7 +113,7 @@ def rules_list():
     rule_job_count = {}    # rule.id -> number of distinct jobs using those tasks
     rule_owner = {}        # rule.id -> owner display name
     for rule in rules:
-        used = [t for t in tasks if t.rule_id == rule.id]
+        used = tasks_by_rule.get(rule.id, [])
         rows, job_ids, total = [], set(), 0
         for t in used:
             hits = recovered_by_task.get(t.id, 0)
@@ -87,10 +131,12 @@ def rules_list():
         rule_job_count[rule.id] = len(job_ids)
         rule_owner[rule.id] = user_names.get(rule.owner_id, '—')
 
-    return render_template('rules.html.j2', title='Rules', rules=rules, tasks=tasks, jobs=jobs,
-                           jobtasks=jobtasks, users=users, rule_used_tasks=rule_used_tasks,
+    return render_template('rules.html.j2', title='Rules', rules=rules,
+                           users=users, rule_used_tasks=rule_used_tasks,
                            rule_hits=rule_hits, rule_task_count=rule_task_count,
                            rule_job_count=rule_job_count, rule_owner=rule_owner, rulesForm=RulesForm(),
+                           pagination=pagination, sort_by=sort_by, sort_order=sort_order,
+                           name_filter=name_filter,
                            form_err=session.pop('rules_form_err', None))
 
 @rules.route("/rules/add", methods=['GET', 'POST'])

--- a/hashview/tasks/routes.py
+++ b/hashview/tasks/routes.py
@@ -17,7 +17,7 @@ from hashview.models import (
 )
 from hashview.tasks.forms import TasksForm
 from hashview.utils.audit import log_event
-from hashview.utils.utils import try_commit
+from hashview.utils.utils import apply_name_filter, try_commit
 
 tasks = Blueprint('tasks', __name__)
 
@@ -43,6 +43,10 @@ def tasks_list():
     # Get sorting parameters
     sort_by = request.args.get('sort_by', 'name', type=str)
     sort_order = request.args.get('sort_order', 'asc', type=str)
+
+    # Name filter. Applied server-side, before pagination, so it searches every
+    # task rather than only the ones rendered on the current page.
+    name_filter = request.args.get('q', '', type=str).strip()
 
     # Build the query with sorting
     if sort_by == 'recovered':
@@ -76,6 +80,8 @@ def tasks_list():
             query = Tasks.query.order_by(Tasks.name.desc())
         else:
             query = Tasks.query.order_by(Tasks.name.asc())
+
+    query = apply_name_filter(query, Tasks.name, name_filter)
 
     pagination = query.paginate(page=page, per_page=per_page, error_out=False)
     tasks = pagination.items
@@ -130,7 +136,7 @@ def tasks_list():
         seen.add(job.id)
         jobs_by_task.setdefault(jt.task_id, []).append(job)
 
-    return render_template('tasks.html.j2', title='tasks', tasks=tasks, users=users, jobs=jobs, job_tasks=job_tasks, jobs_by_task=jobs_by_task, wordlists=wordlists, task_groups=task_groups, task_recovery_performance=task_recovery_performance, pagination=pagination, sort_by=sort_by, sort_order=sort_order, rules=Rules.query.all(), wl_filesize=wl_filesize, tasks_in_jobs=tasks_in_jobs, tasksForm=TasksForm(), form_err=session.pop('tasks_form_err', None))
+    return render_template('tasks.html.j2', title='tasks', tasks=tasks, users=users, jobs=jobs, job_tasks=job_tasks, jobs_by_task=jobs_by_task, wordlists=wordlists, task_groups=task_groups, task_recovery_performance=task_recovery_performance, pagination=pagination, sort_by=sort_by, sort_order=sort_order, name_filter=name_filter, rules=Rules.query.all(), wl_filesize=wl_filesize, tasks_in_jobs=tasks_in_jobs, tasksForm=TasksForm(), form_err=session.pop('tasks_form_err', None))
 
 @tasks.route("/tasks/add", methods=['GET', 'POST'])
 @login_required

--- a/hashview/templates/jobs.html.j2
+++ b/hashview/templates/jobs.html.j2
@@ -12,9 +12,9 @@
     </div>
     <div style="display:flex; gap:10px;">
         {% if show_only_mine == 'true' %}
-            <a class="btn active" href="{{ url_for('jobs.jobs_list', show_only_mine='false', page=1) }}">{{ icon('users', size=15) }} All jobs</a>
+            <a class="btn active" href="{{ url_for('jobs.jobs_list', show_only_mine='false', page=1, q=name_filter) }}">{{ icon('users', size=15) }} All jobs</a>
         {% else %}
-            <a class="btn" href="{{ url_for('jobs.jobs_list', show_only_mine='true', page=1) }}">{{ icon('users', size=15) }} Only mine</a>
+            <a class="btn" href="{{ url_for('jobs.jobs_list', show_only_mine='true', page=1, q=name_filter) }}">{{ icon('users', size=15) }} Only mine</a>
         {% endif %}
         <a class="btn btn-primary" href="{{ url_for('jobs.jobs_add') }}">{{ icon('plus', size=15) }} New Job</a>
     </div>
@@ -22,8 +22,15 @@
 
 <div class="card">
     <div class="card-head" style="justify-content:flex-end;">
-        <span style="color:var(--text-mute); display:inline-flex;">{{ icon('search', size=16) }}</span>
-        <input type="text" id="job-filter" class="input" style="width:260px; flex:none;" placeholder="filter jobs…" autocomplete="off" oninput="hvFilterJobs(this.value)">
+        {# Server-side filter: submits so it searches every job, not just this page. #}
+        <form method="GET" action="{{ url_for('jobs.jobs_list') }}" style="display:flex; align-items:center; gap:8px; margin:0;">
+            <input type="hidden" name="show_only_mine" value="{{ show_only_mine }}">
+            <span style="color:var(--text-mute); display:inline-flex;">{{ icon('search', size=16) }}</span>
+            <input type="text" id="job-filter" name="q" value="{{ name_filter }}" class="input" style="width:260px; flex:none;" placeholder="filter jobs…" autocomplete="off">
+            {% if name_filter %}
+            <a class="icon-btn" href="{{ url_for('jobs.jobs_list', show_only_mine=show_only_mine) }}" title="Clear filter">{{ icon('x', size=15) }}</a>
+            {% endif %}
+        </form>
     </div>
     {% if jobs %}
     <table class="tbl">
@@ -97,9 +104,13 @@
                 </td>
             </tr>
             {% endfor %}
-            <tr id="job-no-match" style="display:none;"><td colspan="9" style="text-align:center; padding:28px 16px; color:var(--text-mute);" class="mono">No jobs match that filter.</td></tr>
         </tbody>
     </table>
+    {% elif name_filter %}
+    <div class="card-body" style="text-align:center; padding:48px 24px;">
+        <div class="mono" style="color:var(--text-dim); margin-bottom:14px;">No jobs match &ldquo;{{ name_filter }}&rdquo;.</div>
+        <a class="btn" href="{{ url_for('jobs.jobs_list', show_only_mine=show_only_mine) }}">Clear filter</a>
+    </div>
     {% else %}
     <div class="card-body" style="text-align:center; padding:48px 24px;">
         <div class="mono" style="color:var(--text-dim); margin-bottom:14px;">No jobs found.</div>
@@ -111,7 +122,7 @@
 {% if pagination.pages and pagination.pages > 1 %}
 <div class="pager">
     {% if pagination.has_prev %}
-        <a class="pager-btn" href="{{ url_for('jobs.jobs_list', page=pagination.prev_num, show_only_mine=show_only_mine) }}">‹ Prev</a>
+        <a class="pager-btn" href="{{ url_for('jobs.jobs_list', page=pagination.prev_num, show_only_mine=show_only_mine, q=name_filter) }}">‹ Prev</a>
     {% else %}
         <span class="pager-btn disabled">‹ Prev</span>
     {% endif %}
@@ -120,14 +131,14 @@
             {% if p == pagination.page %}
                 <span class="pager-btn active">{{ p }}</span>
             {% else %}
-                <a class="pager-btn" href="{{ url_for('jobs.jobs_list', page=p, show_only_mine=show_only_mine) }}">{{ p }}</a>
+                <a class="pager-btn" href="{{ url_for('jobs.jobs_list', page=p, show_only_mine=show_only_mine, q=name_filter) }}">{{ p }}</a>
             {% endif %}
         {% else %}
             <span class="pager-btn disabled">…</span>
         {% endif %}
     {% endfor %}
     {% if pagination.has_next %}
-        <a class="pager-btn" href="{{ url_for('jobs.jobs_list', page=pagination.next_num, show_only_mine=show_only_mine) }}">Next ›</a>
+        <a class="pager-btn" href="{{ url_for('jobs.jobs_list', page=pagination.next_num, show_only_mine=show_only_mine, q=name_filter) }}">Next ›</a>
     {% else %}
         <span class="pager-btn disabled">Next ›</span>
     {% endif %}
@@ -190,17 +201,6 @@
         }
     }, true);
 })();
-function hvFilterJobs(q){
-    q = (q || '').trim().toLowerCase();
-    var shown = 0;
-    document.querySelectorAll('#job-tbody tr[data-name]').forEach(function(tr){
-        var hit = !q || (tr.getAttribute('data-name') || '').indexOf(q) !== -1;
-        tr.style.display = hit ? '' : 'none';
-        if (hit) shown++;
-    });
-    var none = document.getElementById('job-no-match');
-    if (none) none.style.display = shown === 0 ? '' : 'none';
-}
 </script>
 
 {# ---- per-job modals (native <dialog>, no framework) ---- #}

--- a/hashview/templates/rules.html.j2
+++ b/hashview/templates/rules.html.j2
@@ -11,7 +11,7 @@
 <div class="page-head">
     <div>
         <h1 class="page-title">Rules</h1>
-        <div class="page-sub">// {{ rules|length | commafy }} rulesets applied as mutations over wordlists</div>
+        <div class="page-sub">// {{ pagination.total | commafy }} ruleset{{ '' if pagination.total == 1 else 's' }} applied as mutations over wordlists · page {{ pagination.page }}/{{ pagination.pages or 1 }}</div>
     </div>
     <button type="button" class="btn btn-primary" onclick="document.getElementById('upload-rule-modal').showModal()">{{ icon('upload', size=15) }} Upload rules</button>
 </div>
@@ -19,17 +19,45 @@
 <div class="card">
     {# ---- filter bar: magnifying glass beside the input, top-right of the card ---- #}
     <div class="card-head" style="justify-content:flex-end;">
-        <span style="color:var(--text-mute); display:inline-flex;">{{ icon('search', size=16) }}</span>
-        <input type="text" id="rule-filter" class="input" style="width:260px; flex:none;" placeholder="filter rules…" autocomplete="off" oninput="hvFilterRules(this.value)">
+        {# Server-side filter: submits so it searches every rule, not just this page. #}
+        <form method="GET" action="{{ url_for('rules.rules_list') }}" style="display:flex; align-items:center; gap:8px; margin:0;">
+            <input type="hidden" name="sort_by" value="{{ sort_by }}">
+            <input type="hidden" name="sort_order" value="{{ sort_order }}">
+            <span style="color:var(--text-mute); display:inline-flex;">{{ icon('search', size=16) }}</span>
+            <input type="text" id="rule-filter" name="q" value="{{ name_filter }}" class="input" style="width:260px; flex:none;" placeholder="filter rules…" autocomplete="off">
+            {% if name_filter %}
+            <a class="icon-btn" href="{{ url_for('rules.rules_list', sort_by=sort_by, sort_order=sort_order) }}" title="Clear filter">{{ icon('x', size=15) }}</a>
+            {% endif %}
+        </form>
     </div>
     {% if rules %}
     <table class="tbl">
         <thead>
             <tr>
-                <th>Name</th>
-                <th>Rules</th>
-                <th>Owner</th>
-                <th>Last Updated</th>
+                <th>
+                    <a href="{{ url_for('rules.rules_list', sort_by='name', sort_order='desc' if sort_by == 'name' and sort_order == 'asc' else 'asc', page=1, q=name_filter) }}" style="color:inherit; text-decoration:none; display:inline-flex; align-items:center; gap:4px;">
+                        Name
+                        {% if sort_by == 'name' %}<span class="mono" style="font-size:9px;">{{ '▲' if sort_order == 'asc' else '▼' }}</span>{% endif %}
+                    </a>
+                </th>
+                <th>
+                    <a href="{{ url_for('rules.rules_list', sort_by='size', sort_order='desc' if sort_by == 'size' and sort_order == 'asc' else 'asc', page=1, q=name_filter) }}" style="color:inherit; text-decoration:none; display:inline-flex; align-items:center; gap:4px;">
+                        Rules
+                        {% if sort_by == 'size' %}<span class="mono" style="font-size:9px;">{{ '▲' if sort_order == 'asc' else '▼' }}</span>{% endif %}
+                    </a>
+                </th>
+                <th>
+                    <a href="{{ url_for('rules.rules_list', sort_by='owner', sort_order='desc' if sort_by == 'owner' and sort_order == 'asc' else 'asc', page=1, q=name_filter) }}" style="color:inherit; text-decoration:none; display:inline-flex; align-items:center; gap:4px;">
+                        Owner
+                        {% if sort_by == 'owner' %}<span class="mono" style="font-size:9px;">{{ '▲' if sort_order == 'asc' else '▼' }}</span>{% endif %}
+                    </a>
+                </th>
+                <th>
+                    <a href="{{ url_for('rules.rules_list', sort_by='last_updated', sort_order='desc' if sort_by == 'last_updated' and sort_order == 'asc' else 'asc', page=1, q=name_filter) }}" style="color:inherit; text-decoration:none; display:inline-flex; align-items:center; gap:4px;">
+                        Last Updated
+                        {% if sort_by == 'last_updated' %}<span class="mono" style="font-size:9px;">{{ '▲' if sort_order == 'asc' else '▼' }}</span>{% endif %}
+                    </a>
+                </th>
                 <th class="center">Control</th>
             </tr>
         </thead>
@@ -55,9 +83,13 @@
                 </td>
             </tr>
             {% endfor %}
-            <tr id="rule-no-match" style="display:none;"><td colspan="5" style="text-align:center; padding:28px 16px; color:var(--text-mute);" class="mono">No rules match that filter.</td></tr>
         </tbody>
     </table>
+    {% elif name_filter %}
+    <div class="card-body" style="text-align:center; padding:48px 24px;">
+        <div class="mono" style="color:var(--text-dim); margin-bottom:14px;">No rules match &ldquo;{{ name_filter }}&rdquo;.</div>
+        <a class="btn" href="{{ url_for('rules.rules_list', sort_by=sort_by, sort_order=sort_order) }}">Clear filter</a>
+    </div>
     {% else %}
     <div class="card-body" style="text-align:center; padding:48px 24px;">
         <div class="mono" style="color:var(--text-dim); margin-bottom:14px;">No rules found.</div>
@@ -65,6 +97,32 @@
     </div>
     {% endif %}
 </div>
+
+{% if pagination.pages and pagination.pages > 1 %}
+<div class="pager">
+    {% if pagination.has_prev %}
+        <a class="pager-btn" href="{{ url_for('rules.rules_list', page=pagination.prev_num, sort_by=sort_by, sort_order=sort_order, q=name_filter) }}">&lsaquo; Prev</a>
+    {% else %}
+        <span class="pager-btn disabled">&lsaquo; Prev</span>
+    {% endif %}
+    {% for p in pagination.iter_pages(left_edge=2, right_edge=2, left_current=2, right_current=2) %}
+        {% if p %}
+            {% if p == pagination.page %}
+                <span class="pager-btn active">{{ p }}</span>
+            {% else %}
+                <a class="pager-btn" href="{{ url_for('rules.rules_list', page=p, sort_by=sort_by, sort_order=sort_order, q=name_filter) }}">{{ p }}</a>
+            {% endif %}
+        {% else %}
+            <span class="pager-btn disabled">&hellip;</span>
+        {% endif %}
+    {% endfor %}
+    {% if pagination.has_next %}
+        <a class="pager-btn" href="{{ url_for('rules.rules_list', page=pagination.next_num, sort_by=sort_by, sort_order=sort_order, q=name_filter) }}">Next &rsaquo;</a>
+    {% else %}
+        <span class="pager-btn disabled">Next &rsaquo;</span>
+    {% endif %}
+</div>
+{% endif %}
 
 {# ---- upload-rule modal (opened from the "Upload rules" button) ---- #}
 <dialog class="hv-dialog" id="upload-rule-modal" style="max-width:560px; width:92vw;">
@@ -196,20 +254,6 @@
     </div>
 </dialog>
 {% endfor %}
-
-<script>
-function hvFilterRules(q){
-    q = (q || '').trim().toLowerCase();
-    var shown = 0;
-    document.querySelectorAll('#rule-tbody tr[data-name]').forEach(function(tr){
-        var hit = !q || (tr.getAttribute('data-name') || '').indexOf(q) !== -1;
-        tr.style.display = hit ? '' : 'none';
-        if (hit) shown++;
-    });
-    var none = document.getElementById('rule-no-match');
-    if (none) none.style.display = shown === 0 ? '' : 'none';
-}
-</script>
 
 {# Reopen the Upload-rule modal after a failed submit, error shown inside it. #}
 {% if form_err %}

--- a/hashview/templates/tasks.html.j2
+++ b/hashview/templates/tasks.html.j2
@@ -103,33 +103,41 @@
 
 <div class="card">
     <div class="card-head" style="justify-content:flex-end;">
-        <span style="color:var(--text-mute); display:inline-flex;">{{ icon('search', size=16) }}</span>
-        <input type="text" id="task-filter" class="input" style="width:260px; flex:none;" placeholder="filter tasks…" autocomplete="off" oninput="hvFilterTasks(this.value)">
+        {# Server-side filter: submits so it searches every task, not just this page. #}
+        <form method="GET" action="{{ url_for('tasks.tasks_list') }}" style="display:flex; align-items:center; gap:8px; margin:0;">
+            <input type="hidden" name="sort_by" value="{{ sort_by }}">
+            <input type="hidden" name="sort_order" value="{{ sort_order }}">
+            <span style="color:var(--text-mute); display:inline-flex;">{{ icon('search', size=16) }}</span>
+            <input type="text" id="task-filter" name="q" value="{{ name_filter }}" class="input" style="width:260px; flex:none;" placeholder="filter tasks…" autocomplete="off">
+            {% if name_filter %}
+            <a class="icon-btn" href="{{ url_for('tasks.tasks_list', sort_by=sort_by, sort_order=sort_order) }}" title="Clear filter">{{ icon('x', size=15) }}</a>
+            {% endif %}
+        </form>
     </div>
     {% if tasks %}
     <table class="tbl">
         <thead>
             <tr>
                 <th>
-                    <a href="{{ url_for('tasks.tasks_list', sort_by='name', sort_order='desc' if sort_by == 'name' and sort_order == 'asc' else 'asc', page=1) }}" style="color:inherit; text-decoration:none; display:inline-flex; align-items:center; gap:4px;">
+                    <a href="{{ url_for('tasks.tasks_list', sort_by='name', sort_order='desc' if sort_by == 'name' and sort_order == 'asc' else 'asc', page=1, q=name_filter) }}" style="color:inherit; text-decoration:none; display:inline-flex; align-items:center; gap:4px;">
                         Task Name
                         {% if sort_by == 'name' %}{{ icon('arrowUp' if sort_order == 'asc' else 'arrowDown', size=12) }}{% endif %}
                     </a>
                 </th>
                 <th>
-                    <a href="{{ url_for('tasks.tasks_list', sort_by='owner', sort_order='desc' if sort_by == 'owner' and sort_order == 'asc' else 'asc', page=1) }}" style="color:inherit; text-decoration:none; display:inline-flex; align-items:center; gap:4px;">
+                    <a href="{{ url_for('tasks.tasks_list', sort_by='owner', sort_order='desc' if sort_by == 'owner' and sort_order == 'asc' else 'asc', page=1, q=name_filter) }}" style="color:inherit; text-decoration:none; display:inline-flex; align-items:center; gap:4px;">
                         Owner
                         {% if sort_by == 'owner' %}{{ icon('arrowUp' if sort_order == 'asc' else 'arrowDown', size=12) }}{% endif %}
                     </a>
                 </th>
                 <th>
-                    <a href="{{ url_for('tasks.tasks_list', sort_by='type', sort_order='desc' if sort_by == 'type' and sort_order == 'asc' else 'asc', page=1) }}" style="color:inherit; text-decoration:none; display:inline-flex; align-items:center; gap:4px;">
+                    <a href="{{ url_for('tasks.tasks_list', sort_by='type', sort_order='desc' if sort_by == 'type' and sort_order == 'asc' else 'asc', page=1, q=name_filter) }}" style="color:inherit; text-decoration:none; display:inline-flex; align-items:center; gap:4px;">
                         Type
                         {% if sort_by == 'type' %}{{ icon('arrowUp' if sort_order == 'asc' else 'arrowDown', size=12) }}{% endif %}
                     </a>
                 </th>
                 <th>
-                    <a href="{{ url_for('tasks.tasks_list', sort_by='recovered', sort_order='desc' if sort_by == 'recovered' and sort_order == 'asc' else 'asc', page=1) }}" style="color:inherit; text-decoration:none; display:inline-flex; align-items:center; gap:4px;">
+                    <a href="{{ url_for('tasks.tasks_list', sort_by='recovered', sort_order='desc' if sort_by == 'recovered' and sort_order == 'asc' else 'asc', page=1, q=name_filter) }}" style="color:inherit; text-decoration:none; display:inline-flex; align-items:center; gap:4px;">
                         Passwords Recovered
                         {% if sort_by == 'recovered' %}{{ icon('arrowUp' if sort_order == 'asc' else 'arrowDown', size=12) }}{% endif %}
                     </a>
@@ -190,9 +198,13 @@
                 </td>
             </tr>
             {% endfor %}
-            <tr id="task-no-match" style="display:none;"><td colspan="5" style="text-align:center; padding:28px 16px; color:var(--text-mute);" class="mono">No tasks match that filter.</td></tr>
         </tbody>
     </table>
+    {% elif name_filter %}
+    <div class="card-body" style="text-align:center; padding:48px 24px;">
+        <div class="mono" style="color:var(--text-dim); margin-bottom:14px;">No tasks match &ldquo;{{ name_filter }}&rdquo;.</div>
+        <a class="btn" href="{{ url_for('tasks.tasks_list', sort_by=sort_by, sort_order=sort_order) }}">Clear filter</a>
+    </div>
     {% else %}
     <div class="card-body" style="text-align:center; padding:48px 24px;">
         <div class="mono" style="color:var(--text-dim); margin-bottom:14px;">No tasks found.</div>
@@ -204,7 +216,7 @@
 {% if pagination.pages and pagination.pages > 1 %}
 <div class="pager">
     {% if pagination.has_prev %}
-        <a class="pager-btn" href="{{ url_for('tasks.tasks_list', page=pagination.prev_num, sort_by=sort_by, sort_order=sort_order) }}">‹ Prev</a>
+        <a class="pager-btn" href="{{ url_for('tasks.tasks_list', page=pagination.prev_num, sort_by=sort_by, sort_order=sort_order, q=name_filter) }}">‹ Prev</a>
     {% else %}
         <span class="pager-btn disabled">‹ Prev</span>
     {% endif %}
@@ -213,33 +225,19 @@
             {% if p == pagination.page %}
                 <span class="pager-btn active">{{ p }}</span>
             {% else %}
-                <a class="pager-btn" href="{{ url_for('tasks.tasks_list', page=p, sort_by=sort_by, sort_order=sort_order) }}">{{ p }}</a>
+                <a class="pager-btn" href="{{ url_for('tasks.tasks_list', page=p, sort_by=sort_by, sort_order=sort_order, q=name_filter) }}">{{ p }}</a>
             {% endif %}
         {% else %}
             <span class="pager-btn disabled">…</span>
         {% endif %}
     {% endfor %}
     {% if pagination.has_next %}
-        <a class="pager-btn" href="{{ url_for('tasks.tasks_list', page=pagination.next_num, sort_by=sort_by, sort_order=sort_order) }}">Next ›</a>
+        <a class="pager-btn" href="{{ url_for('tasks.tasks_list', page=pagination.next_num, sort_by=sort_by, sort_order=sort_order, q=name_filter) }}">Next ›</a>
     {% else %}
         <span class="pager-btn disabled">Next ›</span>
     {% endif %}
 </div>
 {% endif %}
-
-<script>
-function hvFilterTasks(q){
-    q = (q || '').trim().toLowerCase();
-    var shown = 0;
-    document.querySelectorAll('#task-tbody tr[data-name]').forEach(function(tr){
-        var hit = !q || (tr.getAttribute('data-name') || '').indexOf(q) !== -1;
-        tr.style.display = hit ? '' : 'none';
-        if (hit) shown++;
-    });
-    var none = document.getElementById('task-no-match');
-    if (none) none.style.display = shown === 0 ? '' : 'none';
-}
-</script>
 
 {# ---- add-task modal (opened from the "Add Task" button) ---- #}
 <dialog class="hv-dialog" id="add-task-modal" style="max-width:680px; width:94vw;">

--- a/hashview/utils/utils.py
+++ b/hashview/utils/utils.py
@@ -1731,3 +1731,19 @@ def getTimeFormat(total_runtime): # Runtime in seconds
         return str(round(total_runtime/60)) + " minute(s)"
     elif total_runtime < 60:
         return "less then 1 minute"
+
+def apply_name_filter(query, column, search_term):
+    """Narrow `query` to rows whose `column` contains `search_term`.
+
+    Case-insensitive substring match, used by the listing pages so their filter
+    box searches the whole table rather than only the rows the current page
+    happened to render. An empty or whitespace-only term is a no-op.
+
+    LIKE wildcards in the user's input are escaped, so typing a literal '%' or
+    '_' matches that character instead of standing in for "anything".
+    """
+    term = (search_term or '').strip()
+    if not term:
+        return query
+    escaped = term.replace('\\', '\\\\').replace('%', '\\%').replace('_', '\\_')
+    return query.filter(column.ilike('%' + escaped + '%', escape='\\'))

--- a/tests/unit/test_list_filter_scope.py
+++ b/tests/unit/test_list_filter_scope.py
@@ -1,0 +1,236 @@
+"""The name filter on /tasks and /jobs must search every row, not just the page.
+
+Regression tests for #414. Both listings paginate at 20 rows/page, but the
+filter used to run client-side over the rendered rows only, so typing a name
+that lived on a later page rendered "No tasks match that filter." even though
+the record existed.
+
+Each off-page test asserts its own precondition -- that the needle really is
+absent from page 1 -- because without that the test would pass whether or not
+the filter reaches the database.
+
+Fixtures come from tests/unit/conftest.py (app, client). The login helper
+mirrors tests/unit/test_rules_searches_notifications_branches.py.
+"""
+
+import re
+from datetime import datetime
+
+from hashview.models import Customers, Jobs, Tasks, Users, db
+
+PER_PAGE = 20
+
+# A needle that sorts after the filler names, so it lands on the last page.
+LATE_NAME = "zzz-needle-on-a-later-page"
+
+
+def _admin():
+    u = Users(first_name="Ad", last_name="Min",
+              email_address="admin@listfilter.test",
+              password="x" * 60, admin=True)
+    db.session.add(u)
+    db.session.commit()
+    return u
+
+
+def _login(client, user):
+    with client.session_transaction() as sess:
+        sess["_user_id"] = str(user.id)
+        sess["_fresh"] = True
+
+
+def _padding_names(count=PER_PAGE + 4, prefix="aaa-filler"):
+    return [f"{prefix}-{i:03d}" for i in range(count)]
+
+
+def _make_tasks(owner_id, names):
+    for name in names:
+        db.session.add(Tasks(name=name, hc_attackmode=0, owner_id=owner_id))
+    db.session.commit()
+
+
+def _make_jobs(owner_id, names):
+    """Create one Jobs row per name, oldest first in list order.
+
+    /jobs orders by created_at descending, so stamping created_at explicitly
+    keeps the *first* name in ``names`` on the *last* page. Relying on
+    insertion order instead would put the needle on page 1, and the off-page
+    tests would pass without exercising anything.
+    """
+    customer = Customers(name="Filter Customer")
+    db.session.add(customer)
+    db.session.commit()
+    for i, name in enumerate(names):
+        db.session.add(Jobs(name=name, status="Ready",
+                            customer_id=customer.id, owner_id=owner_id,
+                            created_at=datetime(2026, 1, 1, 0, 0, i)))
+    db.session.commit()
+
+
+def _present(body, names):
+    """Subset of ``names`` that appear in the rendered ``body``."""
+    return [n for n in names if n in body]
+
+
+# ---------------------------------------------------------------------------
+# /tasks
+# ---------------------------------------------------------------------------
+
+def test_tasks_filter_finds_a_task_that_is_not_on_the_current_page(client, app):
+    user = _admin()
+    _login(client, user)
+    _make_tasks(user.id, _padding_names() + [LATE_NAME])
+
+    assert LATE_NAME not in client.get("/tasks").get_data(as_text=True), \
+        "needle must be off page 1 for this test to mean anything"
+
+    body = client.get("/tasks?q=needle").get_data(as_text=True)
+
+    assert LATE_NAME in body
+
+
+def test_tasks_filter_excludes_non_matching_tasks(client, app):
+    user = _admin()
+    _login(client, user)
+    padding = _padding_names()
+    _make_tasks(user.id, padding + [LATE_NAME])
+
+    body = client.get("/tasks?q=needle").get_data(as_text=True)
+
+    assert _present(body, padding) == []
+
+
+def test_tasks_filter_is_case_insensitive(client, app):
+    user = _admin()
+    _login(client, user)
+    _make_tasks(user.id, ["Best64-Mixed-Case"])
+
+    body = client.get("/tasks?q=best64-MIXED").get_data(as_text=True)
+
+    assert "Best64-Mixed-Case" in body
+
+
+def test_tasks_filter_survives_a_sort_change(client, app):
+    """Re-sorting a filtered listing keeps the filter applied."""
+    user = _admin()
+    _login(client, user)
+    padding = _padding_names()
+    _make_tasks(user.id, padding + [LATE_NAME])
+
+    body = client.get(
+        "/tasks?q=needle&sort_by=name&sort_order=desc").get_data(as_text=True)
+
+    assert LATE_NAME in body
+    assert _present(body, padding) == []
+
+
+def test_tasks_filter_treats_like_wildcards_literally(client, app):
+    """A literal % typed in the box must not match everything.
+
+    Unescaped, '%' reaches SQL LIKE as "any sequence", so this would return
+    the filler rows too.
+    """
+    user = _admin()
+    _login(client, user)
+    padding = _padding_names()
+    _make_tasks(user.id, padding + ["100%-real-task"])
+
+    body = client.get("/tasks?q=%25").get_data(as_text=True)
+
+    assert "100%-real-task" in body
+    assert _present(body, padding) == []
+
+
+def test_tasks_empty_filter_is_a_no_op(client, app):
+    """An empty q behaves like no filter at all (still a full first page)."""
+    user = _admin()
+    _login(client, user)
+    names = _padding_names(25)
+    _make_tasks(user.id, names)
+
+    body = client.get("/tasks?q=").get_data(as_text=True)
+
+    assert len(_present(body, names)) == PER_PAGE
+
+
+# ---------------------------------------------------------------------------
+# /jobs
+# ---------------------------------------------------------------------------
+
+def test_jobs_filter_finds_a_job_that_is_not_on_the_current_page(client, app):
+    user = _admin()
+    _login(client, user)
+    _make_jobs(user.id, [LATE_NAME] + _padding_names())
+
+    assert LATE_NAME not in client.get("/jobs").get_data(as_text=True), \
+        "needle must be off page 1 for this test to mean anything"
+
+    body = client.get("/jobs?q=needle").get_data(as_text=True)
+
+    assert LATE_NAME in body
+
+
+def test_jobs_filter_excludes_non_matching_jobs(client, app):
+    user = _admin()
+    _login(client, user)
+    padding = _padding_names()
+    _make_jobs(user.id, [LATE_NAME] + padding)
+
+    body = client.get("/jobs?q=needle").get_data(as_text=True)
+
+    assert _present(body, padding) == []
+
+
+def test_tasks_clear_filter_link_drops_the_search_term(client, app):
+    """The clear-filter affordance must not carry q, or it re-applies it."""
+    user = _admin()
+    _login(client, user)
+    _make_tasks(user.id, ["needle-task"])
+
+    body = client.get("/tasks?q=needle").get_data(as_text=True)
+
+    clear_links = re.findall(r'href="([^"]*)"[^>]*title="Clear filter"', body)
+    assert clear_links, "expected a clear-filter link while a filter is active"
+    for href in clear_links:
+        assert "q=needle" not in href
+
+
+def test_jobs_clear_filter_link_drops_the_search_term(client, app):
+    user = _admin()
+    _login(client, user)
+    _make_jobs(user.id, ["needle-job"])
+
+    body = client.get("/jobs?q=needle").get_data(as_text=True)
+
+    clear_links = re.findall(r'href="([^"]*)"[^>]*title="Clear filter"', body)
+    assert clear_links, "expected a clear-filter link while a filter is active"
+    for href in clear_links:
+        assert "q=needle" not in href
+
+
+def test_jobs_filter_composes_with_show_only_mine(client, app):
+    """The filter and the owner toggle apply together, not one or the other."""
+    mine = _admin()
+    other = Users(first_name="Other", last_name="Owner",
+                  email_address="other@listfilter.test",
+                  password="x" * 60, admin=False)
+    db.session.add(other)
+    db.session.commit()
+    _login(client, mine)
+
+    customer = Customers(name="Compose Customer")
+    db.session.add(customer)
+    db.session.commit()
+    db.session.add(Jobs(name="needle-mine", status="Ready",
+                        customer_id=customer.id, owner_id=mine.id,
+                        created_at=datetime(2026, 1, 1)))
+    db.session.add(Jobs(name="needle-theirs", status="Ready",
+                        customer_id=customer.id, owner_id=other.id,
+                        created_at=datetime(2026, 1, 2)))
+    db.session.commit()
+
+    body = client.get(
+        "/jobs?q=needle&show_only_mine=true").get_data(as_text=True)
+
+    assert "needle-mine" in body
+    assert "needle-theirs" not in body

--- a/tests/unit/test_rules_pagination.py
+++ b/tests/unit/test_rules_pagination.py
@@ -1,0 +1,316 @@
+"""/rules pagination, sorting, and server-side filtering.
+
+Tests for #413. The rules listing rendered every ruleset in one unpaginated
+table with no sortable columns, unlike /tasks and /jobs. Adding pagination
+means the filter has to run server-side in the same change, or /rules just
+acquires the bug fixed for /tasks and /jobs in #414.
+
+Fixtures come from tests/unit/conftest.py (app, client). The login helper
+mirrors tests/unit/test_rules_searches_notifications_branches.py.
+"""
+
+import re
+from datetime import datetime
+
+from hashview.models import Rules, Tasks, Users, db
+
+PER_PAGE = 20
+
+# A needle that sorts after the filler names, so it lands on the last page.
+LATE_NAME = "zzz-needle-on-a-later-page"
+
+
+def _admin():
+    u = Users(first_name="Ad", last_name="Min",
+              email_address="admin@rulepage.test",
+              password="x" * 60, admin=True)
+    db.session.add(u)
+    db.session.commit()
+    return u
+
+
+def _login(client, user):
+    with client.session_transaction() as sess:
+        sess["_user_id"] = str(user.id)
+        sess["_fresh"] = True
+
+
+def _padding_names(count=PER_PAGE + 4, prefix="aaa-filler"):
+    return [f"{prefix}-{i:03d}" for i in range(count)]
+
+
+def _make_rules(owner_id, names, sizes=None):
+    for i, name in enumerate(names):
+        db.session.add(Rules(name=name, owner_id=owner_id,
+                             path=f"/tmp/{name}.rule",
+                             size=(sizes[i] if sizes else 1),
+                             checksum=f"{i:064d}",
+                             last_updated=datetime(2026, 1, 1 + (i % 27))))
+    db.session.commit()
+
+
+def _present(body, names):
+    """Subset of ``names`` that appear in the rendered ``body``."""
+    return [n for n in names if n in body]
+
+
+# ---------------------------------------------------------------------------
+# Pagination
+# ---------------------------------------------------------------------------
+
+def test_rules_list_paginates_at_twenty_per_page(client, app):
+    user = _admin()
+    _login(client, user)
+    names = _padding_names(25)
+    _make_rules(user.id, names)
+
+    body = client.get("/rules").get_data(as_text=True)
+
+    assert len(_present(body, names)) == PER_PAGE
+
+
+def test_rules_list_second_page_shows_the_remainder(client, app):
+    user = _admin()
+    _login(client, user)
+    names = _padding_names(25)
+    _make_rules(user.id, names)
+
+    page1 = _present(client.get("/rules").get_data(as_text=True), names)
+    page2 = _present(client.get("/rules?page=2").get_data(as_text=True), names)
+
+    assert len(page2) == 5
+    assert not set(page1) & set(page2)
+    assert set(page1) | set(page2) == set(names)
+
+
+def test_rules_page_out_of_range_does_not_error(client, app):
+    """A page past the end renders an empty page rather than a 404/500."""
+    user = _admin()
+    _login(client, user)
+    _make_rules(user.id, _padding_names(3))
+
+    assert client.get("/rules?page=99").status_code == 200
+
+
+def test_rules_non_numeric_page_falls_back_to_the_first_page(client, app):
+    user = _admin()
+    _login(client, user)
+    names = _padding_names(25)
+    _make_rules(user.id, names)
+
+    body = client.get("/rules?page=notanumber").get_data(as_text=True)
+
+    assert len(_present(body, names)) == PER_PAGE
+
+
+# ---------------------------------------------------------------------------
+# Server-side filtering
+# ---------------------------------------------------------------------------
+
+def test_rules_filter_finds_a_rule_that_is_not_on_the_current_page(client, app):
+    user = _admin()
+    _login(client, user)
+    _make_rules(user.id, _padding_names() + [LATE_NAME])
+
+    assert LATE_NAME not in client.get("/rules").get_data(as_text=True), \
+        "needle must be off page 1 for this test to mean anything"
+
+    body = client.get("/rules?q=needle").get_data(as_text=True)
+
+    assert LATE_NAME in body
+
+
+def test_rules_filter_excludes_non_matching_rules(client, app):
+    user = _admin()
+    _login(client, user)
+    padding = _padding_names()
+    _make_rules(user.id, padding + [LATE_NAME])
+
+    body = client.get("/rules?q=needle").get_data(as_text=True)
+
+    assert _present(body, padding) == []
+
+
+def test_rules_filter_is_case_insensitive(client, app):
+    user = _admin()
+    _login(client, user)
+    _make_rules(user.id, ["Best64-Mixed-Case"])
+
+    body = client.get("/rules?q=best64-MIXED").get_data(as_text=True)
+
+    assert "Best64-Mixed-Case" in body
+
+
+def test_rules_filter_treats_like_wildcards_literally(client, app):
+    user = _admin()
+    _login(client, user)
+    padding = _padding_names()
+    _make_rules(user.id, padding + ["100%-real-rule"])
+
+    body = client.get("/rules?q=%25").get_data(as_text=True)
+
+    assert "100%-real-rule" in body
+    assert _present(body, padding) == []
+
+
+def test_rules_filter_is_preserved_across_pagination(client, app):
+    """A filter matching more than one page keeps applying on page 2."""
+    user = _admin()
+    _login(client, user)
+    matching = [f"needle-{i:03d}" for i in range(25)]
+    _make_rules(user.id, matching + ["unrelated-rule"])
+
+    body = client.get("/rules?q=needle&page=2").get_data(as_text=True)
+
+    assert len(_present(body, matching)) == 5
+    assert "unrelated-rule" not in body
+
+
+# ---------------------------------------------------------------------------
+# Sorting
+# ---------------------------------------------------------------------------
+
+def test_rules_sort_by_size_descending_puts_the_largest_first(client, app):
+    user = _admin()
+    _login(client, user)
+    _make_rules(user.id, ["small-rule", "huge-rule"], sizes=[5, 9999])
+
+    body = client.get("/rules?sort_by=size&sort_order=desc").get_data(as_text=True)
+
+    assert body.index("huge-rule") < body.index("small-rule")
+
+
+def test_rules_sort_by_name_descending_reverses_the_default_order(client, app):
+    user = _admin()
+    _login(client, user)
+    _make_rules(user.id, ["aaa-rule", "zzz-rule"])
+
+    asc = client.get("/rules?sort_by=name&sort_order=asc").get_data(as_text=True)
+    desc = client.get("/rules?sort_by=name&sort_order=desc").get_data(as_text=True)
+
+    assert asc.index("aaa-rule") < asc.index("zzz-rule")
+    assert desc.index("zzz-rule") < desc.index("aaa-rule")
+
+
+def test_rules_sort_by_owner_orders_by_owner_name(client, app):
+    admin = _admin()
+    zed = Users(first_name="Zed", last_name="Last",
+                email_address="zed@rulepage.test",
+                password="x" * 60, admin=False)
+    db.session.add(zed)
+    db.session.commit()
+    _login(client, admin)
+    _make_rules(admin.id, ["owned-by-ad"])
+    _make_rules(zed.id, ["owned-by-zed"])
+
+    body = client.get("/rules?sort_by=owner&sort_order=asc").get_data(as_text=True)
+
+    assert body.index("owned-by-ad") < body.index("owned-by-zed")
+
+
+def test_rules_unknown_sort_key_falls_back_to_name(client, app):
+    """An unrecognised sort_by must not 500; it sorts by name."""
+    user = _admin()
+    _login(client, user)
+    _make_rules(user.id, ["aaa-rule", "zzz-rule"])
+
+    resp = client.get("/rules?sort_by=;DROP TABLE rules;--")
+    body = resp.get_data(as_text=True)
+
+    assert resp.status_code == 200
+    assert body.index("aaa-rule") < body.index("zzz-rule")
+
+
+# ---------------------------------------------------------------------------
+# The info-modal data build must be scoped to the rendered page, not the
+# whole table -- otherwise pagination bounds the DOM but not the query cost.
+# ---------------------------------------------------------------------------
+
+def test_rules_info_modal_data_is_built_only_for_the_current_page(client, app):
+    user = _admin()
+    _login(client, user)
+    names = _padding_names(25)
+    _make_rules(user.id, names)
+
+    body = client.get("/rules").get_data(as_text=True)
+
+    # One delete dialog is emitted per rule the template loops over; if that
+    # loop still ran over the whole table there would be 25 of them.
+    assert body.count('id="del-') == PER_PAGE
+
+
+def test_rules_task_lookup_is_restricted_to_the_pages_rule_ids(client, app):
+    """The tasks query must be narrowed, not just the rendering.
+
+    Counting rendered dialogs cannot distinguish "loaded 20 rules' tasks" from
+    "loaded every task and rendered 20", so this inspects the SQL actually
+    issued: every SELECT against `tasks` must carry a rule_id restriction.
+    """
+    from sqlalchemy import event
+
+    from hashview.models import db as _db
+
+    user = _admin()
+    _login(client, user)
+    _make_rules(user.id, _padding_names(25))
+
+    statements = []
+
+    def record(conn, cursor, statement, parameters, context, executemany):
+        statements.append(" ".join(statement.split()).lower())
+
+    engine = _db.engine
+    event.listen(engine, "before_cursor_execute", record)
+    try:
+        client.get("/rules")
+    finally:
+        event.remove(engine, "before_cursor_execute", record)
+
+    # Aggregate counts are excluded: the sidebar nav badges issue a global
+    # SELECT COUNT(*) FROM tasks on every authenticated page (see
+    # inject_nav_counts in hashview/__init__.py). That is bounded work and
+    # predates this route; what matters here is that no query *materialises*
+    # task rows for rules outside the page.
+    row_loads = [s for s in statements
+                 if s.startswith("select") and " from tasks" in s
+                 and "count(" not in s]
+
+    # Deliberately not "every row-load must mention rule_id": asserting over
+    # all captured statements makes the test hostage to any unrelated query
+    # that happens to run inside the listener's window. Instead: the scoped
+    # lookup must be present, and no row-load may be an unfiltered full scan.
+    assert any("rule_id in" in s for s in row_loads), \
+        f"no rule_id-scoped task lookup found; saw: {row_loads}"
+    unfiltered = [s for s in row_loads if " where " not in s]
+    assert not unfiltered, f"unrestricted scan of tasks: {unfiltered}"
+
+
+def test_rules_info_modal_omits_tasks_belonging_to_off_page_rules(client, app):
+    """A task attached to a rule on page 2 is not rendered into page 1."""
+    user = _admin()
+    _login(client, user)
+    _make_rules(user.id, _padding_names(24) + ["zzz-last-page-rule"])
+    off_page = Rules.query.filter_by(name="zzz-last-page-rule").first()
+    db.session.add(Tasks(name="task-of-the-off-page-rule", hc_attackmode=0,
+                         owner_id=user.id, rule_id=off_page.id))
+    db.session.commit()
+
+    page1 = client.get("/rules").get_data(as_text=True)
+    page2 = client.get("/rules?page=2").get_data(as_text=True)
+
+    assert "task-of-the-off-page-rule" not in page1
+    assert "task-of-the-off-page-rule" in page2
+
+
+def test_rules_clear_filter_link_drops_the_search_term(client, app):
+    """The clear-filter affordance must not carry q, or it re-applies it."""
+    user = _admin()
+    _login(client, user)
+    _make_rules(user.id, ["needle-rule"])
+
+    body = client.get("/rules?q=needle").get_data(as_text=True)
+
+    clear_links = re.findall(r'href="([^"]*)"[^>]*title="Clear filter"', body)
+    assert clear_links, "expected a clear-filter link while a filter is active"
+    for href in clear_links:
+        assert "q=needle" not in href


### PR DESCRIPTION
Fixes #414. Fixes #413.

## Why

The name filter on `/tasks` and `/jobs` ran client-side over the rows already in the DOM, but both listings paginate at 20 rows per page. Typing a name that lived on a later page rendered "No tasks match that filter." even though the record existed — the filter stopped working at exactly the list size that makes it useful, and it failed by *asserting* the match didn't exist rather than by looking incomplete.

`/rules` had the opposite problem: no pagination and no sortable columns at all, so it rendered the entire rules table on every load. Adding pagination there without moving the filter server-side would just have handed `/rules` the same bug.

## What changed

**`/tasks` and `/jobs` (#414)** — the filter now runs in the query, before `.paginate()`, through a shared `apply_name_filter()` helper. LIKE metacharacters in the search term are escaped, so a literal `%` or `_` matches itself instead of acting as a wildcard. The input became a GET form; the pager, column-sort links, and the jobs all/mine toggle carry the active `q` so filter + sort + page compose. The dead "no match" rows were replaced with a filter-aware empty state.

**`/rules` (#413)** — paginated at 20/page with sortable Name / Rules / Owner / Last Updated headers, matching `/tasks`, plus the same server-side filter. An unrecognised `sort_by` falls back to name rather than erroring. The info-modal data build is now scoped to the current page: tasks are fetched by the page's rule ids and indexed once, and the hits/job-count lookups are narrowed to those tasks, dropping per-request work from O(rules × tasks) to O(page). `tasks`/`jobs`/`jobtasks` were being passed to the template unused and are no longer queried at all.

Two commits, one per issue; each is green on its own so the history bisects.

## Tests

28 new tests across `tests/unit/test_list_filter_scope.py` and `tests/unit/test_rules_pagination.py`, written before the fixes and confirmed to fail first.

The off-page tests assert their own precondition — that the needle really is absent from page 1 — because without that they'd pass whether or not the filter reaches the database. That check caught a genuine flaw while writing them: `/jobs` orders by `created_at desc`, so a needle inserted last lands *first*, and the test passed vacuously until `created_at` was stamped explicitly.

Each fix was mutation-verified rather than assumed:

| Mutation | Result |
| --- | --- |
| `apply_name_filter` returns query unchanged | 10 fail |
| LIKE escaping removed | the 2 wildcard tests fail |
| rules `per_page` raised to 100000 | 6 fail |
| rules task lookup back to `Tasks.query.all()` | SQL-scoping test fails |

The scoping test inspects the SQL actually issued rather than counting rendered dialogs, since counting DOM elements can't distinguish "loaded 20 rules' tasks" from "loaded every task and rendered 20". It asserts the scoped lookup is present and that no task row-load is an unfiltered full scan, rather than quantifying over every captured statement — that stricter form would be hostage to any unrelated query in the listener's window. Aggregate `COUNT(*)`s are excluded because the sidebar nav badges issue one on every authenticated page (pre-existing, and bounded).

## Verification

- Unit + security together (what CI runs): **1452 passed**, 0 failed. Base is 1424, so +28 and no regressions.
- MySQL 8.4.11 parity, since this repo has a history of MySQL-only divergence (#373): the 28 new tests pass on real MySQL, and the escaping was checked on both dialects. Running the wider `-k "rule or task or job"` selection under MySQL gives 18 failed / 496 passed against **18 failed / 473 passed on the base commit** — the same pre-existing failures (the unit suite isn't MySQL-gated in CI), no new ones.
- CI-gated `tests/integration -m mysql` against an Alembic-migrated schema: 9 passed, 13 skipped.
- Ruff clean on all changed files. Verified the echoed filter value is escaped (no XSS) and the new filter form introduces no nested `<form>` on any of the three pages.

## Notes for the reviewer

- Filtering submits on Enter rather than as debounced live search. #413 asked for "on input (debounced) or on Enter"; this is the simpler reading and adds no JS.
- The `owner` sort uses an inner join, so a rule whose `owner_id` has no `Users` row would drop out of the listing. This mirrors the pre-existing `/tasks` owner sort, and MySQL's FK prevents the orphan, but SQLite never enables `PRAGMA foreign_keys`, so it's reachable there. Left as-is to match `/tasks`; an `outerjoin` on both would be a reasonable follow-up.
- `test_wordlist_encoding.py` is flaky in this environment (unrelated to this diff — it covers wordlist gzip round-trips). It failed 3 tests on one combined run and passed clean on a re-run.
- The pre-push hook blocked this branch on a false positive: for a first push it passes `rev-list`-style args (`$local_sha --not --remotes`) to `git diff`, producing a combined diff in which pre-existing lines appear as additions. It flagged an `api.pushover.net` URL that is already on `origin/main` and `origin/v0.8.3-dev` and that this diff never touches. I confirmed the 757 added lines contain no URLs, private IPs, internal hostnames, or credentials before bypassing. Worth fixing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
