### PR TITLE
feat(api): add /v1 task-group endpoints (#401)

### DIFF
--- a/.githooks/safe-allowlist.txt
+++ b/.githooks/safe-allowlist.txt
@@ -43,6 +43,11 @@ password="hashed-pw"
 api_key="user-api-key-admin"
 src_ip="127\.0\.0\.1"
 
+# Test-only dummy credential literals in tests/unit/test_api_task_groups.py
+# (owner/other-user fixtures for #401's /v1 task-group endpoint tests).
+api_key="user-api-key-owner"
+api_key="user-api-key-other"
+
 # test fixture api_key literal in the download tests (not a real secret)
 api_key="dl-key"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ Notable changes will be documented here
 **API Expansion**
 - `GET /v1/customers/<customer_id>/hashfiles` -- list every hashfile belonging to a customer in one call, replacing the downstream client-side loop over common hash types (which silently missed uncommon types). Counts cover the whole file (`total_hashes`/`cracked_hashes`) and `hash_type` is the file's representative mode; an unknown customer returns an empty list. (#346)
 - `POST /v1/hashes/import/<hash_type>` now imports cracked hashes for any hash type the server can recompute locally, not just NTLM: MD5 (0), SHA1 (100), MySQL4.1/5 (300), MD4 (900), NTLM (1000), SHA2-256 (1400), and MSSQL 2012/2014 (1731). Each submitted `HASH:plaintext` pair is still verified server-side; unverifiable plaintext is never trusted. Imports are atomic: a single failing line rolls back the entire request.
+- `GET /v1/task_groups` -- list task groups, with `tasks` returned as a parsed array of ids (#401)
+- `POST /v1/task_groups/add` -- create a task group and its ordered task membership in one call (#401)
+- `POST /v1/task_groups/<task_group_id>/tasks` -- replace or append a task group's task membership (#401)
+- `DELETE /v1/task_groups/<task_group_id>` -- delete a task group, owner/admin only (#401)
 
 **Encrypted Database Backup**
 - Download an encrypted `mysqldump` of the database from Settings -> Data Management, protected by a one-time password

--- a/hashview/api/routes.py
+++ b/hashview/api/routes.py
@@ -29,6 +29,7 @@ from hashview.models import (
     JobTasks,
     Rules,
     Settings,
+    TaskGroups,
     Tasks,
     Users,
     Wordlists,
@@ -1250,6 +1251,254 @@ def v1_api_add_task():
         'type': 'message',
         'msg': 'Task added',
         'task_id': task.id
+    }
+    return jsonify(message)
+
+def _validate_ordered_task_ids(task_ids):
+    """Validate a list of task ids against the Tasks table, dedupe preserving
+    first-occurrence order (mirrors task_groups_add/task_groups_edit in the
+    web UI blueprint). Returns (ordered_list, error_msg_or_None) — on the
+    first invalid id, ordered_list is None and error_msg is set."""
+    valid_ids = {t.id for t in Tasks.query.all()}
+    ordered = []
+    for raw_id in task_ids:
+        try:
+            tid = int(raw_id)
+        except (TypeError, ValueError):
+            return None, f'Invalid task id: {raw_id!r}'
+        if tid not in valid_ids:
+            return None, f'Invalid task id: {raw_id!r}'
+        if tid not in ordered:
+            ordered.append(tid)
+    return ordered, None
+
+# List all task groups
+@api.route('/v1/task_groups', methods=['GET'])
+def v1_api_get_task_groups():
+    if not is_authorized(user=True, agent=False, request=request):
+        return redirect("/v1/not_authorized")
+
+    groups = TaskGroups.query.all()
+    native = alchemy_to_native(groups)
+    for row in native:
+        try:
+            row['tasks'] = json.loads(row['tasks']) if row['tasks'] else []
+        except (ValueError, TypeError):
+            row['tasks'] = []
+    message = {
+        'status': 200,
+        'task_groups': native
+    }
+    return jsonify(message)
+
+# Create a new task group with an ordered task membership list
+@api.route('/v1/task_groups/add', methods=['POST'])
+def v1_api_add_task_group():
+    if not is_authorized(user=True, agent=False, request=request):
+        return redirect("/v1/not_authorized")
+
+    uuid = request.cookies.get('uuid')
+    user = Users.query.filter_by(api_key=uuid).first()
+    if not user:
+        return jsonify({
+            'status': 403,
+            'type': 'Error',
+            'msg': 'User not found'
+        })
+
+    # Expect JSON body: {"name": ..., "tasks": [id, ...]}
+    group_data = request.get_json(silent=True)
+    if not group_data:
+        return jsonify({
+            'status': 400,
+            'type': 'Error',
+            'msg': 'Missing task group data in request body'
+        })
+
+    name = str(group_data.get('name') or '').strip()
+    if not name:
+        return jsonify({
+            'status': 400,
+            'type': 'Error',
+            'msg': 'Task group name is required'
+        })
+    if TaskGroups.query.filter_by(name=name).first():
+        return jsonify({
+            'status': 400,
+            'type': 'Error',
+            'msg': 'A task group with that name already exists'
+        })
+
+    task_ids = group_data.get('tasks', [])
+    if not isinstance(task_ids, list):
+        return jsonify({
+            'status': 400,
+            'type': 'Error',
+            'msg': 'tasks must be a list of task ids'
+        })
+    ordered, err = _validate_ordered_task_ids(task_ids)
+    if err:
+        return jsonify({
+            'status': 400,
+            'type': 'Error',
+            'msg': err
+        })
+
+    try:
+        task_group = TaskGroups(name=name, owner_id=user.id, tasks=json.dumps(ordered))
+        db.session.add(task_group)
+        db.session.commit()
+    except Exception:
+        current_app.logger.exception('API /v1/task_groups: failed to add task group')
+        return jsonify({
+            'status': 500,
+            'type': 'Error',
+            'msg': 'Failed to add task group.'
+        })
+
+    log_event('task_group.create', actor=(user.email_address, user.id),
+              target=f'task_group:{task_group.id} {task_group.name!r}')
+    message = {
+        'status': 200,
+        'type': 'message',
+        'msg': 'Task group added',
+        'task_group_id': task_group.id
+    }
+    return jsonify(message)
+
+# Set or append a task group's task membership
+@api.route('/v1/task_groups/<int:task_group_id>/tasks', methods=['POST'])
+def v1_api_set_task_group_tasks(task_group_id):
+    if not is_authorized(user=True, agent=False, request=request):
+        return redirect("/v1/not_authorized")
+
+    uuid = request.cookies.get('uuid')
+    user = Users.query.filter_by(api_key=uuid).first()
+    if not user:
+        return jsonify({
+            'status': 403,
+            'type': 'Error',
+            'msg': 'User not found'
+        })
+
+    task_group = TaskGroups.query.get(task_group_id)
+    if task_group is None:
+        return jsonify({'status': 404, 'type': 'Error', 'msg': 'Task group not found'}), 404
+
+    if not (user.admin or task_group.owner_id == user.id):
+        return jsonify({
+            'status': 403,
+            'type': 'Error',
+            'msg': 'You do not have rights to modify this task group'
+        })
+
+    body = request.get_json(silent=True)
+    if not body:
+        return jsonify({
+            'status': 400,
+            'type': 'Error',
+            'msg': 'Missing task group data in request body'
+        })
+
+    task_ids = body.get('tasks')
+    if not isinstance(task_ids, list):
+        return jsonify({
+            'status': 400,
+            'type': 'Error',
+            'msg': 'tasks must be a list of task ids'
+        })
+
+    mode = body.get('mode', 'replace')
+    if mode not in ('replace', 'append'):
+        return jsonify({
+            'status': 400,
+            'type': 'Error',
+            'msg': "mode must be 'replace' or 'append'"
+        })
+
+    ordered, err = _validate_ordered_task_ids(task_ids)
+    if err:
+        return jsonify({
+            'status': 400,
+            'type': 'Error',
+            'msg': err
+        })
+
+    if mode == 'append':
+        try:
+            existing = json.loads(task_group.tasks) if task_group.tasks else []
+        except (ValueError, TypeError):
+            existing = []
+        new_list = existing + [tid for tid in ordered if tid not in existing]
+    else:
+        new_list = ordered
+
+    try:
+        task_group.tasks = json.dumps(new_list)
+        db.session.commit()
+    except Exception:
+        current_app.logger.exception('API /v1/task_groups: failed to update task group tasks')
+        return jsonify({
+            'status': 500,
+            'type': 'Error',
+            'msg': 'Failed to update task group.'
+        })
+
+    log_event('task_group.edit', actor=(user.email_address, user.id),
+              target=f'task_group:{task_group.id} {task_group.name!r}')
+    message = {
+        'status': 200,
+        'type': 'message',
+        'msg': 'Task group updated',
+        'task_group_id': task_group.id,
+        'tasks': new_list
+    }
+    return jsonify(message)
+
+# Delete a task group
+@api.route('/v1/task_groups/<int:task_group_id>', methods=['DELETE'])
+def v1_api_delete_task_group(task_group_id):
+    if not is_authorized(user=True, agent=False, request=request):
+        return redirect("/v1/not_authorized")
+
+    uuid = request.cookies.get('uuid')
+    user = Users.query.filter_by(api_key=uuid).first()
+    if not user:
+        return jsonify({
+            'status': 403,
+            'type': 'Error',
+            'msg': 'User not found'
+        })
+
+    task_group = TaskGroups.query.get(task_group_id)
+    if task_group is None:
+        return jsonify({'status': 404, 'type': 'Error', 'msg': 'Task group not found'}), 404
+
+    if not (user.admin or task_group.owner_id == user.id):
+        return jsonify({
+            'status': 403,
+            'type': 'Error',
+            'msg': 'You do not have rights to delete this task group'
+        })
+
+    task_group_target = f'task_group:{task_group.id} {task_group.name!r}'
+    try:
+        db.session.delete(task_group)
+        db.session.commit()
+    except Exception:
+        current_app.logger.exception('API /v1/task_groups: failed to delete task group')
+        return jsonify({
+            'status': 500,
+            'type': 'Error',
+            'msg': 'Failed to delete task group.'
+        })
+
+    log_event('task_group.delete', actor=(user.email_address, user.id), target=task_group_target)
+    message = {
+        'status': 200,
+        'type': 'message',
+        'msg': 'Task group deleted',
+        'task_group_id': task_group_id
     }
     return jsonify(message)
 

--- a/hashview/api_docs/openapi.yaml
+++ b/hashview/api_docs/openapi.yaml
@@ -76,6 +76,8 @@ tags:
     description: Per-job task queue entries dispatched to agents.
   - name: Tasks
     description: Reusable attack definitions (wordlist/rule/mask combinations).
+  - name: Task Groups
+    description: Named, ordered collections of tasks (built in the web UI or via the API).
   - name: Hashfiles
     description: Uploaded hash files and their contents.
   - name: Hashes
@@ -922,6 +924,168 @@ paths:
         '302':
           $ref: '#/components/responses/NotAuthorizedRedirect'
 
+  # ------------------------------------------------------------ Task Groups
+  /v1/task_groups:
+    get:
+      tags: [Task Groups]
+      summary: List task groups
+      operationId: listTaskGroups
+      x-audience: user
+      security:
+        - userApiKey: []
+      responses:
+        '200':
+          description: >-
+            Envelope with `task_groups` as a native JSON array; each row's
+            `tasks` is parsed into an array of task ids (not the raw stored
+            JSON string). A malformed stored value is coerced to `[]` rather
+            than failing the whole response.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaskGroupsListResponse'
+        '302':
+          $ref: '#/components/responses/NotAuthorizedRedirect'
+
+  /v1/task_groups/add:
+    post:
+      tags: [Task Groups]
+      summary: Create a task group
+      description: >-
+        Creates the group and its ordered task membership in one call.
+        `tasks` ids are validated against the Tasks table and deduped
+        preserving first-occurrence order. Group names must be unique.
+      operationId: addTaskGroup
+      x-audience: user
+      security:
+        - userApiKey: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TaskGroupCreate'
+            examples:
+              withTasks: {value: {name: nightly-run, tasks: [1, 2, 3]}}
+              empty: {value: {name: empty-group}}
+      responses:
+        '200':
+          description: >-
+            HTTP 200 always; body status 200 with `task_group_id` on
+            success, 400 for each validation failure, 403 if the key
+            resolves to no user, 500 on a database error.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/TaskGroupAddedResponse'
+                  - $ref: '#/components/schemas/ApiError'
+              examples:
+                added: {value: {status: 200, type: message, msg: Task group added, task_group_id: 7}}
+                missingBody: {value: {status: 400, type: Error, msg: Missing task group data in request body}}
+                missingName: {value: {status: 400, type: Error, msg: Task group name is required}}
+                duplicateName: {value: {status: 400, type: Error, msg: A task group with that name already exists}}
+                badTasksType: {value: {status: 400, type: Error, msg: tasks must be a list of task ids}}
+                badTaskId: {value: {status: 400, type: Error, msg: "Invalid task id: 999"}}
+        '302':
+          $ref: '#/components/responses/NotAuthorizedRedirect'
+
+  /v1/task_groups/{task_group_id}/tasks:
+    post:
+      tags: [Task Groups]
+      summary: Set or append a task group's task membership
+      description: >-
+        Owner or admin only. `mode: replace` (default when omitted or
+        absent) sets membership to exactly the given, validated, deduped,
+        order-preserving list. `mode: append` adds the given ids (deduped
+        against the existing membership too) to the end of the existing
+        list, preserving order.
+      operationId: setTaskGroupTasks
+      x-audience: user
+      security:
+        - userApiKey: []
+      parameters:
+        - name: task_group_id
+          in: path
+          required: true
+          schema: {type: integer}
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TaskGroupTasksUpdate'
+            examples:
+              replace: {value: {tasks: [1, 2, 3]}}
+              append: {value: {tasks: [4], mode: append}}
+      responses:
+        '200':
+          description: >-
+            HTTP 200 always; body status 200 with the resulting `tasks`
+            list on success, 400 for each validation failure, 403 when not
+            owner/admin or when the key resolves to no user, 500 on a
+            database error.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/TaskGroupUpdatedResponse'
+                  - $ref: '#/components/schemas/ApiError'
+              examples:
+                updated: {value: {status: 200, type: message, msg: Task group updated, task_group_id: 7, tasks: [1, 2, 3]}}
+                missingBody: {value: {status: 400, type: Error, msg: Missing task group data in request body}}
+                badTasksType: {value: {status: 400, type: Error, msg: tasks must be a list of task ids}}
+                badMode: {value: {status: 400, type: Error, msg: "mode must be 'replace' or 'append'"}}
+                badTaskId: {value: {status: 400, type: Error, msg: "Invalid task id: 999"}}
+                forbidden: {value: {status: 403, type: Error, msg: You do not have rights to modify this task group}}
+        '404':
+          description: Real HTTP 404 — unknown task_group_id.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+              example: {status: 404, type: Error, msg: Task group not found}
+        '302':
+          $ref: '#/components/responses/NotAuthorizedRedirect'
+
+  /v1/task_groups/{task_group_id}:
+    delete:
+      tags: [Task Groups]
+      summary: Delete a task group
+      description: Owner or admin only. Deletes the group row (member tasks are untouched).
+      operationId: deleteTaskGroup
+      x-audience: user
+      security:
+        - userApiKey: []
+      parameters:
+        - name: task_group_id
+          in: path
+          required: true
+          schema: {type: integer}
+      responses:
+        '200':
+          description: >-
+            HTTP 200; body status 200 on success, 403 when not owner or
+            admin, 500 on a database error.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/TaskGroupDeletedResponse'
+                  - $ref: '#/components/schemas/ApiError'
+              examples:
+                deleted: {value: {status: 200, type: message, msg: Task group deleted, task_group_id: 7}}
+                forbidden: {value: {status: 403, type: Error, msg: You do not have rights to delete this task group}}
+        '404':
+          description: Real HTTP 404 — unknown task_group_id.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+              example: {status: 404, type: Error, msg: Task group not found}
+        '302':
+          $ref: '#/components/responses/NotAuthorizedRedirect'
+
   # ------------------------------------------------------------- Hashfiles
   /v1/hashfiles/upload/{customer_id}/{file_format}/{hash_type}/{hashfile_name}:
     post:
@@ -1504,6 +1668,18 @@ components:
         hc_mask: {type: string, nullable: true, description: Mask for modes 3/6/7.}
         loopback: {type: boolean, description: "Enable hashcat --loopback (straight mode + rule only)."}
 
+    TaskGroup:
+      type: object
+      description: A task group row (returned as a native JSON object).
+      properties:
+        id: {type: integer}
+        name: {type: string}
+        owner_id: {type: integer}
+        tasks:
+          type: array
+          description: Ordered list of member task ids (parsed from the stored JSON string).
+          items: {type: integer}
+
     Settings:
       type: object
       description: >-
@@ -1611,6 +1787,41 @@ components:
           description: >-
             Optional rule id (must exist when given). Omit, or send
             null/"None"/"", for a plain dictionary attack.
+
+    TaskGroupCreate:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+          description: Must be unique across task groups.
+        tasks:
+          type: array
+          description: >-
+            Optional ordered list of task ids. Each id must exist in the
+            Tasks table; duplicates are deduped preserving first-occurrence
+            order.
+          items: {type: integer}
+
+    TaskGroupTasksUpdate:
+      type: object
+      required: [tasks]
+      properties:
+        tasks:
+          type: array
+          description: >-
+            Ordered list of task ids. Each id must exist in the Tasks
+            table; duplicates are deduped preserving first-occurrence
+            order.
+          items: {type: integer}
+        mode:
+          type: string
+          enum: [replace, append]
+          default: replace
+          description: >-
+            "replace" (default) sets membership to exactly this list;
+            "append" adds these ids (deduped against existing membership)
+            to the end of the existing list.
 
     JobTaskStatusUpdate:
       type: object
@@ -1927,6 +2138,46 @@ components:
           required: [task_id]
           properties:
             task_id: {type: integer}
+
+    TaskGroupsListResponse:
+      allOf:
+        - $ref: '#/components/schemas/ApiMessage'
+        - type: object
+          required: [task_groups]
+          properties:
+            task_groups:
+              type: array
+              description: Array of TaskGroup rows (native JSON; tasks pre-parsed to an array of ints).
+              items: {$ref: '#/components/schemas/TaskGroup'}
+              example: [{"id": 7, "name": "nightly-run", "owner_id": 1, "tasks": [1, 2, 3]}]
+
+    TaskGroupAddedResponse:
+      allOf:
+        - $ref: '#/components/schemas/ApiMessage'
+        - type: object
+          required: [task_group_id]
+          properties:
+            task_group_id: {type: integer}
+
+    TaskGroupUpdatedResponse:
+      allOf:
+        - $ref: '#/components/schemas/ApiMessage'
+        - type: object
+          required: [task_group_id, tasks]
+          properties:
+            task_group_id: {type: integer}
+            tasks:
+              type: array
+              description: The resulting ordered list of member task ids after the update.
+              items: {type: integer}
+
+    TaskGroupDeletedResponse:
+      allOf:
+        - $ref: '#/components/schemas/ApiMessage'
+        - type: object
+          required: [task_group_id]
+          properties:
+            task_group_id: {type: integer}
 
     HashfileUploadedResponse:
       allOf:

--- a/hashview/api_docs/openapi.yaml
+++ b/hashview/api_docs/openapi.yaml
@@ -999,7 +999,8 @@ paths:
         absent) sets membership to exactly the given, validated, deduped,
         order-preserving list. `mode: append` adds the given ids (deduped
         against the existing membership too) to the end of the existing
-        list, preserving order.
+        list, preserving order; if the existing membership cannot be parsed
+        from storage, it is treated as empty.
       operationId: setTaskGroupTasks
       x-audience: user
       security:
@@ -1821,7 +1822,8 @@ components:
           description: >-
             "replace" (default) sets membership to exactly this list;
             "append" adds these ids (deduped against existing membership)
-            to the end of the existing list.
+            to the end of the existing list; if existing membership cannot
+            be parsed, it is treated as empty.
 
     JobTaskStatusUpdate:
       type: object

--- a/hashview/models.py
+++ b/hashview/models.py
@@ -324,7 +324,7 @@ class TaskGroups(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(50), nullable=False)
     owner_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
-    tasks = db.Column(db.String(256), nullable=False)
+    tasks = db.Column(db.Text, nullable=False)
 
 class Hashes(db.Model):
     """Class object to represent Hashes"""

--- a/hashview/task_groups/routes.py
+++ b/hashview/task_groups/routes.py
@@ -70,14 +70,14 @@ def task_groups_add():
                     tid = int(piece)
                     if tid in valid_ids and tid not in ordered:
                         ordered.append(tid)
-            task_group = TaskGroups(name=task_group_form.name.data, owner_id=current_user.id, tasks=str(ordered))
+            task_group = TaskGroups(name=task_group_form.name.data, owner_id=current_user.id, tasks=json.dumps(ordered))
             db.session.add(task_group)
             db.session.commit()
             log_event('task_group.create', target=f'task_group:{task_group.id} {task_group.name!r}')
             flash(f'Task group {task_group_form.name.data} created!', 'success')
             return redirect(url_for('task_groups.task_groups_list'))
         # Legacy flow: create an empty group then go to the assign-tasks page.
-        task_group = TaskGroups(name=task_group_form.name.data, owner_id=current_user.id, tasks=str([]))
+        task_group = TaskGroups(name=task_group_form.name.data, owner_id=current_user.id, tasks=json.dumps([]))
         db.session.add(task_group)
         db.session.commit()
         log_event('task_group.create', target=f'task_group:{task_group.id} {task_group.name!r}')
@@ -118,7 +118,7 @@ def task_groups_edit():
                 if tid in valid_ids and tid not in ordered:
                     ordered.append(tid)
         task_group.name = task_group_form.name.data
-        task_group.tasks = str(ordered)
+        task_group.tasks = json.dumps(ordered)
         db.session.commit()
         log_event('task_group.edit', target=f'task_group:{task_group.id} {task_group.name!r}')
         flash(f'Task group {task_group_form.name.data} updated!', 'success')
@@ -154,7 +154,7 @@ def task_groups_assigned_tasks_add_task(task_group_id, task_id):
     task_group = TaskGroups.query.get(task_group_id)
     task_group_tasks = json.loads(task_group.tasks)
     task_group_tasks.append(task_id)
-    task_group.tasks = str(task_group_tasks)
+    task_group.tasks = json.dumps(task_group_tasks)
     db.session.commit()
     return redirect("/task_groups/assigned_tasks/"+str(task_group.id))
 
@@ -172,7 +172,7 @@ def task_groups_assigned_tasks_remove_task(task_group_id, task_id):
         flash('That task is no longer in this group — it may have already been removed.', 'warning')
         return redirect("/task_groups/assigned_tasks/"+str(task_group.id))
     task_group_tasks.remove(task_id)
-    task_group.tasks = str(task_group_tasks)
+    task_group.tasks = json.dumps(task_group_tasks)
     if not try_commit(f'remove task {task_id} from task_group {task_group_id}'):
         flash('Could not remove the task — please try again.', 'danger')
     return redirect("/task_groups/assigned_tasks/"+str(task_group.id))
@@ -202,7 +202,7 @@ def task_groups_assigned_tasks_promote_task(task_group_id, task_id):
             else:
                 new_task_group_tasks.append(task_group_tasks[index])
             index+=1
-    task_group.tasks = str(new_task_group_tasks)
+    task_group.tasks = json.dumps(new_task_group_tasks)
     db.session.commit()
     return redirect("/task_groups/assigned_tasks/"+str(task_group.id))
 
@@ -231,7 +231,7 @@ def task_groups_assigned_tasks_demote_task(task_group_id, task_id):
             else:
                 new_task_group_tasks.append(task_group_tasks[index])
             index+=1
-    task_group.tasks = str(new_task_group_tasks)
+    task_group.tasks = json.dumps(new_task_group_tasks)
     db.session.commit()
     return redirect("/task_groups/assigned_tasks/"+str(task_group.id))
 

--- a/migrations/versions/d3a4a6a7b352_widen_task_groups_tasks_to_text.py
+++ b/migrations/versions/d3a4a6a7b352_widen_task_groups_tasks_to_text.py
@@ -1,0 +1,68 @@
+"""widen task_groups.tasks to TEXT
+
+Revision ID: d3a4a6a7b352
+Revises: f1a2b3c4d5e6
+Create Date: 2026-08-28 00:00:00.000000
+
+Widens task_groups.tasks from VARCHAR(1024) to TEXT. The column holds a
+JSON-serialized list of task IDs and may exceed 1024 chars when bulk-creating
+task groups (e.g. 40+ four-digit task IDs = ~240+ chars for JSON, plus
+delimiters and quotes). Changing to TEXT avoids a silent truncation hazard.
+
+Guarded on apply (idempotent under schema drift) so a database that already has
+the column as TEXT or a different size doesn't abort. Uses sa.inspect to
+check the live column type before altering, following the pattern established
+in commit 706bfeb for drift-safe migrations.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'd3a4a6a7b352'
+down_revision = 'f1a2b3c4d5e6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Inspect the live column to see if it's already TEXT or needs conversion.
+    # This handles schema drift: the column may be String(256) (from models.py
+    # create_all), String(1024) (from the initial migration), or already TEXT
+    # (from a prior run).
+    insp = sa.inspect(op.get_bind())
+    if 'task_groups' in insp.get_table_names():
+        for col in insp.get_columns('task_groups'):
+            if col['name'] == 'tasks':
+                # Check if it's already TEXT. String types report as VARCHAR in
+                # inspection, but Text types report as TEXT, LONGTEXT, etc.
+                col_type_str = str(col['type'])
+                if col_type_str.upper() not in ('TEXT', 'LONGTEXT', 'MEDIUMTEXT'):
+                    # It's a String type, alter to Text
+                    op.alter_column(
+                        'task_groups',
+                        'tasks',
+                        type_=sa.Text(),
+                        existing_type=sa.String(length=1024),
+                        existing_nullable=False,
+                    )
+                break
+
+
+def downgrade():
+    # On downgrade, revert to String(1024) to match the existing initial
+    # migration (d6a54eeeaeb9_initial_migration.py:112).
+    insp = sa.inspect(op.get_bind())
+    if 'task_groups' in insp.get_table_names():
+        for col in insp.get_columns('task_groups'):
+            if col['name'] == 'tasks':
+                col_type_str = str(col['type'])
+                if col_type_str.upper() in ('TEXT', 'LONGTEXT', 'MEDIUMTEXT'):
+                    # It's a TEXT type, revert to String(1024)
+                    op.alter_column(
+                        'task_groups',
+                        'tasks',
+                        type_=sa.String(length=1024),
+                        existing_type=sa.Text(),
+                        existing_nullable=False,
+                    )
+                break

--- a/tests/integration/test_migration_e2e.py
+++ b/tests/integration/test_migration_e2e.py
@@ -12,7 +12,7 @@ from sqlalchemy import create_engine, text
 
 from tests.migration.expected_hex import PLAINTEXT_CASES, USERNAME_CASES
 
-DEV_HEAD = "f1a2b3c4d5e6"
+DEV_HEAD = "d3a4a6a7b352"
 
 pytestmark = [pytest.mark.mysql, pytest.mark.migration]
 

--- a/tests/run_migration_e2e.sh
+++ b/tests/run_migration_e2e.sh
@@ -20,7 +20,7 @@ export DOCKER_PLATFORM="${DOCKER_PLATFORM:-linux/amd64}"
 COMPOSE="${COMPOSE_BIN:-docker compose} -f docker-compose.migration.yml"
 KEEP="${HASHVIEW_MIGRATION_KEEP:-0}"
 MAIN_REF="${HASHVIEW_MAIN_REF:-origin/main}"
-DEV_HEAD="f1a2b3c4d5e6"
+DEV_HEAD="d3a4a6a7b352"
 
 TMP_ROOT="$(mktemp -d)"
 MAIN_WT="$TMP_ROOT/hv-main"

--- a/tests/unit/test_api_task_groups.py
+++ b/tests/unit/test_api_task_groups.py
@@ -1,0 +1,651 @@
+"""Unit tests for the /v1/task_groups routes in hashview/api/routes.py.
+
+Covers: GET /v1/task_groups, POST /v1/task_groups/add,
+POST /v1/task_groups/<id>/tasks, DELETE /v1/task_groups/<id>.
+
+Follows the conventions in tests/unit/test_api_endpoints.py: local fixtures
+(not tests/unit/helpers.py::make_admin, which doesn't set api_key), the
+@pytest.mark.security marker, and cookie auth via client.set_cookie(...,
+domain="localhost.test").
+"""
+
+import json
+from unittest import mock
+
+import pytest
+
+from hashview.api import routes as api_routes
+from hashview.models import Agents, TaskGroups, Tasks, Users
+from hashview.models import db as _db
+
+# ---------------------------------------------------------------------------
+# Local fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def admin_user(app):
+    user = Users(
+        first_name="Admin",
+        last_name="User",
+        email_address="admin@example.test",
+        password="hashed-pw",
+        admin=True,
+        api_key="user-api-key-admin",
+    )
+    _db.session.add(user)
+    _db.session.commit()
+    return user
+
+
+@pytest.fixture()
+def owner_user(app):
+    user = Users(
+        first_name="Owner",
+        last_name="User",
+        email_address="owner@example.test",
+        password="hashed-pw",
+        admin=False,
+        api_key="user-api-key-owner",
+    )
+    _db.session.add(user)
+    _db.session.commit()
+    return user
+
+
+@pytest.fixture()
+def other_user(app):
+    user = Users(
+        first_name="Other",
+        last_name="User",
+        email_address="other@example.test",
+        password="hashed-pw",
+        admin=False,
+        api_key="user-api-key-other",
+    )
+    _db.session.add(user)
+    _db.session.commit()
+    return user
+
+
+@pytest.fixture()
+def authorized_agent(app):
+    agent = Agents(
+        name="agent-1",
+        src_ip="127.0.0.1",
+        uuid="agent-uuid-ok",
+        status="Authorized",
+    )
+    _db.session.add(agent)
+    _db.session.commit()
+    return agent
+
+
+def _json_body(resp):
+    """Return parsed JSON body from a Flask test response."""
+    return json.loads(resp.get_data(as_text=True))
+
+
+def _task(owner, name="t"):
+    t = Tasks(name=name, hc_attackmode=0, owner_id=owner.id)
+    _db.session.add(t)
+    _db.session.commit()
+    return t
+
+
+def _group(owner, task_ids, name="grp"):
+    tg = TaskGroups(name=name, owner_id=owner.id, tasks=json.dumps(list(task_ids)))
+    _db.session.add(tg)
+    _db.session.commit()
+    return tg
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/task_groups
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.security
+def test_list_no_cookie_redirects_to_not_authorized(client):
+    resp = client.get("/v1/task_groups")
+    assert 300 <= resp.status_code < 400
+    assert "/v1/not_authorized" in resp.headers.get("Location", "")
+
+
+@pytest.mark.security
+def test_list_agent_cookie_rejected(client, authorized_agent):
+    client.set_cookie("uuid", authorized_agent.uuid, domain="localhost.test")
+    resp = client.get("/v1/task_groups")
+    assert 300 <= resp.status_code < 400
+    assert "/v1/not_authorized" in resp.headers.get("Location", "")
+
+
+@pytest.mark.security
+def test_list_returns_parsed_task_lists(client, admin_user):
+    t1 = _task(admin_user, "a")
+    t2 = _task(admin_user, "b")
+    _group(admin_user, [t1.id, t2.id], name="G1")
+
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    resp = client.get("/v1/task_groups")
+
+    assert resp.status_code == 200
+    body = _json_body(resp)
+    assert body["status"] == 200
+    groups = body["task_groups"]
+    assert len(groups) == 1
+    assert groups[0]["tasks"] == [t1.id, t2.id]
+    assert all(isinstance(x, int) for x in groups[0]["tasks"])
+
+
+@pytest.mark.security
+def test_list_malformed_tasks_json_degrades_to_empty_list(client, admin_user):
+    tg = TaskGroups(name="Bad", owner_id=admin_user.id, tasks="not json")
+    _db.session.add(tg)
+    _db.session.commit()
+
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    resp = client.get("/v1/task_groups")
+
+    assert resp.status_code == 200
+    body = _json_body(resp)
+    assert body["status"] == 200
+    row = next(g for g in body["task_groups"] if g["name"] == "Bad")
+    assert row["tasks"] == []
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/task_groups/add
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.security
+def test_add_no_cookie_redirects_to_not_authorized(client):
+    resp = client.post(
+        "/v1/task_groups/add",
+        data=json.dumps({"name": "G"}),
+        content_type="application/json",
+    )
+    assert 300 <= resp.status_code < 400
+    assert "/v1/not_authorized" in resp.headers.get("Location", "")
+
+
+@pytest.mark.security
+def test_add_agent_cookie_rejected(client, authorized_agent):
+    client.set_cookie("uuid", authorized_agent.uuid, domain="localhost.test")
+    resp = client.post(
+        "/v1/task_groups/add",
+        data=json.dumps({"name": "G"}),
+        content_type="application/json",
+    )
+    assert 300 <= resp.status_code < 400
+    assert "/v1/not_authorized" in resp.headers.get("Location", "")
+
+
+@pytest.mark.security
+def test_add_cookie_no_user_returns_403(client):
+    # A cookie with no matching Users row can never pass is_authorized(user=True,
+    # ...) in practice (it runs the identical Users.query.filter_by(api_key=...)
+    # lookup), so this downstream 403 branch is only reachable by isolating it
+    # from the auth gate — patch is_authorized to simulate the gate passing.
+    with mock.patch.object(api_routes, "is_authorized", return_value=True):
+        client.set_cookie("uuid", "not-a-real-key", domain="localhost.test")
+        resp = client.post(
+            "/v1/task_groups/add",
+            data=json.dumps({"name": "G"}),
+            content_type="application/json",
+        )
+    body = _json_body(resp)
+    assert body["status"] == 403
+    assert body["msg"] == "User not found"
+
+
+@pytest.mark.security
+def test_add_missing_body_returns_400(client, admin_user):
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    resp = client.post("/v1/task_groups/add", data="", content_type="application/json")
+    body = _json_body(resp)
+    assert body["status"] == 400
+    assert body["msg"] == "Missing task group data in request body"
+
+
+@pytest.mark.security
+def test_add_blank_name_returns_400(client, admin_user):
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    resp = client.post(
+        "/v1/task_groups/add",
+        data=json.dumps({"name": "   "}),
+        content_type="application/json",
+    )
+    body = _json_body(resp)
+    assert body["status"] == 400
+    assert body["msg"] == "Task group name is required"
+
+
+@pytest.mark.security
+def test_add_duplicate_name_returns_400(client, admin_user):
+    _group(admin_user, [], name="Dup")
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    resp = client.post(
+        "/v1/task_groups/add",
+        data=json.dumps({"name": "Dup"}),
+        content_type="application/json",
+    )
+    body = _json_body(resp)
+    assert body["status"] == 400
+    assert body["msg"] == "A task group with that name already exists"
+
+
+@pytest.mark.security
+def test_add_tasks_not_a_list_returns_400(client, admin_user):
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    resp = client.post(
+        "/v1/task_groups/add",
+        data=json.dumps({"name": "G", "tasks": "not-a-list"}),
+        content_type="application/json",
+    )
+    body = _json_body(resp)
+    assert body["status"] == 400
+    assert body["msg"] == "tasks must be a list of task ids"
+
+
+@pytest.mark.security
+def test_add_invalid_task_id_returns_400(client, admin_user):
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    resp = client.post(
+        "/v1/task_groups/add",
+        data=json.dumps({"name": "G", "tasks": ["abc"]}),
+        content_type="application/json",
+    )
+    body = _json_body(resp)
+    assert body["status"] == 400
+    assert body["msg"] == "Invalid task id: 'abc'"
+
+
+@pytest.mark.security
+def test_add_success_creates_group_with_deduped_ordered_tasks(client, admin_user):
+    t1 = _task(admin_user, "a")
+    t2 = _task(admin_user, "b")
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    resp = client.post(
+        "/v1/task_groups/add",
+        data=json.dumps({"name": "NewGroup", "tasks": [t1.id, t2.id, t1.id]}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    body = _json_body(resp)
+    assert body["status"] == 200
+    assert body["type"] == "message"
+    assert body["msg"] == "Task group added"
+    tg_id = body["task_group_id"]
+    assert isinstance(tg_id, int)
+
+    stored = TaskGroups.query.get(tg_id)
+    assert json.loads(stored.tasks) == [t1.id, t2.id]
+
+
+@pytest.mark.security
+def test_add_default_tasks_is_empty_list(client, admin_user):
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    resp = client.post(
+        "/v1/task_groups/add",
+        data=json.dumps({"name": "NoTasks"}),
+        content_type="application/json",
+    )
+    body = _json_body(resp)
+    assert body["status"] == 200
+    stored = TaskGroups.query.get(body["task_group_id"])
+    assert json.loads(stored.tasks) == []
+
+
+# ---------------------------------------------------------------------------
+# POST /v1/task_groups/<id>/tasks
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.security
+def test_set_tasks_no_cookie_redirects(client, owner_user):
+    tg = _group(owner_user, [], name="G")
+    resp = client.post(
+        f"/v1/task_groups/{tg.id}/tasks",
+        data=json.dumps({"tasks": []}),
+        content_type="application/json",
+    )
+    assert 300 <= resp.status_code < 400
+    assert "/v1/not_authorized" in resp.headers.get("Location", "")
+
+
+@pytest.mark.security
+def test_set_tasks_agent_cookie_rejected(client, owner_user, authorized_agent):
+    tg = _group(owner_user, [], name="G")
+    client.set_cookie("uuid", authorized_agent.uuid, domain="localhost.test")
+    resp = client.post(
+        f"/v1/task_groups/{tg.id}/tasks",
+        data=json.dumps({"tasks": []}),
+        content_type="application/json",
+    )
+    assert 300 <= resp.status_code < 400
+    assert "/v1/not_authorized" in resp.headers.get("Location", "")
+
+
+@pytest.mark.security
+def test_set_tasks_cookie_no_user_returns_403(client, owner_user):
+    tg = _group(owner_user, [], name="G")
+    with mock.patch.object(api_routes, "is_authorized", return_value=True):
+        client.set_cookie("uuid", "not-a-real-key", domain="localhost.test")
+        resp = client.post(
+            f"/v1/task_groups/{tg.id}/tasks",
+            data=json.dumps({"tasks": []}),
+            content_type="application/json",
+        )
+    body = _json_body(resp)
+    assert body["status"] == 403
+    assert body["msg"] == "User not found"
+
+
+@pytest.mark.security
+def test_set_tasks_missing_group_returns_real_404(client, owner_user):
+    client.set_cookie("uuid", owner_user.api_key, domain="localhost.test")
+    resp = client.post(
+        "/v1/task_groups/999999/tasks",
+        data=json.dumps({"tasks": []}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 404
+    body = _json_body(resp)
+    assert body == {"status": 404, "type": "Error", "msg": "Task group not found"}
+
+
+@pytest.mark.security
+def test_set_tasks_non_owner_non_admin_returns_body_403(client, owner_user, other_user):
+    tg = _group(owner_user, [], name="G")
+    client.set_cookie("uuid", other_user.api_key, domain="localhost.test")
+    resp = client.post(
+        f"/v1/task_groups/{tg.id}/tasks",
+        data=json.dumps({"tasks": []}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    body = _json_body(resp)
+    assert body["status"] == 403
+    assert body["msg"] == "You do not have rights to modify this task group"
+
+
+@pytest.mark.security
+def test_set_tasks_missing_body_returns_400(client, owner_user):
+    tg = _group(owner_user, [], name="G")
+    client.set_cookie("uuid", owner_user.api_key, domain="localhost.test")
+    resp = client.post(f"/v1/task_groups/{tg.id}/tasks", data="", content_type="application/json")
+    body = _json_body(resp)
+    assert body["status"] == 400
+    assert body["msg"] == "Missing task group data in request body"
+
+
+@pytest.mark.security
+def test_set_tasks_not_a_list_returns_400(client, owner_user):
+    tg = _group(owner_user, [], name="G")
+    client.set_cookie("uuid", owner_user.api_key, domain="localhost.test")
+    resp = client.post(
+        f"/v1/task_groups/{tg.id}/tasks",
+        data=json.dumps({"tasks": "nope"}),
+        content_type="application/json",
+    )
+    body = _json_body(resp)
+    assert body["status"] == 400
+    assert body["msg"] == "tasks must be a list of task ids"
+
+
+@pytest.mark.security
+def test_set_tasks_missing_tasks_key_returns_400(client, owner_user):
+    tg = _group(owner_user, [], name="G")
+    client.set_cookie("uuid", owner_user.api_key, domain="localhost.test")
+    # A body of {} is falsy in Python, so it would hit the "missing body"
+    # branch instead of the "tasks must be a list" branch; use a non-empty
+    # body that simply omits the "tasks" key.
+    resp = client.post(
+        f"/v1/task_groups/{tg.id}/tasks",
+        data=json.dumps({"mode": "replace"}),
+        content_type="application/json",
+    )
+    body = _json_body(resp)
+    assert body["status"] == 400
+    assert body["msg"] == "tasks must be a list of task ids"
+
+
+@pytest.mark.security
+def test_set_tasks_invalid_mode_returns_400(client, owner_user):
+    tg = _group(owner_user, [], name="G")
+    client.set_cookie("uuid", owner_user.api_key, domain="localhost.test")
+    resp = client.post(
+        f"/v1/task_groups/{tg.id}/tasks",
+        data=json.dumps({"tasks": [], "mode": "bogus"}),
+        content_type="application/json",
+    )
+    body = _json_body(resp)
+    assert body["status"] == 400
+    assert body["msg"] == "mode must be 'replace' or 'append'"
+
+
+@pytest.mark.security
+def test_set_tasks_invalid_task_id_returns_400(client, owner_user):
+    tg = _group(owner_user, [], name="G")
+    client.set_cookie("uuid", owner_user.api_key, domain="localhost.test")
+    resp = client.post(
+        f"/v1/task_groups/{tg.id}/tasks",
+        data=json.dumps({"tasks": ["abc"]}),
+        content_type="application/json",
+    )
+    body = _json_body(resp)
+    assert body["status"] == 400
+    assert body["msg"] == "Invalid task id: 'abc'"
+
+
+@pytest.mark.security
+def test_set_tasks_replace_mode_discards_existing(client, owner_user):
+    t1 = _task(owner_user, "a")
+    t2 = _task(owner_user, "b")
+    t3 = _task(owner_user, "c")
+    tg = _group(owner_user, [t1.id, t2.id], name="G")
+
+    client.set_cookie("uuid", owner_user.api_key, domain="localhost.test")
+    resp = client.post(
+        f"/v1/task_groups/{tg.id}/tasks",
+        data=json.dumps({"tasks": [t3.id], "mode": "replace"}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    body = _json_body(resp)
+    assert body["status"] == 200
+    assert body["type"] == "message"
+    assert body["msg"] == "Task group updated"
+    assert body["task_group_id"] == tg.id
+    assert body["tasks"] == [t3.id]
+    assert json.loads(TaskGroups.query.get(tg.id).tasks) == [t3.id]
+
+
+@pytest.mark.security
+def test_set_tasks_replace_is_default_mode(client, owner_user):
+    t1 = _task(owner_user, "a")
+    t2 = _task(owner_user, "b")
+    tg = _group(owner_user, [t1.id], name="G")
+
+    client.set_cookie("uuid", owner_user.api_key, domain="localhost.test")
+    resp = client.post(
+        f"/v1/task_groups/{tg.id}/tasks",
+        data=json.dumps({"tasks": [t2.id]}),
+        content_type="application/json",
+    )
+    body = _json_body(resp)
+    assert body["tasks"] == [t2.id]
+    assert json.loads(TaskGroups.query.get(tg.id).tasks) == [t2.id]
+
+
+@pytest.mark.security
+def test_set_tasks_append_mode_preserves_existing_and_dedupes(client, owner_user):
+    t1 = _task(owner_user, "a")
+    t2 = _task(owner_user, "b")
+    t3 = _task(owner_user, "c")
+    tg = _group(owner_user, [t1.id, t2.id], name="G")
+
+    client.set_cookie("uuid", owner_user.api_key, domain="localhost.test")
+    resp = client.post(
+        f"/v1/task_groups/{tg.id}/tasks",
+        data=json.dumps({"tasks": [t2.id, t3.id], "mode": "append"}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    body = _json_body(resp)
+    assert body["tasks"] == [t1.id, t2.id, t3.id]
+    assert json.loads(TaskGroups.query.get(tg.id).tasks) == [t1.id, t2.id, t3.id]
+
+
+@pytest.mark.security
+def test_set_tasks_append_mode_malformed_existing_json_falls_back_to_empty(client, owner_user):
+    t1 = _task(owner_user, "a")
+    tg = TaskGroups(name="G", owner_id=owner_user.id, tasks="not json")
+    _db.session.add(tg)
+    _db.session.commit()
+
+    client.set_cookie("uuid", owner_user.api_key, domain="localhost.test")
+    resp = client.post(
+        f"/v1/task_groups/{tg.id}/tasks",
+        data=json.dumps({"tasks": [t1.id], "mode": "append"}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    body = _json_body(resp)
+    assert body["tasks"] == [t1.id]
+    assert json.loads(TaskGroups.query.get(tg.id).tasks) == [t1.id]
+
+
+@pytest.mark.security
+def test_set_tasks_admin_can_update_others_group(client, owner_user, admin_user):
+    t1 = _task(owner_user, "a")
+    tg = _group(owner_user, [], name="G")
+
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    resp = client.post(
+        f"/v1/task_groups/{tg.id}/tasks",
+        data=json.dumps({"tasks": [t1.id]}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    body = _json_body(resp)
+    assert body["status"] == 200
+    assert json.loads(TaskGroups.query.get(tg.id).tasks) == [t1.id]
+
+
+# ---------------------------------------------------------------------------
+# DELETE /v1/task_groups/<id>
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.security
+def test_delete_no_cookie_redirects(client, owner_user):
+    tg = _group(owner_user, [], name="G")
+    resp = client.delete(f"/v1/task_groups/{tg.id}")
+    assert 300 <= resp.status_code < 400
+    assert "/v1/not_authorized" in resp.headers.get("Location", "")
+
+
+@pytest.mark.security
+def test_delete_agent_cookie_rejected(client, owner_user, authorized_agent):
+    tg = _group(owner_user, [], name="G")
+    client.set_cookie("uuid", authorized_agent.uuid, domain="localhost.test")
+    resp = client.delete(f"/v1/task_groups/{tg.id}")
+    assert 300 <= resp.status_code < 400
+    assert "/v1/not_authorized" in resp.headers.get("Location", "")
+
+
+@pytest.mark.security
+def test_delete_cookie_no_user_returns_403(client, owner_user):
+    tg = _group(owner_user, [], name="G")
+    with mock.patch.object(api_routes, "is_authorized", return_value=True):
+        client.set_cookie("uuid", "not-a-real-key", domain="localhost.test")
+        resp = client.delete(f"/v1/task_groups/{tg.id}")
+    body = _json_body(resp)
+    assert body["status"] == 403
+    assert body["msg"] == "User not found"
+
+
+@pytest.mark.security
+def test_delete_missing_group_returns_real_404(client, owner_user):
+    client.set_cookie("uuid", owner_user.api_key, domain="localhost.test")
+    resp = client.delete("/v1/task_groups/999999")
+    assert resp.status_code == 404
+    body = _json_body(resp)
+    assert body == {"status": 404, "type": "Error", "msg": "Task group not found"}
+
+
+@pytest.mark.security
+def test_delete_non_owner_non_admin_returns_body_403(client, owner_user, other_user):
+    tg = _group(owner_user, [], name="G")
+    client.set_cookie("uuid", other_user.api_key, domain="localhost.test")
+    resp = client.delete(f"/v1/task_groups/{tg.id}")
+    assert resp.status_code == 200
+    body = _json_body(resp)
+    assert body["status"] == 403
+    assert body["msg"] == "You do not have rights to delete this task group"
+    assert TaskGroups.query.get(tg.id) is not None
+
+
+@pytest.mark.security
+def test_delete_admin_can_delete_others_group(client, owner_user, admin_user):
+    tg = _group(owner_user, [], name="G")
+    tg_id = tg.id
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    resp = client.delete(f"/v1/task_groups/{tg_id}")
+    assert resp.status_code == 200
+    body = _json_body(resp)
+    assert body["status"] == 200
+    assert TaskGroups.query.get(tg_id) is None
+
+
+@pytest.mark.security
+def test_delete_success(client, owner_user):
+    tg = _group(owner_user, [], name="G")
+    tg_id = tg.id
+    client.set_cookie("uuid", owner_user.api_key, domain="localhost.test")
+    resp = client.delete(f"/v1/task_groups/{tg_id}")
+    assert resp.status_code == 200
+    body = _json_body(resp)
+    assert body["status"] == 200
+    assert body["type"] == "message"
+    assert body["msg"] == "Task group deleted"
+    assert body["task_group_id"] == tg_id
+    assert TaskGroups.query.get(tg_id) is None
+
+
+# ---------------------------------------------------------------------------
+# Storage-format regression: TaskGroups.tasks used to be String(256), which
+# truncated JSON for groups with enough task ids. Verify the widened TEXT
+# column round-trips a large id list without truncation, end to end through
+# the add + list routes.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.security
+def test_add_and_list_large_task_list_is_not_truncated(client, admin_user):
+    tasks = [_task(admin_user, f"t{i}") for i in range(120)]
+    task_ids = [t.id for t in tasks]
+    # Sanity: the serialized ids alone must exceed the old String(256) limit.
+    assert len(json.dumps(task_ids)) > 256
+
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    resp = client.post(
+        "/v1/task_groups/add",
+        data=json.dumps({"name": "BigGroup", "tasks": task_ids}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    body = _json_body(resp)
+    assert body["status"] == 200
+    tg_id = body["task_group_id"]
+
+    stored = TaskGroups.query.get(tg_id)
+    assert json.loads(stored.tasks) == task_ids
+
+    list_resp = client.get("/v1/task_groups")
+    list_body = _json_body(list_resp)
+    row = next(g for g in list_body["task_groups"] if g["id"] == tg_id)
+    assert row["tasks"] == task_ids

--- a/tests/unit/test_migration_drift_idempotency.py
+++ b/tests/unit/test_migration_drift_idempotency.py
@@ -24,7 +24,7 @@ from sqlalchemy import text
 
 MIGRATIONS_DIR = str(Path(__file__).resolve().parents[2] / "migrations")
 BASE_REV = "8027c2d2b40a"      # what the drifted field DB was stamped at
-DEV_HEAD = "f1a2b3c4d5e6"
+DEV_HEAD = "d3a4a6a7b352"
 
 
 def _drifted_app(tmp_path, drop_columns=()):


### PR DESCRIPTION
## Summary

Closes #401. Adds four `/v1` endpoints so a curated task set can be assembled entirely over the API, matching the auth/response conventions already used by `hashview/api/routes.py`:

- `GET /v1/task_groups` — list groups, `tasks` returned as a parsed array of ints (not the raw stored string)
- `POST /v1/task_groups/add` — `{"name": ..., "tasks": [id, ...]}`, creates the group and its ordered membership in one call
- `POST /v1/task_groups/<id>/tasks` — `{"tasks": [...], "mode": "replace"|"append"}`, set or incrementally build membership
- `DELETE /v1/task_groups/<id>` — same ownership rule the UI applies (`user.admin or owner_id == user.id`)

All four are user-only, mirror `v1_api_add_task`/`v1_api_delete_job`'s structure exactly, and come with full OpenAPI spec entries (required — `test_openapi_spec.py` enforces two-way parity between the spec and the `/v1` url_map).

## The storage question #401 left open

`TaskGroups.tasks` stores a serialized list of task ids, written historically via Python's `str(list)` (valid JSON only by luck) and read via `json.loads()`. There was also a **real model/DB mismatch nobody had reconciled**: `models.py` declared `String(256)`, but the initial migration actually created `VARCHAR(1024)`, and no later migration touched it — so depending on how a given deployment's schema was created, the effective cap was either ~10 or ~40 four-digit task ids, enforced nowhere in code. `task_groups_assigned_tasks_add_task` in the UI blueprint appends and commits with no length check, so a group that outgrew its column got its `tasks` string truncated mid-id, and the next `json.loads()` on it raised — taking out `/task_groups` for *every* group, not just the oversized one.

This PR resolves it by widening the column to `TEXT` (migration `d3a4a6a7b352`, idempotent under schema drift — it inspects the live column type before altering, so it's safe whether the target DB currently has 256, 1024, or is already TEXT) and switching every write site (UI blueprint + the new API) to `json.dumps()`. This is the smaller-blast-radius option versus normalizing into a `task_group_tasks` join table with an explicit order column — that's the architecturally cleaner end state and is called out as a natural follow-up, but is a much larger, higher-risk refactor than an unsolicited PR should attempt in one pass.

**No backfill needed for existing rows:** `str([1, 2, 3])` produces `'[1, 2, 3]'`, which is already valid JSON, so every non-truncated legacy row parses identically under `json.loads()` before and after this change. Rows that were *already* truncated before this fix are not repaired by the migration — the new API's list/append paths degrade a malformed row to `[]` rather than 500ing, but the UI's own unguarded `json.loads()` call sites (`task_groups_assigned_tasks`, `jobs_assign_task_group`) will still raise on one if it exists. If any deployment has hit the truncation bug already, its `task_groups` table is worth a manual check before/after this migration.

## Scope

Deliberately **not** included: hardening the UI blueprint's own auth gaps (`add_task`/`remove_task`/`promote_task`/`demote_task` have no ownership check at all, and are state-changing `GET` routes with no CSRF protection). Those are real, pre-existing issues this PR doesn't introduce or worsen — they belong in a separate, security-focused PR rather than riding along with a feature addition.

Follow-ups filed rather than folded in here, since each is either out of this PR's blast radius or affects more than these four endpoints:
- #439 — `TaskGroups.name` has no unique DB constraint (TOCTOU on the duplicate-name check; pre-existing in the UI form, the API just makes it easier to hit)
- #440 — a repo-wide `/v1` JSON-body pattern (`get_json(silent=True)` + falsy check) 500s on a valid-but-non-dict body like a top-level array; inherited verbatim from `v1_api_add_task`, worth fixing for every `/v1` endpoint in one pass rather than just the two added here
- #441 — `hashview/api/routes.py` is now ~2263 lines / 37 handlers; a sub-module split by resource is worth doing as its own pure-code-motion PR

## Verification

- `python -m openapi_spec_validator hashview/api_docs/openapi.yaml` — OK
- `python -m pytest tests/unit/test_openapi_spec.py -q` — 7 passed (spec↔route parity)
- `python -m pytest tests/unit/test_api_task_groups.py -q` — 37 passed (new endpoint coverage, including a regression test that a group serializing past the old 256-char cap round-trips intact)
- `python -m pytest tests/unit/test_task_groups_routes.py tests/unit/test_task_groups_routes_branches.py -q` — 50 passed (existing UI-blueprint coverage, unaffected by the `str()`→`json.dumps()` write-site change)
- `python -m pytest tests/unit/test_migration_drift_idempotency.py tests/unit/test_migration_smoke.py -q` — 3 passed (migration head pins updated, drift-guard logic verified)
- Full pre-push gate (`tests/unit tests/security tests/agent_unit`): **1674 passed, 2 skipped, 50 xfailed, 1 xpassed** (the 1 xpassed is a pre-existing, unrelated, explicitly non-strict marker in `test_customers_routes_branches.py` documenting a known CI-flake bug tracked by #208/#258/#259 — untouched by this branch)
- `ruff check .` clean on all changed files
- `tests/check_function_coverage.py` — 0 zero-coverage functions

`tests/integration/test_migration_e2e.py` (the one test that exercises the actual `VARCHAR`→`TEXT` `ALTER` against real MySQL) is Docker-gated and wasn't run locally — please confirm CI's `db-parity.yml` picks it up on this PR.