### PR TITLE
fix(githooks): pre-push scanner missed secrets on new-branch pushes

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -9,6 +9,14 @@
 # Enable once per clone:
 #   git config core.hooksPath .githooks
 #
+# Keep that value relative, exactly as written above. Git resolves a relative
+# hooksPath against the top level of whichever working tree you run git from, so
+# each git worktree correctly uses its own .githooks/. An absolute path (e.g.
+# /Users/you/projects/hashview/.githooks) instead pins every worktree to the
+# main checkout's copy: edits to this script made in a worktree then have no
+# effect on a push from it, and you are silently testing the old version.
+# Check with: git config core.hooksPath
+#
 # Bypass (use sparingly):
 #   git push --no-verify
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -69,18 +69,45 @@ while read -r local_ref local_sha remote_ref remote_sha; do
     commits=$(git rev-list "${range_args[@]}" 2>/dev/null)
     [ -z "$commits" ] && continue
 
-    # Combined diff of added lines only for the push range.
-    diff=$(git diff --unified=0 --no-color "${range_args[@]}" 2>/dev/null)
+    # Per-commit patch for the push range.
+    #
+    # Must be `git log -p`, not `git diff`: range_args uses rev-list syntax,
+    # and for a new branch that is `<sha> --not --remotes`. `git diff` does not
+    # understand --not/--remotes as range exclusion — it treats the extra revs
+    # as more sides to compare and emits a *combined* diff, which both omits
+    # real additions and attributes untouched upstream lines to the push. That
+    # made the scanner report "clean" on a commit holding an AWS key (#418).
+    # `git log -p` takes rev-list arguments natively. Merge commits are skipped
+    # by default, which is right: they add nothing the listed commits lack.
+    diff=$(git log -p --unified=0 --no-color --format='' "${range_args[@]}")
 
     # Files added/modified in this push.
-    changed_files=$(git diff --name-only --diff-filter=AM "${range_args[@]}" 2>/dev/null)
+    changed_files=$(git log --name-only --diff-filter=AM --format='' \
+                        "${range_args[@]}" | grep -v '^$' | sort -u)
+
+    # Every path touched by the push, any status. Used only for the sanity
+    # check below.
+    touched_files=$(git log --name-only --format='' "${range_args[@]}" \
+                        | grep -v '^$' | sort -u)
 
     # Commit messages (subject + body) for every commit in the push range,
     # prefixed with the short SHA so findings point at the offending commit.
     messages=$(git log --format='%h %B%n---END---' "${range_args[@]}" 2>/dev/null)
 
-    if [ -z "$diff" ] && [ -z "$messages" ]; then
-        continue
+    # Sanity check for gross breakage: files were touched but git returned no
+    # patch text at all. A backstop only — it catches a range that yields
+    # nothing, not one that yields the wrong thing. (In #418 the bad range
+    # still emitted combined-diff headers, so this check would NOT have caught
+    # it; the tests in tests/unit/test_prepush_hook.py are what guard that.)
+    #
+    # Keyed on touched_files rather than on the commit list, because an empty
+    # commit (git commit --allow-empty) legitimately has no patch and must
+    # still be pushable.
+    if [ -z "$diff" ] && [ -n "$touched_files" ]; then
+        printf '%spre-push: %s file(s) changed in this push but no diff could be computed.%s\n' \
+            "$RED" "$(printf '%s\n' "$touched_files" | wc -l | tr -d ' ')" "$RST" >&2
+        printf 'This is a bug in the hook, not a finding. Refusing to report a clean scan.\n' >&2
+        exit 1
     fi
 
     # --- Built-in patterns (scan added diff lines + commit messages) ---

--- a/tests/unit/test_prepush_hook.py
+++ b/tests/unit/test_prepush_hook.py
@@ -1,0 +1,277 @@
+"""The pre-push secret scanner must see the lines a push actually adds.
+
+Regression tests for #418. `.githooks/pre-push` built its scan range with
+`git rev-list` syntax (`<sha> --not --remotes`) and then handed those same
+arguments to `git diff`, which has no notion of `--not`/`--remotes` as range
+exclusion and emits a *combined* diff instead. On a new-branch push the
+scanner could therefore receive an empty haystack and report
+"sensitive-content scan clean." for a commit containing an AWS key.
+
+These tests drive the real hook script through its stdin protocol against
+throwaway repositories. They assert on the hook's scan *output* rather than
+its exit status: the hook also runs a ruff/bandit/pytest gate after the scan,
+which exits non-zero in a throwaway repo for unrelated reasons, so exit
+status alone cannot distinguish "blocked by the scanner" from "gate failed".
+"""
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOK = REPO_ROOT / ".githooks" / "pre-push"
+ZERO = "0" * 40
+
+# Secret-shaped fixtures, assembled at runtime so this file holds no literal
+# that a secret scanner (this hook, GitHub push protection, gitleaks) would
+# flag. The strings the tests write to disk are complete and do match; only the
+# source text here does not. AKIA... is AWS's own published example key ID.
+FAKE_AWS_KEY = "AKIA" + "IOSFODNN7EXAMPLE"
+FAKE_PASSWORD = "sup3r" + "s3cret_value"
+
+
+def _assignment(name, value):
+    """Render `name = "value"` as file content.
+
+    Going through a helper keeps the assignment shape the scanner looks for
+    out of this file's own source, while the text written to disk still has
+    it. Inlining an f-string here would make this file trip the very patterns
+    these tests exercise.
+    """
+    return f'{name} = "{value}"\n'
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("git") is None or shutil.which("bash") is None,
+    reason="needs git and bash",
+)
+
+
+def _clean_env():
+    """Environment with git's own variables stripped out.
+
+    These tests can run *inside* a git hook -- the pre-push gate they cover
+    invokes the test suite -- and git exports GIT_DIR, GIT_INDEX_FILE and
+    friends to hooks. Inherited, they redirect every `git` call below at the
+    real repository instead of the throwaway one, so each must be scrubbed.
+    """
+    return {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+
+
+def _git(cwd, *args):
+    return subprocess.run(("git",) + args, cwd=cwd, check=True,
+                          capture_output=True, text=True,
+                          env=_clean_env()).stdout
+
+
+def _build_repo(tmp_path):
+    """An upstream plus a clone with main and an older fork branch pushed.
+
+    The older fork branch matters: it gives `--remotes` more than one ref, so
+    the buggy `git diff` invocation produces a multi-parent combined diff
+    rather than something that coincidentally resembles a real one.
+    """
+    upstream = tmp_path / "up.git"
+    clone = tmp_path / "clone"
+    subprocess.run(["git", "init", "-q", "--bare", str(upstream)], check=True,
+                   env=_clean_env())
+    subprocess.run(["git", "clone", "-q", str(upstream), str(clone)], check=True,
+                   env=_clean_env())
+    _git(clone, "config", "user.email", "t@t.test")
+    _git(clone, "config", "user.name", "T")
+    _git(clone, "config", "commit.gpgsign", "false")
+
+    (clone / "app.py").write_text("value = 1\n")
+    _git(clone, "add", "app.py")
+    _git(clone, "commit", "-q", "-m", "initial")
+    _git(clone, "branch", "-M", "main")
+    _git(clone, "push", "-q", "origin", "main")
+
+    # A fork branch pushed before the content main gains below.
+    _git(clone, "checkout", "-q", "-b", "oldfork", "main")
+    _git(clone, "push", "-q", "origin", "oldfork")
+
+    # main then gains a line holding a URL, which no later branch touches.
+    _git(clone, "checkout", "-q", "main")
+    (clone / "app.py").write_text(
+        'value = 1\nnotify("https://hooks.example.com/notify")\n')
+    _git(clone, "add", "app.py")
+    _git(clone, "commit", "-q", "-m", "add notify url")
+    _git(clone, "push", "-q", "origin", "main")
+
+    hooks = clone / ".githooks"
+    hooks.mkdir(exist_ok=True)
+    shutil.copy(HOOK, hooks / "pre-push")
+    _git(clone, "fetch", "-q", "origin")
+    return upstream, clone
+
+
+def _run_hook(clone, upstream, local_ref, local_sha, remote_sha):
+    """Invoke the hook exactly as git would, and return its combined output."""
+    stdin = f"{local_ref} {local_sha} {local_ref} {remote_sha}\n"
+    proc = subprocess.run(
+        ["bash", str(clone / ".githooks" / "pre-push"), "origin", str(upstream)],
+        cwd=clone, input=stdin, capture_output=True, text=True,
+        env=_clean_env(),
+    )
+    return proc.stdout + proc.stderr
+
+
+def _scan_output(text):
+    """Just the scanner's portion, before the ruff/bandit/pytest gate."""
+    return text.split("pre-push: running ruff")[0]
+
+
+def test_new_branch_push_scans_secrets_in_added_lines(tmp_path):
+    """The core #418 regression: a new branch's added lines must be scanned."""
+    upstream, clone = _build_repo(tmp_path)
+    _git(clone, "checkout", "-q", "-b", "feature/x", "main")
+    (clone / "leak.py").write_text(_assignment("AWS_KEY", FAKE_AWS_KEY))
+    _git(clone, "add", "leak.py")
+    _git(clone, "commit", "-q", "-m", "add a key")
+    sha = _git(clone, "rev-parse", "HEAD").strip()
+
+    out = _scan_output(_run_hook(clone, upstream, "refs/heads/feature/x", sha, ZERO))
+
+    assert "sensitive-content scan clean" not in out
+    assert "AWS access key ID" in out
+
+
+def test_new_branch_push_scans_generic_secret_assignments(tmp_path):
+    upstream, clone = _build_repo(tmp_path)
+    _git(clone, "checkout", "-q", "-b", "feature/y", "main")
+    (clone / "conf.py").write_text(_assignment("password", FAKE_PASSWORD))
+    _git(clone, "add", "conf.py")
+    _git(clone, "commit", "-q", "-m", "add config")
+    sha = _git(clone, "rev-parse", "HEAD").strip()
+
+    out = _scan_output(_run_hook(clone, upstream, "refs/heads/feature/y", sha, ZERO))
+
+    assert "sensitive-content scan clean" not in out
+    assert "Generic secret assign" in out
+
+
+def test_new_branch_push_flags_added_env_file(tmp_path):
+    """The changed-files list had the same broken range, so .env slipped by."""
+    upstream, clone = _build_repo(tmp_path)
+    _git(clone, "checkout", "-q", "-b", "feature/env", "main")
+    (clone / ".env").write_text("DB_PASSWORD=hunter2\n")
+    _git(clone, "add", "-f", ".env")
+    _git(clone, "commit", "-q", "-m", "add env")
+    sha = _git(clone, "rev-parse", "HEAD").strip()
+
+    out = _scan_output(_run_hook(clone, upstream, "refs/heads/feature/env", sha, ZERO))
+
+    assert ".env file added/modified" in out
+
+
+def test_new_branch_push_scans_every_commit_not_just_the_tip(tmp_path):
+    """A secret in an earlier commit of the branch is still caught."""
+    upstream, clone = _build_repo(tmp_path)
+    _git(clone, "checkout", "-q", "-b", "feature/multi", "main")
+    (clone / "early.py").write_text(_assignment("AWS_KEY", FAKE_AWS_KEY))
+    _git(clone, "add", "early.py")
+    _git(clone, "commit", "-q", "-m", "first commit with the key")
+    (clone / "later.py").write_text("harmless = True\n")
+    _git(clone, "add", "later.py")
+    _git(clone, "commit", "-q", "-m", "second, innocent commit")
+    sha = _git(clone, "rev-parse", "HEAD").strip()
+
+    out = _scan_output(_run_hook(clone, upstream, "refs/heads/feature/multi", sha, ZERO))
+
+    assert "AWS access key ID" in out
+
+
+def test_existing_branch_push_still_scans_secrets(tmp_path):
+    """The two-dot range path already worked; keep it working."""
+    upstream, clone = _build_repo(tmp_path)
+    base = _git(clone, "rev-parse", "origin/main").strip()
+    _git(clone, "checkout", "-q", "main")
+    (clone / "leak.py").write_text(_assignment("AWS_KEY", FAKE_AWS_KEY))
+    _git(clone, "add", "leak.py")
+    _git(clone, "commit", "-q", "-m", "add a key")
+    sha = _git(clone, "rev-parse", "HEAD").strip()
+
+    out = _scan_output(_run_hook(clone, upstream, "refs/heads/main", sha, base))
+
+    assert "sensitive-content scan clean" not in out
+    assert "AWS access key ID" in out
+
+
+def test_clean_new_branch_push_does_not_report_untouched_upstream_lines(tmp_path):
+    """A clean branch scans clean; upstream's URL line is not attributed to it.
+
+    Note: this guards the false-positive direction reported in #418, but it is
+    not a strict reproduction of it -- the observed noise depended on the real
+    repository's ref topology (many divergent fork branches) and does not
+    reproduce minimally. It would have passed before the fix as well.
+    """
+    upstream, clone = _build_repo(tmp_path)
+    _git(clone, "checkout", "-q", "-b", "feature/clean", "main")
+    (clone / "helper.py").write_text("def add(a, b):\n    return a + b\n")
+    _git(clone, "add", "helper.py")
+    _git(clone, "commit", "-q", "-m", "add helper")
+    sha = _git(clone, "rev-parse", "HEAD").strip()
+
+    out = _scan_output(_run_hook(clone, upstream, "refs/heads/feature/clean", sha, ZERO))
+
+    assert "hooks.example.com" not in out
+    assert "sensitive-content scan clean" in out
+
+
+def test_merge_only_push_is_not_blocked_and_is_still_scanned(tmp_path):
+    """A push whose only new commit is a merge must not trip the guard.
+
+    `git log -p` omits merge diffs by default, so a naive "empty patch means
+    the range is broken" check would reject the merge commits this project
+    pushes routinely. The merge's content must also still be scanned.
+    """
+    upstream, clone = _build_repo(tmp_path)
+    # A side branch that is already on the remote, carrying a secret.
+    _git(clone, "checkout", "-q", "-b", "side", "main")
+    (clone / "leak.py").write_text(_assignment("AWS_KEY", FAKE_AWS_KEY))
+    _git(clone, "add", "leak.py")
+    _git(clone, "commit", "-q", "-m", "side work")
+    _git(clone, "push", "-q", "origin", "side")
+
+    # Locally merge it into main; only the merge commit is new to the remote.
+    _git(clone, "checkout", "-q", "main")
+    _git(clone, "merge", "-q", "--no-ff", "side", "-m", "Merge side")
+    sha = _git(clone, "rev-parse", "HEAD").strip()
+    base = _git(clone, "rev-parse", "origin/main").strip()
+
+    out = _scan_output(_run_hook(clone, upstream, "refs/heads/main", sha, base))
+
+    assert "could not compute a diff" not in out, \
+        "the fail-closed guard must not fire on a legitimate merge-only push"
+    assert "AWS access key ID" in out, \
+        "content brought in by a merge must still be scanned"
+
+
+def test_empty_commit_push_is_not_blocked(tmp_path):
+    """`git commit --allow-empty` has no patch and must still be pushable.
+
+    The sanity check keys on files touched rather than on the commit count for
+    exactly this reason.
+    """
+    upstream, clone = _build_repo(tmp_path)
+    base = _git(clone, "rev-parse", "origin/main").strip()
+    _git(clone, "checkout", "-q", "main")
+    _git(clone, "commit", "-q", "--allow-empty", "-m", "empty commit to retrigger CI")
+    sha = _git(clone, "rev-parse", "HEAD").strip()
+
+    out = _scan_output(_run_hook(clone, upstream, "refs/heads/main", sha, base))
+
+    assert "no diff could be computed" not in out
+    assert "sensitive-content scan clean" in out
+
+
+def test_deletion_push_is_skipped(tmp_path):
+    """Deleting a remote branch has nothing to scan."""
+    upstream, clone = _build_repo(tmp_path)
+
+    out = _scan_output(_run_hook(clone, upstream, "refs/heads/gone", ZERO, ZERO))
+
+    assert "sensitive-content scan clean" in out


### PR DESCRIPTION
Fixes #418.

## Why

`.githooks/pre-push` computed its scan range with `git rev-list` syntax and then passed those same arguments to `git diff`. For a new branch that range is `<sha> --not --remotes`, which `git diff` does not understand as range exclusion — it treats the extra revisions as further sides to compare and emits a *combined* diff. Combined-diff semantics are "how this differs from each parent", which is not "what this push adds": it drops real additions and attributes untouched upstream lines to the push. The `2>/dev/null` on the call kept the mismatch quiet.

The result was a false negative in a secret scanner. On a new-branch push carrying an AWS access key ID and a plaintext password, the hook printed:

```
pre-push: sensitive-content scan clean.
```

A scanner that clears an obvious key is worse than no scanner, because it is trusted. #418 has a self-contained reproduction using the unmodified hook.

The noisier symptom is the same root cause: on PR #416 the hook blocked a push over an `api.pushover.net` URL that was already on `origin/main` and that the branch never touched, reported with a mangled `+ ++ +` gutter (the combined-diff column layout) and a meaningless line number. That trains people to reach for `--no-verify`, which skips the entire gate — ruff, bandit, OpenAPI, and the test suite included.

## What changed

`git log -p` accepts rev-list arguments natively and emits per-commit patches, which is the intended meaning, so both `git diff` calls become `git log`. Merge commits are skipped by default, which is right here: they carry nothing the individual commits in the range lack, and those commits are themselves in range.

Also added a backstop that fails closed when files were touched but no patch text came back at all, instead of reporting a clean scan. Its reach is deliberately documented as limited — the bad range still emitted combined-diff *headers*, so this check would **not** have caught the original bug. I verified that rather than assuming it. The tests are the real guard. It keys on files touched rather than on the commit count so an empty commit (`git commit --allow-empty`) stays pushable, which I confirmed was otherwise a spurious block I'd introduced.

## Tests

`tests/unit/test_prepush_hook.py` — the first coverage this hook has had. 9 tests drive the real script through its stdin protocol against throwaway repositories: new-branch and existing-branch pushes, a secret in a non-tip commit, `.env` additions, merge-only and empty-commit pushes, and branch deletion. Restoring the `git diff` call fails three of them.

They assert on scan *output* rather than exit status, because the hook's later ruff/bandit/pytest gate exits non-zero in a throwaway repo for unrelated reasons — exit status alone can't distinguish "the scanner blocked this" from "the gate failed".

Two things worth flagging, both found by running this rather than reasoning about it:

**The tests scrub `GIT_*` from the environment of every git call.** Without that they fail when run from inside the hook, which is exactly where the gate runs them: git exports `GIT_DIR` and `GIT_INDEX_FILE` to hooks, and inherited they point each fixture command at the real repository instead of the throwaway one. This is not theoretical — a trial run renamed my checked-out branch to `main`, clobbered the local `main` ref, and committed fixture state onto it. I repaired it from the reflog and then verified the scrubbed version leaves the host repo byte-identical (branch, HEAD, and `main` all unchanged) when run with `GIT_DIR` set.

**The fixtures assemble their secret-shaped strings at runtime** and render assignments through a helper, so the file contains no literal that this hook — or GitHub push protection — would flag, and no allowlist entry is needed. The fixed hook caught an earlier version of this file, which is a decent sign it works.

## Verification

Pushed with the fixed hook active and the full gate running: `pre-push: all checks passed`, 1523 passed / 2 skipped / 39 xfailed, no bypass. Compare with #416, which had to be pushed with `--no-verify` because of the false positive.

Note the hook is also verified under a real `git push`, not just standalone — the two differ, and that mattered. `core.hooksPath` here is an **absolute** path (`/Users/.../hashview/.githooks`), so pushes from a git worktree run the *main checkout's* hook, not the worktree's. My first attempts were silently exercising the old hook. Instrumenting a real push through the fixed one confirmed it sees the full diff (275 added lines, all three finding categories reported). That footgun is now addressed in the second commit, which documents next to the enable instruction that the value must stay relative. Git resolves a relative `hooksPath` against the top level of whichever working tree you run git from, so each worktree correctly uses its own `.githooks/` — verified from a repo root, a subdirectory, and a worktree. I also corrected my own clone's config, which was absolute; this PR's final push ran with no `-c core.hooksPath` override and correctly used the worktree's own hook (`pre-push: all checks passed`, 1523 passed).

Note this only fixes the documentation and my clone — `core.hooksPath` is per-clone local config, so anyone whose clone already has an absolute value needs to re-run `git config core.hooksPath .githooks` themselves. Checking with `git config core.hooksPath` is called out in the header.

No CHANGELOG entry: `.githooks/` changes are developer tooling and aren't changelogged here, matching the existing `chore(githooks):` commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

