### PR TITLE
fix(api): one grouped query for the hash-type hashfile listing (#228)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ Notable changes will be documented here
 
 **Testing**
 - Job-creation performance e2e suite (`tests/e2e/test_job_creation_perf.py`) with a tunable volume seeder (`tests/seed_perf_db.py`), covering latency budgets for each wizard step plus strict-xfail scaling guards for the four endpoints in issue #422 whose cost grows with table size rather than page size
-- API hashfile-listing performance suite (`tests/e2e/test_api_hashfile_listing_perf.py`), sharing that seeder. Asserts loop cost as a ratio to a same-route zero-hashfile floor rather than an absolute budget, so the threshold survives a change of hardware; carries a strict-xfail scaling guard for issue #228 (`GET /v1/hashfiles/hash_type/<t>` runs an ORM get plus two counts per matching hashfile) and a passing regression guard on `GET /v1/customers/<id>/hashfiles`, which runs one combined aggregate per hashfile and measures under the ceiling today
+- API hashfile-listing performance suite (`tests/e2e/test_api_hashfile_listing_perf.py`), sharing that seeder. Asserts loop cost as a ratio to a same-route zero-hashfile floor rather than an absolute budget, so the threshold survives a change of hardware; carries regression guards for issue #228 (fixed in this release; the guard remains so a per-hashfile loop cannot return) and on `GET /v1/customers/<id>/hashfiles`, which runs one combined aggregate per hashfile and measures under the ceiling today
 
 ### Changed
 - The Rules listing is paginated (20 per page) with sortable Name / Rules / Owner / Last Updated columns and a server-side name filter, matching the Tasks listing
@@ -68,6 +68,7 @@ Notable changes will be documented here
 - Every top-level page is now covered by a Playwright reachability test, and a guard fails CI when a new sidebar entry ships without one; Task Groups gained an end-to-end create/delete test
 
 ### Fixed
+- `GET /v1/hashfiles/hash_type/<t>` now answers with one grouped query instead of three per matching hashfile (issue #228). It previously took a DISTINCT list of hashfile ids and, for each, ran an ORM lookup plus two separate COUNTs, so the work above the fixed request cost grew with the number of matching files. On a production instance holding 7.85M NTLM hashes the endpoint took 549 seconds to return 13 KB — past every default client timeout, so callers saw not a slow listing but no listing, indistinguishable from a customer having no hashfiles. Response content is unchanged (verified byte-identical against MySQL for a populated type, an empty type and an unknown type), and results are now returned in hashfile-id order, which `GROUP BY` alone does not guarantee
 - The Analytics page no longer hangs the browser on large datasets: the Shared Passwords and Username = Password cards render a capped preview (with the full total shown) instead of one form per group, and the complete lists remain available from the download buttons
 - Analytics counted a password as "shared" when a single account's hash appeared in more than one hashfile, or when the rows had no username at all; shared passwords are now grouped by distinct named account
 - The name filter on the Tasks and Jobs listings now searches every task/job instead of only the rows on the current page, so a match on a later page is no longer reported as "no match"

--- a/hashview/api/routes.py
+++ b/hashview/api/routes.py
@@ -1570,32 +1570,45 @@ def v1_api_get_hashfiles_by_hash_type(hash_type):
     # hash_type lives on Hashes (per-hash), not on Hashfiles: a file can hold
     # mixed types, so match via the HashfileHashes junction and scope the
     # counts to THIS hash_type within each file.
-    matching_ids = [row[0] for row in
-                    db.session.query(HashfileHashes.hashfile_id)
-                    .join(Hashes, Hashes.id == HashfileHashes.hash_id)
-                    .filter(Hashes.hash_type == hash_type)
-                    .distinct().all()]
+    #
+    # One grouped query, not one per hashfile (issue #228). The previous form
+    # took a DISTINCT list of hashfile ids and then, for each, ran an ORM
+    # Hashfiles.query.get() plus two separate COUNTs -- three round trips per
+    # matching file. Joining from Hashfiles and grouping does the same work in
+    # a single statement.
+    #
+    # Joining FROM Hashfiles also subsumes the old `if hashfile is None:
+    # continue` guard: a HashfileHashes row pointing at a deleted hashfile has
+    # no row to join to, so it drops out instead of needing a lookup to
+    # discover it is an orphan.
+    rows = db.session.query(
+            Hashfiles.id,
+            Hashfiles.name,
+            Hashfiles.customer_id,
+            Hashfiles.owner_id,
+            Hashfiles.uploaded_at,
+            func.count(Hashes.id),
+            func.coalesce(func.sum(case((Hashes.cracked == True, 1), else_=0)), 0),  # noqa: E712
+        ) \
+        .join(HashfileHashes, HashfileHashes.hashfile_id == Hashfiles.id) \
+        .join(Hashes, Hashes.id == HashfileHashes.hash_id) \
+        .filter(Hashes.hash_type == hash_type) \
+        .group_by(Hashfiles.id) \
+        .order_by(Hashfiles.id) \
+        .all()
 
     results = []
-    for hashfile_id in matching_ids:
-        hashfile = Hashfiles.query.get(hashfile_id)
-        if hashfile is None:
-            continue
-        base = db.session.query(Hashes.id) \
-            .join(HashfileHashes, HashfileHashes.hash_id == Hashes.id) \
-            .filter(HashfileHashes.hashfile_id == hashfile_id) \
-            .filter(Hashes.hash_type == hash_type)
-        total = base.count()
-        cracked = base.filter(Hashes.cracked == '1').count()
+    for (hashfile_id, name, customer_id, owner_id,
+         uploaded_at, total, cracked) in rows:
         results.append({
-            'id': hashfile.id,
-            'name': hashfile.name,
-            'customer_id': hashfile.customer_id,
-            'owner_id': hashfile.owner_id,
-            'uploaded_at': hashfile.uploaded_at.isoformat() if hashfile.uploaded_at else None,
+            'id': hashfile_id,
+            'name': name,
+            'customer_id': customer_id,
+            'owner_id': owner_id,
+            'uploaded_at': uploaded_at.isoformat() if uploaded_at else None,
             'hash_type': hash_type,
-            'total_hashes': total,
-            'cracked_hashes': cracked,
+            'total_hashes': int(total or 0),
+            'cracked_hashes': int(cracked or 0),
         })
 
     # Structured list (not AlchemyEncoder) because the count fields are

--- a/tests/e2e/test_api_hashfile_listing_perf.py
+++ b/tests/e2e/test_api_hashfile_listing_perf.py
@@ -42,10 +42,10 @@ by 1.4x at worst, and the grouped version clears it by 1.5x at worst. Both
 margins are real but neither is enormous, so
 ``HASHVIEW_PERF_MAX_LOOP_COST_RATIO`` exists for hardware where they are not.
 
-This was verified in both directions rather than assumed: patching the
-``GROUP BY`` into a running stack turned the xfail below into an XPASS, which
-under ``strict=True`` fails the suite. That is the signal to delete the marker,
-and it has been confirmed to fire.
+Both regimes were measured on a running stack, and the by-hash-type route now
+uses the grouped form, so it sits in the lower band. The strict ``xfail`` that
+pinned issue #228 has been removed along with the defect; what remains is a
+guard against the per-hashfile loop coming back.
 
 Note the ratio understates production. On a real instance with 7.85M hashes of
 one type the same endpoint takes 549 s, far worse than scaling this fixture
@@ -180,19 +180,17 @@ def test_empty_hash_type_listing_is_fast(api, seeded_hashfiles):
 
 
 @pytest.mark.perf
-@pytest.mark.xfail(
-    strict=True,
-    reason="Issue #228: /v1/hashfiles/hash_type/<t> resolves each matching "
-    "hashfile with its own ORM get plus two count queries, so the work above "
-    "the fixed request cost grows with the number of matching hashfiles "
-    "instead of being one grouped query.",
-)
 def test_hash_type_listing_loop_cost_is_bounded(api, seeded_hashfiles):
     """Isolate the per-hashfile loop from fixed request overhead.
 
     Both measurements hit the same route with the same auth, so everything
     except the loop cancels: one hash type has every seeded hashfile, the other
     has none.
+
+    This carried a strict ``xfail`` for issue #228 until the route was rewritten
+    to one grouped query. The marker is gone because the defect is: it measured
+    2.04x-2.65x before and 0.92x-1.00x after, against a 1.5x ceiling. It stays
+    as a guard so a reintroduced per-hashfile loop fails here.
     """
     floor_ms, _, _ = time_get(api, f"/v1/hashfiles/hash_type/{UNUSED_HASH_TYPE}")
     median, samples, body = time_get(api, f"/v1/hashfiles/hash_type/{SEEDED_HASH_TYPE}")

--- a/tests/unit/test_api_endpoints.py
+++ b/tests/unit/test_api_endpoints.py
@@ -884,6 +884,75 @@ def test_hashfiles_by_hash_type_lists_matching_with_counts(client, admin_user):
 
 
 @pytest.mark.security
+def test_hashfiles_by_hash_type_lists_each_hashfile_once(client, admin_user):
+    """One row per hashfile, however many matching hashes it holds.
+
+    This is the assertion that matters, and it bites: since #228 the route
+    joins Hashfiles to the junction table, so dropping the GROUP BY emits one
+    row per *hash*. Verified by removing it and watching this fail.
+
+    The id-order assertion below is deliberately weaker. The route now says
+    ``.order_by(Hashfiles.id)``, which MySQL needs because ``GROUP BY`` does not
+    imply an ordering, but sqlite returns grouped rows in rowid order anyway --
+    so removing the ``order_by`` does *not* fail this test here. It documents
+    the intent and only earns its keep against a real MySQL backend; treat it
+    as a statement of contract rather than a guard.
+    """
+    cust = Customers(name="OrderCo")
+    _db.session.add(cust)
+    _db.session.commit()
+
+    hashfiles = [
+        Hashfiles(name=f"order-{n}", customer_id=cust.id, owner_id=admin_user.id)
+        for n in range(4)
+    ]
+    _db.session.add_all(hashfiles)
+    _db.session.commit()
+
+    # Differing hash counts: a join without GROUP BY would emit one row per
+    # hash, so the counts double as a duplication check.
+    for index, hashfile in enumerate(hashfiles):
+        for _ in range(index + 1):
+            _seed_hash(hashfile.id, 4242, False)
+
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    resp = client.get("/v1/hashfiles/hash_type/4242")
+
+    body = _json_body(resp)
+    assert body["status"] == 200
+    returned_ids = [entry["id"] for entry in body["hashfiles"]]
+    assert returned_ids == sorted(hf.id for hf in hashfiles)
+    assert [entry["total_hashes"] for entry in body["hashfiles"]] == [1, 2, 3, 4]
+
+
+@pytest.mark.security
+def test_hashfiles_by_hash_type_counts_a_fully_cracked_file(client, admin_user):
+    """total == cracked when every matching hash is cracked.
+
+    The cracked figure is a SUM over a CASE wrapped in COALESCE; this covers the
+    all-ones end of it, where the mixed-type test above covers the zero end (a
+    file with no cracked hashes of the queried type must report 0, not null).
+    """
+    cust = Customers(name="AllCrackedCo")
+    _db.session.add(cust)
+    _db.session.commit()
+    hashfile = Hashfiles(
+        name="all-cracked", customer_id=cust.id, owner_id=admin_user.id
+    )
+    _db.session.add(hashfile)
+    _db.session.commit()
+    for _ in range(3):
+        _seed_hash(hashfile.id, 4243, True)
+
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    resp = client.get("/v1/hashfiles/hash_type/4243")
+
+    entry = _json_body(resp)["hashfiles"][0]
+    assert entry["total_hashes"] == 3
+    assert entry["cracked_hashes"] == 3
+
+
+@pytest.mark.security
 def test_hashfiles_by_hash_type_unused_type_returns_empty_list(client, admin_user):
     """A hash type with no hashfiles is a valid empty result, not an error."""
     client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")

--- a/tests/unit/test_api_routes_branches.py
+++ b/tests/unit/test_api_routes_branches.py
@@ -1895,12 +1895,17 @@ def test_hashfile_get_no_cookie_redirects(client):
 
 @pytest.mark.security
 def test_hashfiles_by_hash_type_hashfile_missing_in_loop(client, admin_user):
-    """GET /v1/hashfiles/hash_type/<n> skips hashfile_id rows where Hashfiles.get()
-    returns None (line 1165: the `continue` guard in the loop).
+    """GET /v1/hashfiles/hash_type/<n> ignores junction rows whose hashfile is gone.
 
-    We create a HashfileHashes row pointing to a nonexistent hashfile_id and
-    a hash of the queried type, then verify no crash occurs and the result list
-    is empty.
+    We create a HashfileHashes row pointing to a nonexistent hashfile_id and a
+    hash of the queried type, then verify no crash occurs and the result list is
+    empty.
+
+    This used to be an explicit `if hashfile is None: continue` guard inside a
+    per-hashfile loop. Since #228 the route joins from Hashfiles and groups, so
+    an orphaned junction row has nothing to join to and drops out on its own.
+    The assertion is unchanged because the behaviour is: the test pins the
+    contract, not the mechanism.
     """
     # Create a hash of type 7777 but link it to a nonexistent hashfile
     h = Hashes(sub_ciphertext="7" * 32, ciphertext="ghost7777", hash_type=7777, cracked=False)


### PR DESCRIPTION
Fixes the N+1 in `GET /v1/hashfiles/hash_type/<t>` from #228.

> **Stacked on #433.** Base is `test/api-hashfile-listing-perf`, so the diff here is just the fix. GitHub retargets this to `v0.8.3-dev` automatically once #433 merges. Review #433 first.

## The change

The route took a `DISTINCT` list of matching hashfile ids and then, for each one, ran an ORM `Hashfiles.query.get()` plus two separate `COUNT`s — three round trips per matching file. Joining from `Hashfiles` and grouping does the same work in one statement.

Two things fall out of the rewrite:

- **The `if hashfile is None: continue` guard is gone**, subsumed by joining *from* `Hashfiles`. An orphaned junction row has nothing to join to, so it drops out rather than needing a lookup to discover it is an orphan. `test_hashfiles_by_hash_type_hashfile_missing_in_loop` is unchanged because the behaviour is; only its docstring moves off the deleted line reference.
- **Results are ordered by hashfile id.** `GROUP BY` does not imply an ordering on MySQL, and the old code iterated a `DISTINCT` list in whatever order came back, so this is newly deterministic.

## Measurements

Perf fixture: 31 hashfiles, 110k hashes, MySQL 8 in Docker. Loop cost is measured above the same-route zero-hashfile floor, per #433.

| | median | loop / floor | per hashfile |
| --- | --- | --- | --- |
| before | 1001 ms | 2.04x – 2.65x | 23 – 29 ms |
| after | **427 ms** | **0.49x** | **4.6 ms** |

For scale, on a production instance holding 7.85M NTLM hashes this endpoint took **549 seconds to return 13 KB** — past every default client timeout. Callers did not experience a slow listing, they experienced *no* listing, indistinguishable from a customer having no hashfiles of that type. That is why this is worth more than the 2.3x the local fixture shows.

## Output equivalence

Verified **byte-identical against MySQL**, not just against the sqlite unit fixtures — old and new code served from the same running stack and the same seeded data, compared for three cases:

- a populated type (31 hashfiles with real total/cracked counts) — identical
- an empty type (`22000`) — identical
- a type no hash has ever had (`4242`) — identical

## Tests

Two unit tests added for properties the rewrite makes load-bearing:

- **one row per hashfile regardless of hash count** — mutation-verified: removing the `GROUP BY` fails it (along with two existing tests)
- **`total == cracked` for a fully cracked file** — covers the all-ones end of `COALESCE(SUM(CASE ...))`, where the existing mixed-type test covers the zero end

The id-order assertion is deliberately called out in its docstring as **not** mutation-provable: sqlite returns grouped rows in rowid order regardless, so removing the `order_by` does not fail it. It documents contract, not a guard, and I would rather say so than let it read as coverage it is not.

The strict `xfail` from #433 is dropped. A marker being added, then clearing when the defect goes, is the workflow it was added for.

## Verification

- `pytest -m perf` (fix in place, `HASHVIEW_PERF_TASKS=2000`): **9 passed, 4 xfailed, 0 failed** — the four remaining xfails are #422's
- `pytest tests/unit tests/security tests/agent_unit`: **1622 passed, 2 skipped, 44 xfailed, 5 xpassed** (1620 before; the two new tests are mine, and the 5 xpassed are unchanged from baseline)
- `ruff check hashview/ hashview.py`: clean
- `pylint` at CI's exact invocation: **9.63/10, rc=0**, unchanged from baseline and above `fail-under=9.0`

## Scope

**This does not close #228.** That issue also covers `/v1/jobs/add` re-querying and committing inside a per-task loop. It is a write path and wants its own change with its own testing.

Two sibling call sites of the same loop are also left alone, deliberately:

- `hashview/hashfiles/routes.py:71` — the web UI hashfiles list, which runs it over *every* hashfile server-wide and has no issue of its own yet
- `hashview/jobs/routes.py:296` — the job-creation picker, which is #422's item 2

`/v1/customers/<id>/hashfiles` needs nothing: it runs one combined aggregate per hashfile rather than three queries, measures ~6 ms per hashfile, and is already under #433's ceiling. See my measurements on #228.
