### PR TITLE
fix(hooks): skip the lint/test gate on delete-only pushes

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -49,6 +49,9 @@ RST=$'\033[0m'
 
 fail=0
 findings=""
+# Set once any ref update is not a deletion. A push that only deletes refs adds
+# no code, so the lint/test gate below has nothing to check and is skipped.
+has_updates=0
 
 record() {
     findings+="$1"$'\n'
@@ -65,6 +68,8 @@ while read -r local_ref local_sha remote_ref remote_sha; do
     if [ "$local_sha" = "$zero" ]; then
         continue
     fi
+
+    has_updates=1
 
     if [ "$remote_sha" = "$zero" ]; then
         # New branch: scan everything reachable from local_sha not already on any remote.
@@ -185,6 +190,15 @@ if [ "$fail" -ne 0 ]; then
 fi
 
 echo "pre-push: sensitive-content scan clean."
+
+# A delete-only push (git push origin --delete <branch>, or a pruning sweep over
+# merged branches) carries no commits: there is nothing to lint and nothing to
+# test. Running the gate anyway cost minutes per invocation and pushed people
+# toward --no-verify, which also skips the secret scan.
+if [ "$has_updates" -eq 0 ]; then
+    echo "pre-push: deletions only — skipping lint/test gate."
+    exit 0
+fi
 
 # --- Local test gate (mirrors CI: no Docker, no Playwright) ---------------------
 cd "$REPO_ROOT" || exit 1

--- a/tests/unit/test_prepush_hook.py
+++ b/tests/unit/test_prepush_hook.py
@@ -108,14 +108,27 @@ def _build_repo(tmp_path):
     return upstream, clone
 
 
-def _run_hook(clone, upstream, local_ref, local_sha, remote_sha):
-    """Invoke the hook exactly as git would, and return its combined output."""
-    stdin = f"{local_ref} {local_sha} {local_ref} {remote_sha}\n"
-    proc = subprocess.run(
+def _run_hook_refs(clone, upstream, refs):
+    """Invoke the hook as git would for one or more ref updates.
+
+    `refs` is a sequence of (local_ref, local_sha, remote_sha) triples, one per
+    line of the hook's stdin protocol. Returns the CompletedProcess so callers
+    can assert on exit status as well as output.
+    """
+    stdin = "".join(
+        f"{local_ref} {local_sha} {local_ref} {remote_sha}\n"
+        for local_ref, local_sha, remote_sha in refs
+    )
+    return subprocess.run(
         ["bash", str(clone / ".githooks" / "pre-push"), "origin", str(upstream)],
         cwd=clone, input=stdin, capture_output=True, text=True,
         env=_clean_env(),
     )
+
+
+def _run_hook(clone, upstream, local_ref, local_sha, remote_sha):
+    """Invoke the hook exactly as git would, and return its combined output."""
+    proc = _run_hook_refs(clone, upstream, [(local_ref, local_sha, remote_sha)])
     return proc.stdout + proc.stderr
 
 
@@ -275,3 +288,47 @@ def test_deletion_push_is_skipped(tmp_path):
     out = _scan_output(_run_hook(clone, upstream, "refs/heads/gone", ZERO, ZERO))
 
     assert "sensitive-content scan clean" in out
+
+
+def test_deletion_only_push_skips_the_test_gate(tmp_path):
+    """A delete-only push must not run ruff/bandit/pytest.
+
+    The scan loop already skipped deletions, but the gate below it ran
+    unconditionally, so `git push origin --delete <branch>` paid for the full
+    fast test suite. There is no diff to lint and no commit to test: the push
+    removes a ref. Deleting a batch of merged branches timed out at two minutes
+    because of this, which is what pushes people toward --no-verify.
+    """
+    upstream, clone = _build_repo(tmp_path)
+
+    proc = _run_hook_refs(clone, upstream, [("refs/heads/gone", ZERO, ZERO)])
+    out = proc.stdout + proc.stderr
+
+    assert "pre-push: running ruff" not in out, \
+        "the test gate must not run when every ref update is a deletion"
+    assert proc.returncode == 0, f"delete-only push must succeed, got:\n{out}"
+
+
+def test_push_mixing_a_deletion_and_an_update_still_runs_the_gate(tmp_path):
+    """One real ref update is enough to require the gate.
+
+    Guards the obvious over-correction: keying the skip off "saw a deletion"
+    rather than "saw *only* deletions" would let a branch update ride along
+    with a delete and skip linting and tests entirely.
+    """
+    upstream, clone = _build_repo(tmp_path)
+    base = _git(clone, "rev-parse", "origin/main").strip()
+    _git(clone, "checkout", "-q", "main")
+    (clone / "helper.py").write_text("def add(a, b):\n    return a + b\n")
+    _git(clone, "add", "helper.py")
+    _git(clone, "commit", "-q", "-m", "add helper")
+    sha = _git(clone, "rev-parse", "HEAD").strip()
+
+    proc = _run_hook_refs(clone, upstream, [
+        ("refs/heads/gone", ZERO, ZERO),
+        ("refs/heads/main", sha, base),
+    ])
+    out = proc.stdout + proc.stderr
+
+    assert "pre-push: running ruff" in out, \
+        "a real ref update alongside a deletion must still be gated"


### PR DESCRIPTION
## Problem

`.githooks/pre-push` correctly skips ref *deletions* in its secret-scan loop, but the ruff / bandit / OpenAPI / pytest gate below the loop runs unconditionally. A delete-only push therefore pays for the full fast test suite while carrying no commits — there is nothing to lint and nothing to test.

This surfaced while pruning merged branches: `git push origin --delete` over 20 branches ran past two minutes and had to be completed through the GitHub API instead.

The practical hazard is not the wasted time. The obvious workaround is `git push --no-verify`, which also disables the secret scanner this hook exists for — so a slow no-op gate actively trains people to bypass the security control.

## Fix

Track whether any ref update in the push is something other than a deletion. If none is, exit 0 after the (already clean) scan and before the gate.

The secret scan itself is unchanged — it still runs, and still prints `sensitive-content scan clean.` A push that mixes a deletion with a real ref update still runs the full gate.

## Tests

Two tests added to the existing `tests/unit/test_prepush_hook.py` harness, which drives the real hook script through its stdin protocol against throwaway repositories:

- `test_deletion_only_push_skips_the_test_gate` — the gate must not run, and the hook must exit 0.
- `test_push_mixing_a_deletion_and_an_update_still_runs_the_gate` — guards the over-correction of keying the skip off "saw a deletion" rather than "saw *only* deletions", which would let a branch update ride along with a delete and skip linting and tests entirely.

The pre-existing `test_deletion_push_is_skipped` could not catch this: it asserts on `_scan_output()`, which truncates the output before the gate begins.

Both tests were mutation-verified:

- Reverting the hook fix fails `test_deletion_only_push_skips_the_test_gate`.
- Replacing the condition with `if true` fails `test_push_mixing_a_deletion_and_an_update_still_runs_the_gate`.

## Verification

End-to-end against a scratch bare remote, with the hook active:

```
pre-push: sensitive-content scan clean.
pre-push: deletions only — skipping lint/test gate.
 - [deleted]         throwaway
git push verify --delete throwaway  0.271 total
```

0.27s, versus the >2 minute timeout before. Full fast suite: **1620 passed, 2 skipped, 44 xfailed, 5 xpassed**. The push of this very branch ran the complete gate, confirming the update path is unaffected.

No CHANGELOG entry: consistent with #419 and the other `.githooks` changes, this is developer tooling rather than user-facing behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)