### PR TITLE
Add job-creation performance e2e suite with strict xfails for #422

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ Notable changes will be documented here
 - Per-hashfile `--hex-salt` option for salted hash types
 - New "Website Keywords" dynamic wordlist that crawls a per-job URL to build a targeted wordlist
 
+**Testing**
+- Job-creation performance e2e suite (`tests/e2e/test_job_creation_perf.py`) with a tunable volume seeder (`tests/seed_perf_db.py`), covering latency budgets for each wizard step plus strict-xfail scaling guards for the four endpoints in issue #422 whose cost grows with table size rather than page size
+
 ### Changed
 - Reintroduced distributed chunking: eligible mask/wordlist tasks are split into per-agent chunks sized from each agent's benchmark, and a chunked task now appears as a single attack in the job editor
 - Wordlists are stored gzip-compressed at rest; agents sync and verify the compressed files

--- a/TESTING.md
+++ b/TESTING.md
@@ -135,6 +135,41 @@ E2E notes:
   under test lives in docker so the runner doesn't import any `hashview.*`
   modules.
 
+### Job-creation performance suite
+
+`tests/e2e/test_job_creation_perf.py` measures the job wizard's latency and
+response sizes. It needs volume in the database to mean anything, so it skips
+unless `tests/seed_perf_db.py` has been run:
+
+```
+docker compose cp tests/seed_perf_db.py app:/tmp/seed_perf_db.py
+docker compose exec -T -e PYTHONPATH=/ -e HASHVIEW_E2E_CUSTOMER_ID=1 \
+  -w / app python /tmp/seed_perf_db.py
+./.venv/bin/python -m pytest tests/e2e/test_job_creation_perf.py -m e2e -s
+```
+
+The seeder is idempotent and its volumes are tunable:
+`HASHVIEW_PERF_HASHFILES` (default 30), `HASHVIEW_PERF_HASHES_PER_HASHFILE`
+(2000), `HASHVIEW_PERF_BIG_HASHFILE_HASHES` (50000),
+`HASHVIEW_PERF_BIG_CRACKED_RATIO` (0.6), `HASHVIEW_PERF_TASKS` (400). Re-running
+with a larger value tops the fixture up rather than duplicating it. Everything it
+creates is named `perf-hashfile-*`, `perf-big-hashfile`, or `perf-task-*`.
+
+The suite has two kinds of test:
+
+- **Latency budgets** (`test_*_is_fast`) — wall-clock medians against a budget,
+  each overridable with `HASHVIEW_PERF_BUDGET_<NAME>` (e.g.
+  `HASHVIEW_PERF_BUDGET_TASK_LIBRARY=4000`) for slower hardware. These pass at
+  the default fixture volume.
+- **Scaling guards** — payload sizes and per-row costs, which are
+  machine-independent. Four are strict `xfail`s against **issue #422**: the
+  hashfile picker's per-hashfile aggregate query, the task library and job
+  summary rendering per-row output for the entire `tasks` table, and the
+  unpaginated cracked-hash view. Drop a marker when its defect is fixed —
+  strict mode makes the suite fail on XPASS, so it will tell you.
+
+Run `-s` to get the timing table; each line is prefixed `[perf]`.
+
 ### Using the helper script
 
 ```

--- a/TESTING.md
+++ b/TESTING.md
@@ -145,8 +145,13 @@ unless `tests/seed_perf_db.py` has been run:
 docker compose cp tests/seed_perf_db.py app:/tmp/seed_perf_db.py
 docker compose exec -T -e PYTHONPATH=/ -e HASHVIEW_E2E_CUSTOMER_ID=1 \
   -w / app python /tmp/seed_perf_db.py
-./.venv/bin/python -m pytest tests/e2e/test_job_creation_perf.py -m e2e -s
+./.venv/bin/python -m pytest -m perf -s
 ```
+
+These tests carry the `perf` marker rather than `e2e`, so `pytest -m e2e` (what
+CI runs) does not collect them. That is deliberate: CI runs e2e under
+`HASHVIEW_E2E_STRICT` with a cap on skipped results, and since it never seeds the
+perf fixture these ten tests would skip there and trip the cap.
 
 The seeder is idempotent and its volumes are tunable:
 `HASHVIEW_PERF_HASHFILES` (default 30), `HASHVIEW_PERF_HASHES_PER_HASHFILE`

--- a/pytest.ini
+++ b/pytest.ini
@@ -6,6 +6,7 @@ markers =
     agent_sim: agent simulator tests
     security: security-focused tests
     e2e_crack: dockerized multi-agent real-crack e2e test (opt-in; needs compose + rockyou)
+    perf: job-creation performance tests (opt-in; needs a live host seeded by tests/seed_perf_db.py)
     mysql: integration tests that run against a real MySQL/MariaDB backend (needs HASHVIEW_TEST_DATABASE_URI)
     migration: end-to-end main->dev database migration test (needs docker + built images)
 filterwarnings =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,7 +97,12 @@ def live_server():
 
 @pytest.fixture(autouse=True)
 def ensure_setup(page, live_server, request):
-    if not request.node.get_closest_marker("e2e"):
+    # The perf suite (tests/e2e/test_job_creation_perf.py) is marked `perf`
+    # rather than `e2e` so it stays out of the default e2e run, but it drives the
+    # same live host and needs the same first-run setup handled.
+    if not request.node.get_closest_marker("e2e") and not request.node.get_closest_marker(
+        "perf"
+    ):
         return
     if request.node.get_closest_marker("agent_sim"):
         return

--- a/tests/e2e/test_job_creation_perf.py
+++ b/tests/e2e/test_job_creation_perf.py
@@ -8,6 +8,11 @@ They only mean something against a database with volume in it. Run
 ``perf_fixture`` fixture skips the whole module when that data is absent, so an
 empty dev stack reports "skipped", never a bogus pass.
 
+Marked ``perf``, not ``e2e``, so ``pytest -m e2e`` does not collect them. CI runs
+the e2e suite under ``HASHVIEW_E2E_STRICT`` with a cap on skipped results, and
+these would skip there (CI never seeds the perf fixture) and trip that cap. Run
+them with ``pytest -m perf``.
+
 Two kinds of assertion here, because they fail for different reasons:
 
 * **Latency budgets** — wall-clock against localhost Docker, deliberately loose.
@@ -150,7 +155,7 @@ def perf_fixture(page, live_server, login, perf_env, fixture_counts):
     return {**perf_env, "perf_tasks": perf_tasks, "perf_hashfiles": perf_hashfiles}
 
 
-@pytest.mark.e2e
+@pytest.mark.perf
 def test_jobs_add_step_is_fast(page, live_server, perf_fixture):
     """Step 1 of the wizard is a name + customer form; it should be near-free.
 
@@ -167,7 +172,7 @@ def test_jobs_add_step_is_fast(page, live_server, perf_fixture):
     )
 
 
-@pytest.mark.e2e
+@pytest.mark.perf
 def test_hashfile_picker_does_not_scale_with_hashfile_count(
     page, live_server, perf_fixture
 ):
@@ -196,7 +201,7 @@ def test_hashfile_picker_does_not_scale_with_hashfile_count(
     )
 
 
-@pytest.mark.e2e
+@pytest.mark.perf
 def test_task_library_does_not_scale_with_task_table(page, live_server, perf_fixture):
     """The task-library step must not render the entire tasks table.
 
@@ -224,7 +229,7 @@ def test_task_library_does_not_scale_with_task_table(page, live_server, perf_fix
     )
 
 
-@pytest.mark.e2e
+@pytest.mark.perf
 def test_cracked_hashes_view_is_bounded(page, live_server, perf_fixture):
     """Viewing a hashfile's cracked hashes must not load the whole result set.
 
@@ -264,7 +269,7 @@ def test_cracked_hashes_view_is_bounded(page, live_server, perf_fixture):
     )
 
 
-@pytest.mark.e2e
+@pytest.mark.perf
 def test_assigning_a_task_is_fast(page, live_server, login, perf_fixture):
     """Adding one task to a job should cost one insert, not a full re-render.
 
@@ -322,7 +327,7 @@ def test_assigning_a_task_is_fast(page, live_server, login, perf_fixture):
     )
 
 
-@pytest.mark.e2e
+@pytest.mark.perf
 def test_job_summary_is_fast(page, live_server, perf_fixture):
     """The final review step aggregates the hashfile and resolves task names."""
     job_id = perf_fixture["job_id"]
@@ -366,7 +371,7 @@ PAYLOAD_BUDGET_KB = {
 MAX_MS_PER_HASHFILE = 1.0
 
 
-@pytest.mark.e2e
+@pytest.mark.perf
 @pytest.mark.xfail(
     strict=True,
     reason="Issue #422 (3): task library renders one form + CSRF token per row "
@@ -393,7 +398,7 @@ def test_task_library_payload_does_not_scale_with_task_table(
     )
 
 
-@pytest.mark.e2e
+@pytest.mark.perf
 @pytest.mark.xfail(
     strict=True,
     reason="Issue #422 (1): cracked-hash view loads and renders every cracked "
@@ -427,7 +432,7 @@ def test_cracked_hashes_payload_is_bounded(page, live_server, perf_fixture):
     )
 
 
-@pytest.mark.e2e
+@pytest.mark.perf
 @pytest.mark.xfail(
     strict=True,
     reason="Issue #422 (4): job summary resolves each assigned task's name "
@@ -453,7 +458,7 @@ def test_summary_payload_does_not_scale_with_task_table(
     )
 
 
-@pytest.mark.e2e
+@pytest.mark.perf
 @pytest.mark.xfail(
     strict=True,
     reason="Issue #422 (2): hashfile picker issues one cracked/total aggregate "

--- a/tests/e2e/test_job_creation_perf.py
+++ b/tests/e2e/test_job_creation_perf.py
@@ -1,0 +1,491 @@
+"""Performance e2e tests for the job-creation wizard.
+
+These are latency and payload regression guards, not correctness tests — the
+functional walk of the wizard lives in ``test_job_creation.py``.
+
+They only mean something against a database with volume in it. Run
+``tests/seed_perf_db.py`` inside the app container first (see TESTING.md); the
+``perf_fixture`` fixture skips the whole module when that data is absent, so an
+empty dev stack reports "skipped", never a bogus pass.
+
+Two kinds of assertion here, because they fail for different reasons:
+
+* **Latency budgets** — wall-clock against localhost Docker, deliberately loose.
+  They catch an order-of-magnitude regression, not a 50ms drift. Override any of
+  them with the matching ``HASHVIEW_PERF_BUDGET_*`` env var on slower hardware.
+* **Payload budgets** — response body size. These are machine-independent and so
+  are the stronger guard: a page whose HTML grows with a whole table rather than
+  with a page of results will blow a size budget identically on every host.
+
+The payload tests carry strict ``xfail`` markers against **issue #422**: they
+document scaling defects that exist today, and will fail loudly (XPASS) the
+moment one is fixed, which is the signal to drop that marker. The numbering in
+each ``reason`` matches the numbered sections of that issue.
+"""
+import os
+import re
+import statistics
+import time
+
+import pytest
+from playwright.sync_api import expect
+
+# Row counts below these mean the perf fixture was never seeded, so the numbers
+# would measure an empty database and prove nothing.
+MIN_TASKS = 100
+MIN_HASHFILES = 10
+
+# Default budgets in milliseconds. Each is the median of REPEATS samples.
+DEFAULT_BUDGETS = {
+    "jobs_add": 1000,
+    "hashfile_picker": 2000,
+    # Deliberately loose: this endpoint already measures ~2.9s at the default
+    # fixture volume. The defect is pinned precisely by the payload test below,
+    # so a tight latency budget here would only add flake.
+    "cracked_hashes": 6000,
+    "task_library": 2000,
+    "assign_task": 3000,
+    "summary": 2000,
+}
+
+# Median of several samples, so one unlucky GC pause or cold page cache doesn't
+# fail the run. The first sample is discarded as a warmup.
+REPEATS = 5
+
+
+def budget(name: str) -> int:
+    """Budget in ms for ``name``, overridable via HASHVIEW_PERF_BUDGET_<NAME>."""
+    override = os.getenv(f"HASHVIEW_PERF_BUDGET_{name.upper()}")
+    if override:
+        return int(override)
+    return DEFAULT_BUDGETS[name]
+
+
+def time_get(page, url: str, repeats: int = REPEATS):
+    """GET ``url`` ``repeats`` times; return (median_ms, samples, last_response).
+
+    Uses ``page.request`` rather than ``page.goto`` so the measurement is the
+    server's response time, not the browser's render of it. The APIRequestContext
+    shares the page's cookie jar, so the session survives.
+    """
+    samples = []
+    response = None
+    # repeats + 1: the first call is a warmup (cold SQLAlchemy pool, cold InnoDB
+    # buffer pool) and is discarded.
+    for _ in range(repeats + 1):
+        start = time.perf_counter()
+        response = page.request.get(url)
+        body = response.body()
+        elapsed_ms = (time.perf_counter() - start) * 1000
+        assert response.ok, f"GET {url} returned {response.status}"
+        samples.append(elapsed_ms)
+    samples = samples[1:]
+    return statistics.median(samples), samples, (response, body)
+
+
+def report(label: str, median_ms: float, samples, budget_ms: int, extra: str = ""):
+    """Print a one-line result so `pytest -s` output is a readable timing table."""
+    spread = "/".join(f"{s:.0f}" for s in samples)
+    status = "OK " if median_ms <= budget_ms else "SLOW"
+    print(
+        f"[perf] {status} {label:<24} median={median_ms:7.1f}ms "
+        f"budget={budget_ms:5d}ms samples=[{spread}] {extra}"
+    )
+
+
+@pytest.fixture(scope="module")
+def perf_env():
+    job_id = os.getenv("HASHVIEW_E2E_JOB_ID")
+    customer_id = os.getenv("HASHVIEW_E2E_CUSTOMER_ID")
+    if not job_id or not customer_id:
+        pytest.skip("Set HASHVIEW_E2E_JOB_ID and HASHVIEW_E2E_CUSTOMER_ID.")
+    return {"job_id": job_id, "customer_id": customer_id}
+
+
+@pytest.fixture(scope="module")
+def fixture_counts(playwright, perf_env):
+    """Row counts for the seeded perf data, read via the /v1 API.
+
+    The API is used rather than the HTML list pages because those paginate (20
+    rows), which would undercount the fixture and skip the whole module. The
+    e2e suite has no database access, so the API is the only unpaginated view.
+    Authenticates with the api_key as the ``uuid`` cookie, in its own request
+    context so the browser session is untouched.
+    """
+    base_url = os.getenv("HASHVIEW_E2E_BASE_URL", "").rstrip("/")
+    api_key = os.getenv("HASHVIEW_E2E_API_KEY")
+    if not api_key:
+        pytest.skip("Set HASHVIEW_E2E_API_KEY to count the perf fixture.")
+
+    api = playwright.request.new_context(
+        base_url=base_url, extra_http_headers={"Cookie": f"uuid={api_key}"}
+    )
+    try:
+        tasks = api.get("/v1/tasks")
+        assert tasks.ok, f"GET /v1/tasks returned {tasks.status}"
+        perf_tasks = len(re.findall(r"perf-task-\d+", tasks.text()))
+
+        hashfiles = api.get(f"/v1/customers/{perf_env['customer_id']}/hashfiles")
+        assert hashfiles.ok, f"customer hashfiles returned {hashfiles.status}"
+        perf_hashfiles = len(re.findall(r"perf-hashfile-\d+", hashfiles.text()))
+    finally:
+        api.dispose()
+
+    return {"perf_tasks": perf_tasks, "perf_hashfiles": perf_hashfiles}
+
+
+@pytest.fixture()
+def perf_fixture(page, live_server, login, perf_env, fixture_counts):
+    """Log in and confirm the volume fixture is present, else skip."""
+    login()
+    perf_tasks = fixture_counts["perf_tasks"]
+    perf_hashfiles = fixture_counts["perf_hashfiles"]
+
+    if perf_tasks < MIN_TASKS or perf_hashfiles < MIN_HASHFILES:
+        pytest.skip(
+            "Perf fixture not seeded (saw "
+            f"{perf_tasks} perf tasks, {perf_hashfiles} perf hashfiles). "
+            "Run tests/seed_perf_db.py inside the app container first."
+        )
+    return {**perf_env, "perf_tasks": perf_tasks, "perf_hashfiles": perf_hashfiles}
+
+
+@pytest.mark.e2e
+def test_jobs_add_step_is_fast(page, live_server, perf_fixture):
+    """Step 1 of the wizard is a name + customer form; it should be near-free.
+
+    This doubles as the floor for the other measurements: whatever this costs is
+    the per-request overhead (nav counts, session, template base) that every
+    other step also pays.
+    """
+    median, samples, _ = time_get(page, f"{live_server}/jobs/add")
+    report("GET /jobs/add", median, samples, budget("jobs_add"))
+    assert median <= budget("jobs_add"), (
+        f"GET /jobs/add took {median:.0f}ms (budget {budget('jobs_add')}ms). "
+        "Step 1 renders a two-field form; anything slow here is per-request "
+        "overhead paid by every other wizard step too."
+    )
+
+
+@pytest.mark.e2e
+def test_hashfile_picker_does_not_scale_with_hashfile_count(
+    page, live_server, perf_fixture
+):
+    """The 'Assign Hashes' step must not aggregate every hashfile on every load.
+
+    The picker lists the customer's hashfiles with a cracked/total count each. If
+    those counts are computed one query per hashfile, this page's cost is
+    (hashfiles x hashes-per-hashfile) and it degrades as the customer accumulates
+    files — which is exactly the growth pattern real engagements have.
+    """
+    job_id = perf_fixture["job_id"]
+    url = f"{live_server}/jobs/{job_id}/assigned_hashfile/"
+    median, samples, (_, body) = time_get(page, url)
+    report(
+        "GET assigned_hashfile/",
+        median,
+        samples,
+        budget("hashfile_picker"),
+        extra=f"hashfiles={perf_fixture['perf_hashfiles']} body={len(body) // 1024}KB",
+    )
+    assert median <= budget("hashfile_picker"), (
+        f"Hashfile picker took {median:.0f}ms with "
+        f"{perf_fixture['perf_hashfiles']} hashfiles "
+        f"(budget {budget('hashfile_picker')}ms). Suspect a per-hashfile "
+        "aggregate query rather than one grouped query."
+    )
+
+
+@pytest.mark.e2e
+def test_task_library_does_not_scale_with_task_table(page, live_server, perf_fixture):
+    """The task-library step must not render the entire tasks table.
+
+    The 'Add Task' drawer is collapsed on load, but the server pays for it
+    regardless: if it emits one form per task in the whole table, both the
+    response size and the render time grow with the task library rather than
+    with the job. This is the page the wizard returns to after every single task
+    the user adds, so the cost is paid repeatedly.
+    """
+    job_id = perf_fixture["job_id"]
+    url = f"{live_server}/jobs/{job_id}/tasks"
+    median, samples, (_, body) = time_get(page, url)
+    kb = len(body) / 1024
+    report(
+        "GET jobs/<id>/tasks",
+        median,
+        samples,
+        budget("task_library"),
+        extra=f"tasks={perf_fixture['perf_tasks']} body={kb:.0f}KB",
+    )
+    assert median <= budget("task_library"), (
+        f"Task library took {median:.0f}ms with {perf_fixture['perf_tasks']} "
+        f"tasks (budget {budget('task_library')}ms). The page is re-rendered "
+        "after every task the user adds, so this cost is paid N times per job."
+    )
+
+
+@pytest.mark.e2e
+def test_cracked_hashes_view_is_bounded(page, live_server, perf_fixture):
+    """Viewing a hashfile's cracked hashes must not load the whole result set.
+
+    Opened from the hashfile picker. With no pagination, a hashfile with tens of
+    thousands of already-cracked hashes renders one table row per hash.
+    """
+    job_id = perf_fixture["job_id"]
+    live = f"{live_server}/jobs/{job_id}/assigned_hashfile/"
+    picker = page.request.get(live)
+    assert picker.ok, f"GET {live} returned {picker.status}"
+
+    # Find the big seeded hashfile's id from the picker markup so the test does
+    # not hardcode an id the seeder happened to assign.
+    match = re.search(
+        r"name=['\"]hashfile_id['\"][^>]*value=['\"](\d+)['\"](?=(?:(?!<tr)[\s\S])*"
+        r"perf-big-hashfile)",
+        picker.text(),
+    )
+    if not match:
+        pytest.skip("perf-big-hashfile not present in the picker; seed it first.")
+    big_id = match.group(1)
+
+    url = f"{live_server}/jobs/{job_id}/assigned_hashfile/{big_id}"
+    median, samples, (_, body) = time_get(page, url, repeats=3)
+    kb = len(body) / 1024
+    report(
+        "GET cracked hashes",
+        median,
+        samples,
+        budget("cracked_hashes"),
+        extra=f"hashfile={big_id} body={kb:.0f}KB",
+    )
+    assert median <= budget("cracked_hashes"), (
+        f"Cracked-hash view took {median:.0f}ms and returned {kb:.0f}KB "
+        f"(budget {budget('cracked_hashes')}ms). Suspect an unpaginated load of "
+        "every cracked hash in the file."
+    )
+
+
+@pytest.mark.e2e
+def test_assigning_a_task_is_fast(page, live_server, login, perf_fixture):
+    """Adding one task to a job should cost one insert, not a full re-render.
+
+    Measures the whole user-visible action: the POST plus the redirect back to
+    the task library. A user building a 10-task job pays this ten times, so a
+    slow task library compounds here.
+    """
+    login()
+    job_id = perf_fixture["job_id"]
+
+    page.goto(f"{live_server}/jobs/{job_id}/tasks", wait_until="domcontentloaded")
+    expect(page.get_by_role("heading", name="Task Library")).to_be_visible()
+
+    # Pick a task that is not already in this job's queue. Assigning an
+    # already-queued task is allowed (the queue can hold duplicates), but then
+    # the post-assignment assertion below matches two cards and fails on strict
+    # mode rather than on latency.
+    queued_ids = set(
+        page.locator("#task-queue .tq-item").evaluate_all(
+            "els => els.map(e => e.dataset.taskId)"
+        )
+    )
+    assignable = page.locator("form[action*='/assign_task/']").evaluate_all(
+        "els => els.map(e => e.getAttribute('action'))"
+    )
+    task_id = None
+    for action in assignable:
+        candidate = action.rsplit("/", 1)[-1]
+        if candidate.isdigit() and candidate not in queued_ids:
+            task_id = candidate
+            break
+    if task_id is None:
+        pytest.skip("No unassigned task available in the library.")
+
+    assign_action = f"/jobs/{job_id}/assign_task/{task_id}"
+    assign_form = page.locator(f"form[action='{assign_action}']")
+
+    # The form lives in a collapsed <details>; open it before submitting.
+    page.locator(f"details:has(form[action='{assign_action}'])").evaluate(
+        "el => { el.open = true; }"
+    )
+
+    start = time.perf_counter()
+    assign_form.locator("button[type=submit]").first.click()
+    page.wait_for_load_state("domcontentloaded")
+    elapsed_ms = (time.perf_counter() - start) * 1000
+
+    report("POST assign_task", elapsed_ms, [elapsed_ms], budget("assign_task"))
+    queued = page.locator(f"#task-queue .tq-item[data-task-id='{task_id}']")
+    expect(queued).to_be_visible()
+    assert elapsed_ms <= budget("assign_task"), (
+        f"Assigning one task took {elapsed_ms:.0f}ms "
+        f"(budget {budget('assign_task')}ms). The POST itself is one insert; the "
+        "cost is the redirect re-rendering the whole task library."
+    )
+
+
+@pytest.mark.e2e
+def test_job_summary_is_fast(page, live_server, perf_fixture):
+    """The final review step aggregates the hashfile and resolves task names."""
+    job_id = perf_fixture["job_id"]
+    url = f"{live_server}/jobs/{job_id}/summary"
+    median, samples, (_, body) = time_get(page, url)
+    report(
+        "GET jobs/<id>/summary",
+        median,
+        samples,
+        budget("summary"),
+        extra=f"body={len(body) // 1024}KB",
+    )
+    assert median <= budget("summary"), (
+        f"Job summary took {median:.0f}ms (budget {budget('summary')}ms)."
+    )
+
+
+# --------------------------------------------------------------------------
+# Scaling tests.
+#
+# The latency tests above pass at the fixture's current volume — the wizard is
+# not slow on a small install. What these pin is the *shape* of the cost curve:
+# each of these endpoints does work proportional to a whole table rather than to
+# what the page shows, so the latency budgets above only hold until a customer
+# accumulates enough data. Payload size is used as the proxy because it is
+# deterministic and identical on every machine, unlike wall-clock.
+# --------------------------------------------------------------------------
+
+# Response-size ceilings in KB. Each is set to roughly 2x what the page needs at
+# the fixture's volume, so passing means "renders a page of results", not
+# "renders the table".
+PAYLOAD_BUDGET_KB = {
+    "task_library": 400,
+    "cracked_hashes": 2048,
+    "summary": 300,
+}
+
+# Per-hashfile latency cost on the picker, above the per-request floor. One
+# grouped aggregate query would make this ~0; a per-hashfile query makes it
+# grow with the customer's file count.
+MAX_MS_PER_HASHFILE = 1.0
+
+
+@pytest.mark.e2e
+@pytest.mark.xfail(
+    strict=True,
+    reason="Issue #422 (3): task library renders one form + CSRF token per row "
+    "of the whole tasks table, inside a drawer that is collapsed on load. "
+    "Payload grows with the task library instead of with the job.",
+)
+def test_task_library_payload_does_not_scale_with_task_table(
+    page, live_server, perf_fixture
+):
+    job_id = perf_fixture["job_id"]
+    response = page.request.get(f"{live_server}/jobs/{job_id}/tasks")
+    assert response.ok, f"GET tasks returned {response.status}"
+    kb = len(response.body()) / 1024
+    per_task = kb / max(perf_fixture["perf_tasks"], 1)
+    print(
+        f"[perf] payload task_library {kb:.0f}KB "
+        f"({per_task:.2f}KB/task, {perf_fixture['perf_tasks']} tasks) "
+        f"budget={PAYLOAD_BUDGET_KB['task_library']}KB"
+    )
+    assert kb <= PAYLOAD_BUDGET_KB["task_library"], (
+        f"Task library returned {kb:.0f}KB for {perf_fixture['perf_tasks']} "
+        f"tasks ({per_task:.2f}KB per task). This page is re-rendered after "
+        "every task the user adds to a job."
+    )
+
+
+@pytest.mark.e2e
+@pytest.mark.xfail(
+    strict=True,
+    reason="Issue #422 (1): cracked-hash view loads and renders every cracked "
+    "hash in the hashfile with no pagination.",
+)
+def test_cracked_hashes_payload_is_bounded(page, live_server, perf_fixture):
+    job_id = perf_fixture["job_id"]
+    picker = page.request.get(f"{live_server}/jobs/{job_id}/assigned_hashfile/")
+    assert picker.ok, f"picker returned {picker.status}"
+    match = re.search(
+        r"name=['\"]hashfile_id['\"][^>]*value=['\"](\d+)['\"](?=(?:(?!<tr)[\s\S])*"
+        r"perf-big-hashfile)",
+        picker.text(),
+    )
+    if not match:
+        pytest.skip("perf-big-hashfile not present in the picker; seed it first.")
+
+    response = page.request.get(
+        f"{live_server}/jobs/{job_id}/assigned_hashfile/{match.group(1)}"
+    )
+    assert response.ok, f"cracked view returned {response.status}"
+    kb = len(response.body()) / 1024
+    print(
+        f"[perf] payload cracked_hashes {kb:.0f}KB "
+        f"budget={PAYLOAD_BUDGET_KB['cracked_hashes']}KB"
+    )
+    assert kb <= PAYLOAD_BUDGET_KB["cracked_hashes"], (
+        f"Cracked-hash view returned {kb:.0f}KB. It renders one table row per "
+        "cracked hash with no pagination, so the payload is a function of how "
+        "well the crack went."
+    )
+
+
+@pytest.mark.e2e
+@pytest.mark.xfail(
+    strict=True,
+    reason="Issue #422 (4): job summary resolves each assigned task's name "
+    "with a nested template loop over the entire tasks table. Non-matching "
+    "iterations still emit their indentation, so the payload is mostly "
+    "whitespace and grows as assigned x total_tasks.",
+)
+def test_summary_payload_does_not_scale_with_task_table(
+    page, live_server, perf_fixture
+):
+    job_id = perf_fixture["job_id"]
+    response = page.request.get(f"{live_server}/jobs/{job_id}/summary")
+    assert response.ok, f"summary returned {response.status}"
+    kb = len(response.body()) / 1024
+    print(
+        f"[perf] payload summary {kb:.0f}KB "
+        f"({perf_fixture['perf_tasks']} tasks) "
+        f"budget={PAYLOAD_BUDGET_KB['summary']}KB"
+    )
+    assert kb <= PAYLOAD_BUDGET_KB["summary"], (
+        f"Job summary returned {kb:.0f}KB with "
+        f"{perf_fixture['perf_tasks']} tasks in the library."
+    )
+
+
+@pytest.mark.e2e
+@pytest.mark.xfail(
+    strict=True,
+    reason="Issue #422 (2): hashfile picker issues one cracked/total aggregate "
+    "query per hashfile, so its latency grows linearly with the customer's "
+    "file count.",
+)
+def test_hashfile_picker_cost_per_hashfile_is_bounded(
+    page, live_server, perf_fixture
+):
+    """Isolate the picker's marginal cost per hashfile from fixed overhead.
+
+    ``/jobs/add`` is the floor: it is the same authenticated request pipeline
+    (session, nav counts, base template) rendering a two-field form. Subtracting
+    it leaves the picker's own work, which is then divided by the hashfile count.
+    """
+    job_id = perf_fixture["job_id"]
+    hashfiles = perf_fixture["perf_hashfiles"]
+
+    floor_ms, _, _ = time_get(page, f"{live_server}/jobs/add")
+    picker_ms, samples, _ = time_get(
+        page, f"{live_server}/jobs/{job_id}/assigned_hashfile/"
+    )
+    marginal_ms = picker_ms - floor_ms
+    per_hashfile = marginal_ms / max(hashfiles, 1)
+    print(
+        f"[perf] scaling hashfile_picker floor={floor_ms:.0f}ms "
+        f"picker={picker_ms:.0f}ms marginal={marginal_ms:.0f}ms over "
+        f"{hashfiles} hashfiles = {per_hashfile:.2f}ms/hashfile "
+        f"budget={MAX_MS_PER_HASHFILE}ms/hashfile"
+    )
+    assert per_hashfile <= MAX_MS_PER_HASHFILE, (
+        f"Hashfile picker costs {per_hashfile:.2f}ms per hashfile "
+        f"({marginal_ms:.0f}ms over {hashfiles} files, floor {floor_ms:.0f}ms). "
+        "A single grouped aggregate would make this roughly constant."
+    )

--- a/tests/seed_perf_db.py
+++ b/tests/seed_perf_db.py
@@ -1,0 +1,233 @@
+"""Volume seeder for the job-creation performance e2e suite.
+
+Run inside the app container, AFTER ``seed_e2e_db.py``. Idempotent: every block
+checks for its own marker rows first, so re-running is a no-op.
+
+An empty database hides the job wizard's scaling problems — the hotspots are
+N+1 loops and full-table renders whose cost is a function of row counts, not of
+page size. This seeder adds volume in exactly the three places the wizard reads:
+
+* ``HASHFILES_PER_CUSTOMER`` hashfiles owned by the e2e customer, each holding
+  ``HASHES_PER_HASHFILE`` hashes — drives the per-hashfile aggregate loop on the
+  "Assign Hashes" step.
+* one large hashfile (``BIG_HASHFILE_HASHES`` hashes, ``BIG_CRACKED_RATIO``
+  already cracked) — drives the cracked-hash listing.
+* ``EXTRA_TASKS`` rows in ``tasks`` — drives the task library render, which
+  emits one form + CSRF token per task in the whole table.
+
+Volumes are overridable by env var so the same seeder can produce a quick
+smoke-sized fixture or a realistic one.
+"""
+import os
+import sys
+
+from flask import Flask
+
+from hashview.config import Config
+from hashview.models import (
+    Customers,
+    Hashes,
+    HashfileHashes,
+    Hashfiles,
+    Tasks,
+    Users,
+    Wordlists,
+    db,
+)
+
+# Marker prefixes. Every row this seeder creates is named with one of these, so
+# the idempotency checks (and any manual cleanup) can find them unambiguously.
+HASHFILE_PREFIX = "perf-hashfile-"
+BIG_HASHFILE_NAME = "perf-big-hashfile"
+TASK_PREFIX = "perf-task-"
+
+# Bulk-insert chunk size. Large enough to amortize round-trips, small enough to
+# stay well inside MySQL's max_allowed_packet on the widest row here.
+CHUNK = 5000
+
+
+def _env_int(key: str, default: int) -> int:
+    raw = os.getenv(key)
+    if raw is None or raw.strip() == "":
+        return default
+    return int(raw)
+
+
+def build_app() -> Flask:
+    app = Flask(__name__)
+    app.config.from_object(Config)
+    db.init_app(app)
+    return app
+
+
+def _bulk_insert(model, rows):
+    """Insert ``rows`` (list of dicts) in chunks, committing per chunk."""
+    for start in range(0, len(rows), CHUNK):
+        db.session.bulk_insert_mappings(model, rows[start : start + CHUNK])
+        db.session.commit()
+
+
+def _make_hashes(count: int, cracked_count: int, hash_type: int, tag: str):
+    """Create ``count`` Hashes rows and return their ids, in insertion order.
+
+    ``sub_ciphertext`` is capped at 32 chars by the schema, so the tag is
+    truncated from the left to keep the numeric suffix (the part that makes each
+    value unique) intact.
+    """
+    rows = []
+    for i in range(count):
+        suffix = f"{i:012d}"
+        prefix = f"{tag}"[: 32 - len(suffix)]
+        digest = f"{prefix}{suffix}"
+        rows.append(
+            {
+                "sub_ciphertext": digest,
+                "ciphertext": digest,
+                "hash_type": hash_type,
+                "cracked": i < cracked_count,
+                "plaintext": f"pw{i}" if i < cracked_count else None,
+            }
+        )
+    _bulk_insert(Hashes, rows)
+
+    # bulk_insert_mappings does not populate primary keys, so read the ids back
+    # by the unique sub_ciphertext prefix we just wrote.
+    prefix_like = f"{tag}%"
+    return [
+        row.id
+        for row in Hashes.query.with_entities(Hashes.id)
+        .filter(Hashes.sub_ciphertext.like(prefix_like))
+        .order_by(Hashes.id)
+        .all()
+    ]
+
+
+def seed_many_hashfiles(customer_id: int, owner_id: int, count: int, per_file: int):
+    existing = Hashfiles.query.filter(
+        Hashfiles.name.like(f"{HASHFILE_PREFIX}%")
+    ).count()
+    if existing >= count:
+        print(f"seed_perf_db: {existing} perf hashfiles already present, skipping")
+        return
+
+    for n in range(existing, count):
+        name = f"{HASHFILE_PREFIX}{n:03d}"
+        hashfile = Hashfiles(name=name, customer_id=customer_id, owner_id=owner_id)
+        db.session.add(hashfile)
+        db.session.commit()
+
+        # Half cracked, so the picker's SUM(CASE cracked) aggregate has real work.
+        hash_ids = _make_hashes(
+            per_file, per_file // 2, hash_type=1000, tag=f"hf{n:03d}"
+        )
+        _bulk_insert(
+            HashfileHashes,
+            [
+                {
+                    "hash_id": hid,
+                    "username": f"user{i}",
+                    "hashfile_id": hashfile.id,
+                }
+                for i, hid in enumerate(hash_ids)
+            ],
+        )
+        print(f"seed_perf_db: hashfile {name} -> {len(hash_ids)} hashes")
+
+
+def seed_big_hashfile(customer_id: int, owner_id: int, total: int, cracked_ratio: float):
+    if Hashfiles.query.filter_by(name=BIG_HASHFILE_NAME).first() is not None:
+        print("seed_perf_db: big hashfile already present, skipping")
+        return
+
+    hashfile = Hashfiles(
+        name=BIG_HASHFILE_NAME, customer_id=customer_id, owner_id=owner_id
+    )
+    db.session.add(hashfile)
+    db.session.commit()
+
+    cracked = int(total * cracked_ratio)
+    hash_ids = _make_hashes(total, cracked, hash_type=1000, tag="big")
+    _bulk_insert(
+        HashfileHashes,
+        [
+            {"hash_id": hid, "username": f"biguser{i}", "hashfile_id": hashfile.id}
+            for i, hid in enumerate(hash_ids)
+        ],
+    )
+    print(
+        f"seed_perf_db: big hashfile -> {len(hash_ids)} hashes "
+        f"({cracked} cracked), id={hashfile.id}"
+    )
+
+
+def seed_tasks(owner_id: int, count: int):
+    existing = Tasks.query.filter(Tasks.name.like(f"{TASK_PREFIX}%")).count()
+    if existing >= count:
+        print(f"seed_perf_db: {existing} perf tasks already present, skipping")
+        return
+
+    wordlist = Wordlists.query.first()
+    if wordlist is None:
+        raise RuntimeError(
+            "No wordlist found. The app creates defaults on boot; seed after boot."
+        )
+
+    _bulk_insert(
+        Tasks,
+        [
+            {
+                "name": f"{TASK_PREFIX}{n:04d}",
+                "hc_attackmode": 0,
+                "owner_id": owner_id,
+                "wl_id": wordlist.id,
+            }
+            for n in range(existing, count)
+        ],
+    )
+    print(f"seed_perf_db: tasks -> {count} total perf tasks")
+
+
+def seed(app: Flask) -> None:
+    customer_id = int(os.environ["HASHVIEW_E2E_CUSTOMER_ID"])
+
+    hashfiles_per_customer = _env_int("HASHVIEW_PERF_HASHFILES", 30)
+    hashes_per_hashfile = _env_int("HASHVIEW_PERF_HASHES_PER_HASHFILE", 2000)
+    big_hashfile_hashes = _env_int("HASHVIEW_PERF_BIG_HASHFILE_HASHES", 50000)
+    cracked_ratio = float(os.getenv("HASHVIEW_PERF_BIG_CRACKED_RATIO", "0.6"))
+    extra_tasks = _env_int("HASHVIEW_PERF_TASKS", 400)
+
+    with app.app_context():
+        admin = db.session.get(Users, 1)
+        if admin is None:
+            raise RuntimeError("Admin user (id=1) not found; app must finish booting.")
+        if db.session.get(Customers, customer_id) is None:
+            raise RuntimeError(
+                f"Customer id={customer_id} not found; run seed_e2e_db.py first."
+            )
+
+        seed_many_hashfiles(
+            customer_id, admin.id, hashfiles_per_customer, hashes_per_hashfile
+        )
+        seed_big_hashfile(customer_id, admin.id, big_hashfile_hashes, cracked_ratio)
+        seed_tasks(admin.id, extra_tasks)
+
+        print(
+            "seed_perf_db: totals -> "
+            f"hashfiles={Hashfiles.query.count()} "
+            f"hashes={Hashes.query.count()} "
+            f"hashfile_hashes={HashfileHashes.query.count()} "
+            f"tasks={Tasks.query.count()}"
+        )
+
+
+def main() -> int:
+    if not os.getenv("HASHVIEW_E2E_CUSTOMER_ID"):
+        print("seed_perf_db: missing HASHVIEW_E2E_CUSTOMER_ID", file=sys.stderr)
+        return 2
+    seed(build_app())
+    print("seed_perf_db: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds a Playwright performance suite for the job-creation wizard, pinning the four scaling defects reported in #422 as strict `xfail`s.

Tests only — no application code changes.

## Why

The wizard is fast on a fresh install and degrades as data accumulates, so a perf test run against an empty database proves nothing. This adds a tunable volume seeder alongside the suite, and the suite skips itself (rather than passing) when that fixture is absent.

## What's here

**`tests/seed_perf_db.py`** — idempotent volume seeder, run inside the app container after `seed_e2e_db.py`. Adds volume in the three places the wizard reads: many hashfiles for one customer, one large mostly-cracked hashfile, and several hundred rows in `tasks`. Volumes are env-tunable (`HASHVIEW_PERF_HASHFILES`, `HASHVIEW_PERF_TASKS`, …) so the same seeder produces either a quick smoke fixture or a realistic one. Everything it creates is prefixed `perf-`.

**`tests/e2e/test_job_creation_perf.py`** — two kinds of assertion, because they fail for different reasons:

- *Latency budgets* (6 tests, passing) — wall-clock medians of 5 samples with the warmup discarded. Deliberately loose, and each overridable via `HASHVIEW_PERF_BUDGET_<NAME>` for slower hardware. These catch order-of-magnitude regressions, not drift.
- *Scaling guards* (4 tests, strict `xfail` against #422) — response payload sizes and per-row marginal cost. These are machine-independent and so are the stronger guard: a page whose HTML grows with a whole table blows a size budget identically on every host.

Strict mode means each guard fails with XPASS the moment its defect is fixed, which is the signal to drop the marker. The numbering in each `reason` matches the numbered sections of #422.

## Measured on the local docker stack

150 hashfiles for one customer, 350k hashes, 2,000 tasks:

| Step | Median | Response size |
| --- | --- | --- |
| `GET /jobs/add` (per-request floor) | 237 ms | small |
| `GET /jobs/<id>/assigned_hashfile/` | 762 ms | 318 KB |
| `GET /jobs/<id>/tasks` | 324 ms | 1.5 MB |
| `GET /jobs/<id>/assigned_hashfile/<id>` | 2,864 ms | 16 MB |
| `POST /jobs/<id>/assign_task/<id>` | 625 ms | — |
| `GET /jobs/<id>/summary` | 288 ms | 998 KB |

The hashfile picker's marginal cost measures 3.4 ms per hashfile above the floor, confirming the per-hashfile aggregate query in `jobs/routes.py:287` is linear in the customer's file count.

## Verification

- `pytest -m perf`: 6 passed, 4 xfailed against the local stack
- `tests/e2e/test_job_creation.py` (existing functional walk): still passes
- `tests/unit tests/security tests/agent_unit`: 1514 passed, 2 skipped, 39 xfailed, 5 xpassed (xpasses pre-existing on `v0.8.3-dev`)
- `ruff check` clean on both new files

## Notes for review

- These tests carry a new `perf` marker rather than `e2e`, so `pytest -m e2e` (what CI runs) does not collect them and CI behaviour is unchanged. That matters: CI runs e2e under `HASHVIEW_E2E_STRICT` with a cap of 4 skipped results, and since it never seeds the perf fixture these ten tests would otherwise skip there and fail the build. Verified `-m e2e` collects 0 of them and `-m perf` collects all 10.
- `tests/conftest.py`'s `ensure_setup` fixture is extended to recognise `perf` alongside `e2e`, so the suite still handles the first-run setup wizard on a fresh stack. This is the only change to shared test code.
- `test_assigning_a_task_is_fast` adds one task to the seeded job per run. It picks a task not already queued, so repeated runs stay correct, but the job's queue does grow across runs.

Closes nothing — #422 stays open until the underlying defects are fixed and these markers come off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
