### PR TITLE
docs: add CONTRIBUTING.md, PR/issue templates

### DIFF
--- a/.githooks/safe-allowlist.txt
+++ b/.githooks/safe-allowlist.txt
@@ -96,6 +96,10 @@ control/wordlists/deadbeef
 # surfaced whenever the allowlist itself is edited.
 ignore trustedsec mentions in the example
 
+# --- CONTRIBUTING.md false positives ---
+# Public documentation link to the Conventional Commits spec.
+conventionalcommits\.org
+
 # --- tests/unit/test_issue_xfail_import_hash_type_int.py false positives ---
 # A throwaway MySQL 4.1 (hashcat -m 300) SHA1 test digest; its 40 hex chars
 # trip the AWS-secret-key heuristic. Not a credential.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,92 @@
+name: Bug report
+description: Report a problem with Hashview server or agent
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Please **do not** paste real
+        hashes, plaintext passwords, potfiles, or anything identifying a
+        client/engagement here — use synthetic examples instead.
+
+  - type: input
+    id: version
+    attributes:
+      label: Hashview version
+      description: Server release/commit, and agent VERSION.TXT if relevant
+      placeholder: e.g. v0.8.3, or commit SHA
+    validations:
+      required: true
+
+  - type: dropdown
+    id: deployment
+    attributes:
+      label: Deployment
+      options:
+        - Docker Compose (dev setup)
+        - Bare metal / manual install
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      options:
+        - Server
+        - Agent
+        - Both / not sure
+    validations:
+      required: true
+
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version
+      placeholder: e.g. 3.11.8
+
+  - type: input
+    id: db-version
+    attributes:
+      label: Database version
+      placeholder: e.g. MySQL 8.0, MariaDB 11
+
+  - type: input
+    id: hashcat-version
+    attributes:
+      label: Hashcat version (agent-side, if relevant)
+      placeholder: e.g. 6.2.6
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Use synthetic hashes/wordlists, not real engagement data
+      placeholder: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Server/agent logs or a traceback. Redact anything sensitive.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Existing issues
+    url: https://github.com/hashview/hashview/issues
+    about: Check whether your issue or idea has already been reported before filing a new one.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,43 @@
+name: Feature request
+description: Suggest an idea or enhancement for Hashview
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before filing, check [existing issues](https://github.com/hashview/hashview/issues)
+        for the same request — if you find one, upvote/comment on it instead of
+        opening a duplicate.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: What are you trying to do that Hashview doesn't support today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: What should happen instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches, workarounds, or why they fall short
+
+  - type: dropdown
+    id: contribute
+    attributes:
+      label: Would you be willing to submit a PR for this?
+      options:
+        - "Yes"
+        - "Maybe, with some guidance"
+        - "No"
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Summary
+
+<!-- What does this PR do, and why? Link the issue it addresses. -->
+
+Closes #
+
+## Checklist
+
+- [ ] This PR targets `v0.8.3-dev` (the current dev branch), **not** `main`
+- [ ] Commit subjects follow `type(scope): subject` (see [CONTRIBUTING.md](../CONTRIBUTING.md#commit-messages))
+- [ ] `scripts/preflight.sh` passes locally
+- [ ] Pushed through the pre-push hook (not `--no-verify`)
+- [ ] New/changed behavior has test coverage
+- [ ] If a route changed: `hashview/api_docs/openapi.yaml` is updated
+- [ ] If a migration was added: it's MySQL/MariaDB-safe, and `DEV_HEAD` in
+      `tests/run_migration_e2e.sh` is bumped
+- [ ] If user-visible: `CHANGELOG.md` has an entry under `## Current Release`
+- [ ] N/A items above are just left unchecked, not deleted
+
+## Testing
+
+<!-- How did you verify this? Commands run, suites exercised. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,226 @@
+# Contributing to Hashview
+
+Thanks for considering a contribution. This document covers the process:
+branching, commit style, local gates, and the gotchas that repeatedly bite new
+PRs. For suite-by-suite test detail, see [`TESTING.md`](TESTING.md) — this doc
+won't repeat it.
+
+## Before you start
+
+Check the [Issues](https://github.com/hashview/hashview/issues) page first. If
+there's no existing issue for what you want to do, open one — bug or feature
+request — so we can discuss the approach before you sink time into code. We
+accept pull requests; see the [feature requests](README.md#feature-requests)
+note in the README if you'd rather just ask for something.
+
+## Branching — target the dev branch, not `main`
+
+**Open PRs against `v0.8.3-dev`, not `main`.** `main` tracks the last release;
+active development happens on the current `vX.Y.Z-dev` branch. Because
+`origin/HEAD` points at `main`, GitHub will pre-select `main` as your PR base —
+change it explicitly before submitting.
+
+Branch names follow a `type/short-description` pattern, matching the prefixes
+already in use on `origin`: `feat/`, `fix/`, `test/`, `chore/`, `ci/`, `docs/`.
+For example: `fix/hashfile-listing-group-by`, `test/api-hashfile-listing-perf`.
+
+PRs are merged with a regular merge commit (not squash or rebase).
+
+## Commit messages
+
+This repo uses [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+type(scope): subject
+
+optional body
+```
+
+Types in use: `feat`, `fix`, `test`, `docs`, `style`, `refactor`, `perf`,
+`chore`, `ci`. Scopes are usually a module or subsystem name (`api`, `jobs`,
+`wordlists`, `githooks`, `migrations`, `analytics`). Reference an issue with
+`(#123)` at the end of the subject when one exists.
+
+Keep commits atomic — one logical change per commit. Don't bundle an unrelated
+lint fix or refactor into a feature commit.
+
+## Setting up a dev environment
+
+```bash
+git clone https://github.com/hashview/hashview
+cd hashview
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt -r requirements-dev.txt
+pre-commit install
+```
+
+Enable the pre-push hook (see below) — it's opt-in per clone:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+Use a **relative** path (as above), not an absolute one, so each git worktree
+picks up its own `.githooks` copy instead of another checkout's.
+
+Config:
+
+```bash
+cp hashview/config.conf.example hashview/config.conf
+```
+
+Edit it with real DB credentials and a random `SECRET_KEY`. `config.conf` is
+gitignored — never commit it. For Docker, set the DB host to `db` and match
+`MYSQL_PASSWORD` in `docker-compose.yml`.
+
+Before running the test suites, create the runtime control directories (they're
+gitignored but expected to exist):
+
+```bash
+mkdir -p hashview/control/{hashes,logs,rules,tmp,wordlists,wordlists_import}
+```
+
+Run the app:
+
+```bash
+./setup.py
+./hashview.py --debug
+```
+
+For local end-to-end / Docker testing, copy the `.env.test` template documented
+in [`TESTING.md`](TESTING.md#environment-files) into your own `.env.test`
+(gitignored) — don't commit real credentials there either.
+
+## The pre-push hook
+
+`.githooks/pre-push` is the main safety net before code leaves your machine.
+It runs in two phases:
+
+1. **Secret scan** over the lines you're pushing (added diff lines, plus your
+   commit messages) for AWS keys, `password=`/`token=`/`api_key=`-style
+   assignments, PEM blocks, **any URL**, **any IP address**, and `.env` file
+   adds/modifications, plus whatever's in your local `.sensitive-keywords`
+   (gitignored — this is where you'd add engagement- or client-specific
+   keywords; never commit that file).
+2. **CI mirror**: `ruff check .` → `bandit` (against the baseline) →
+   `openapi-spec-validator` → `pytest tests/unit tests/security
+   tests/agent_unit`. Skipped entirely on a delete-only push.
+
+The hook prefers `.venv/bin/python`; if you don't have a `.venv` it falls back
+to a system `python3` that likely lacks these tools and will fail confusingly.
+
+If phase 1 flags something that's a legitimate false positive (an example URL
+in a test fixture, a dummy API key, etc.), add a narrowly-scoped regex to the
+**tracked** `.githooks/safe-allowlist.txt` rather than working around the hook.
+Read the comments at the top of that file — patterns must match the *entire hit
+line*, so anchor on the surrounding file path or unique text, not just the
+trigger substring.
+
+Don't push with `--no-verify` — it skips the secret scan along with everything
+else. If a gate is genuinely broken (not your change's fault), say so in the PR
+rather than bypassing silently.
+
+## Local gates before opening a PR
+
+Run everything CI runs, in one shot:
+
+```bash
+scripts/preflight.sh          # all static gates + unit tests
+scripts/preflight.sh --fast   # skip pip-audit and unit tests
+scripts/preflight.sh --e2e    # also run the docker e2e harness (slow)
+```
+
+It runs, in order: `ruff check hashview/ hashview.py`, `bandit` against the
+baseline, `openapi-spec-validator`, `pip-audit`, `pylint`, and
+`pytest tests/unit`.
+
+**Note:** `preflight.sh` lints only `hashview/ hashview.py`, while CI's
+`lint.yml` runs `ruff check .` across the whole repo (including `tests/`,
+`install/`, `migrations/`). If you've touched files outside `hashview/`, also
+run `ruff check .` directly, or trust CI to catch it.
+
+Lint/format config lives in `pyproject.toml` (`[tool.ruff]`: Python 3.11
+target, 100-column lines, `select = ["E","F","I","B","UP"]`) and `.pylintrc`.
+`.bandit-baseline.json` is committed — only *new* Bandit findings fail a build,
+so don't need to fix pre-existing ones in unrelated code.
+
+## Tests
+
+See [`TESTING.md`](TESTING.md) for the full suite map, markers, and CI
+workflow table. The short version:
+
+- The fast, always-imported gate is `pytest tests/unit tests/security
+  tests/agent_unit` — this is what the pre-push hook and `unit-tests.yml` run.
+- Everything else (`tests/integration` with `-m mysql`, `tests/e2e`,
+  `tests/crack`) is opt-in and needs a live DB, Docker stack, or Playwright.
+- Coverage floors are **ratchets, not targets** — 85% line+branch on
+  `hashview`, 75% on `agent`, plus a function-coverage gate that fails on any
+  function with zero executed body lines. Raise these as coverage improves;
+  never lower them.
+- If a bug is real but not yet fixed, add a **strict `xfail`** test named after
+  the issue (see `tests/unit/test_api_issues_xfail.py`,
+  `tests/security/test_csrf_xfail.py` for examples) rather than leaving it
+  undocumented. Remove the marker in the same PR that fixes the bug — strict
+  xfail turns an unexpected pass into a failure, so it'll tell you when it's
+  safe to drop.
+- A brand-new `tests/<subdir>/` needs its own `conftest.py` (even a trivial
+  one) — the root e2e fixture is autouse and will silently skip everything
+  under an unrecognized directory otherwise.
+
+## CI workflows
+
+All of the following run on push and PR unless noted:
+
+| Workflow | Gates |
+| --- | --- |
+| `unit-tests.yml` | Unit + security + agent tests across Python 3.11/3.12/3.13, coverage ratchets, function-coverage gate |
+| `lint.yml` | `ruff check .` (repo-wide), Bandit vs. baseline, `pip-audit`, OpenAPI spec validation |
+| `pylint.yml` | Pylint across 3.11/3.12/3.13 (**push only**, not PR) |
+| `e2e.yml` | Playwright e2e suite against a Docker Compose stack, strict mode |
+| `e2e-crack.yml` | Multi-agent real-crack harness against a pinned, checksummed rockyou.txt |
+| `db-parity.yml` | Real Alembic migration chain + `-m mysql` integration tests against MariaDB |
+| `migration-e2e.yml` | `main` → dev upgrade path, using built Docker images of both |
+| `mutation.yml` | Weekly `mutmut` campaign — quality signal only, never blocks a PR |
+
+CI never runs real hashcat; `Dockerfile.agent` ships a shim binary at
+`/opt/hcshim/hashcat` for the agent tests.
+
+## Checklists for specific kinds of changes
+
+**Database migration** (`migrations/versions/`)
+- The unit suite runs on SQLite, so it can't catch MySQL-only DDL problems —
+  `db-parity.yml` is what does. Keep your migration MySQL/MariaDB-safe.
+- Bump the hardcoded `DEV_HEAD` in `tests/run_migration_e2e.sh` to your new
+  head revision, or `migration-e2e.yml` will test against the wrong target.
+- `migrations/versions/` is excluded from both ruff and pylint (autogenerated).
+
+**`/v1` API / route change**
+- Update `hashview/api_docs/openapi.yaml` to match. `tests/unit/test_openapi_spec.py`
+  enforces route↔spec parity and will fail otherwise.
+
+**New mutating POST route**
+- There is no global `CSRFProtect`. CSRF protection only comes from
+  `FlaskForm.validate_on_submit()`, so any new state-changing form route must
+  use a `FlaskForm`, not raw `request.form` parsing.
+
+**Hashview-Agent change** (`install/hashview-agent/`)
+- Has its own `requirements.txt` and `VERSION.TXT`. Agents require hashcat
+  6.2.x+ and must be approved by an admin after their first check-in.
+
+**User-visible change**
+- Add an entry to `CHANGELOG.md` under `## Current Release`, in the existing
+  grouped `### Added` / feature-heading style, with the issue number if there
+  is one.
+
+## Things not to commit
+
+`config.conf`, `.env.test`, `.sensitive-keywords`, and local artifacts like
+`.coverage`, `coverage.json`, `.pytest_cache/`, `.ruff_cache/`, `.hypothesis/`,
+and `.venv/`. All of these are already gitignored — if `git status` shows one
+as untracked-but-should-stay-that-way, don't `git add -A` past it.
+
+## License
+
+By contributing, you agree your changes are licensed under the project's
+[GNU GPLv3](LICENSE).

--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ The following are to install hashview after the mysql db has been setup.
 sudo apt-get install python3 python3-pip python3-venv
 git clone https://github.com/hashview/hashview
 cd hashview
-python3 -m venv venv
-source venv/bin/activate
+python3 -m venv .venv
+source .venv/bin/activate
 pip install -r requirements.txt
 ./setup.py
 ./hashview.py # (note you can add a --debug if you are attempting to troubleshoot an issue)
 ```
-Note: run `./setup.py` and `./hashview.py` with the virtual environment active (`source venv/bin/activate`).
+Note: run `./setup.py` and `./hashview.py` with the virtual environment active (`source .venv/bin/activate`).
 
 #### 4) Log into your hashview server
 Navigate to your server, default port is 8443. https://IP:8443
@@ -90,7 +90,7 @@ python3 ./hashview-agent.py
 
 ### Developing and Contributing
 
-Please see the [Contribution Guide](https://github.com/hashview/hashview/wiki/Contributing) for how to develop and contribute.
+Please see [CONTRIBUTING.md](CONTRIBUTING.md) for how to develop and contribute.
 If you have any problems, please consult [Issues](https://github.com/hashview/hashview/issues) page first. If you don't see a related issue, feel free to add one and we'll help.
 
 ### Feature Requests

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -4,11 +4,15 @@
 #
 # Mirrors the GitHub Actions workflows so failures are caught on your machine
 # instead of after a push:
-#   .github/workflows/lint.yml    -> ruff, bandit (vs baseline), pip-audit, openapi
-#   .github/workflows/pylint.yml  -> pylint (rules + fail-under from .pylintrc)
-#   .github/workflows/e2e.yml     -> docker-compose Playwright harness  (opt-in: --e2e)
-# Plus the unit-test suite (tests/unit/), which has no CI job but is meant to be
-# run locally (see CLAUDE.md / tests/unit/conftest.py — in-memory SQLite, no DB).
+#   .github/workflows/lint.yml        -> ruff, bandit (vs baseline), pip-audit, openapi
+#   .github/workflows/pylint.yml      -> pylint (rules + fail-under from .pylintrc)
+#   .github/workflows/unit-tests.yml  -> tests/unit/ (in-memory SQLite, no DB)
+#   .github/workflows/e2e.yml         -> docker-compose Playwright harness  (opt-in: --e2e)
+#
+# Note: this script's ruff gate is scoped to hashview/ hashview.py, narrower
+# than lint.yml's repo-wide `ruff check .` — if you've touched tests/, install/,
+# or migrations/, also run `ruff check .` directly or let CI catch it.
+# See CONTRIBUTING.md for the full contributor workflow.
 #
 # Tool versions are pinned in requirements-dev.txt; install once with:
 #   pip install -r requirements.txt -r requirements-dev.txt
@@ -114,7 +118,7 @@ fi
 run_gate "pylint" "" \
   "$PY" -m pylint --jobs=1 --rcfile=.pylintrc --output-format=colorized --reports=n --score=y hashview/ hashview.py
 
-# 6. Unit tests — in-memory SQLite, no DB/docker. No CI job; run locally.
+# 6. Unit tests — in-memory SQLite, no DB/docker. Matches unit-tests.yml.
 if [ "$RUN_UNIT" -eq 1 ]; then
   run_gate "unit tests" "" \
     "$PY" -m pytest tests/unit -q


### PR DESCRIPTION
## Summary
- Adds `CONTRIBUTING.md`, documenting the process that previously existed only as tribal knowledge and scattered tooling: PRs target `v0.8.3-dev` (not `main`), Conventional Commits, the opt-in pre-push secret-scan/lint/test hook, local preflight gates, coverage ratchets, the strict-xfail-per-issue convention, and per-change-type checklists (migrations need MySQL-safe DDL + a `DEV_HEAD` bump, route changes need `openapi.yaml` updated, new mutating POST routes need a `FlaskForm` for CSRF).
- Adds `.github/PULL_REQUEST_TEMPLATE.md` and `.github/ISSUE_TEMPLATE/` (bug report + feature request forms, plus config disabling blank issues).
- Repoints `README.md`'s "Developing and Contributing" section from the GitHub wiki to the new in-repo doc, and fixes two stale inconsistencies found along the way: README said `venv` where every other doc/script/hook expects `.venv`, and `scripts/preflight.sh`'s header comment claimed unit tests have no CI job and referenced a nonexistent `CLAUDE.md`.

Closes the gap where contributors have no in-repo guidance and can easily open a PR against the wrong base branch or skip local gates.

## Test plan
- [x] `pytest tests/unit/test_openapi_spec.py` — sanity check that the app still imports/runs after the doc-only edits
- [x] Validated all three `.github/ISSUE_TEMPLATE/*.yml` files parse as YAML
- [x] Pushed through the actual pre-push hook (not `--no-verify`) — full local gate (ruff, bandit, openapi, `tests/unit tests/security tests/agent_unit`) passed: 1677 passed, 2 skipped, 61 xfailed
- [ ] Confirm on GitHub that the PR template renders and both issue forms appear under "New issue"