### PR TITLE
fix(jobs): move "+ Add new customer..." to top of dropdown (#133)

### DIFF
--- a/hashview/templates/jobs_add.html.j2
+++ b/hashview/templates/jobs_add.html.j2
@@ -60,10 +60,10 @@
                 <label class="field-label" for="customer_id">Customer <span class="req">*</span></label>
                 <select class="select" id="customer_id" name="customer_id" onchange="showDiv()" required>
                     <option value>--SELECT--</option>
+                    <option value='add_new'>+ Add new customer...</option>
                     {% for customer in customers %}
                         <option value='{{customer.id}}'>{{customer.name}}</option>
                     {% endfor %}
-                    <option value='add_new'>+ Add new customer...</option>
                 </select>
             </div>
 

--- a/tests/e2e/test_job_creation.py
+++ b/tests/e2e/test_job_creation.py
@@ -6,6 +6,26 @@ from playwright.sync_api import expect
 
 
 @pytest.mark.e2e
+def test_job_creation_customer_add_new_option_is_first(page, live_server, login):
+    """#133: '+ Add new customer...' must render before every seeded customer,
+    right after the '--SELECT--' placeholder, so it's reachable without
+    scrolling past an alphabetized customer list."""
+    login()
+    page.get_by_role("link", name="Jobs").click()
+    page.get_by_role("link", name="New Job", exact=True).click()
+    expect(page.get_by_role("heading", name="Create Job")).to_be_visible()
+
+    values = page.locator("#customer_id option").evaluate_all(
+        "opts => opts.map(o => o.value)"
+    )
+    assert values[0] == "", f"expected '--SELECT--' placeholder first, got {values}"
+    assert values[1] == "add_new", (
+        f"expected 'add_new' immediately after the placeholder, got {values}"
+    )
+    assert "add_new" not in values[2:], "add_new option must not be duplicated"
+
+
+@pytest.mark.e2e
 def test_job_creation_flow(page, live_server, login):
     login()
     customer_id = os.getenv("HASHVIEW_E2E_CUSTOMER_ID")

--- a/tests/e2e/test_job_creation.py
+++ b/tests/e2e/test_job_creation.py
@@ -11,6 +11,18 @@ def test_job_creation_customer_add_new_option_is_first(page, live_server, login)
     right after the '--SELECT--' placeholder, so it's reachable without
     scrolling past an alphabetized customer list."""
     login()
+
+    # Seed a real customer through the actual UI flow so the dropdown has at
+    # least one entry to be out-of-order relative to — an empty customer list
+    # would make the ordering assertions vacuously true.
+    page.goto(f"{live_server}/customers", wait_until="domcontentloaded")
+    page.evaluate("document.getElementById('add-customer-modal').showModal()")
+    customer_name = f"E2E Order Check {os.urandom(4).hex()}"
+    page.locator("#add-customer-modal input[name='name']").fill(customer_name)
+    page.locator("#add-customer-modal button[type=submit]").click()
+    page.wait_for_load_state("domcontentloaded")
+    expect(page.get_by_text(f"Customer {customer_name} added!")).to_be_visible()
+
     page.get_by_role("link", name="Jobs").click()
     page.get_by_role("link", name="New Job", exact=True).click()
     expect(page.get_by_role("heading", name="Create Job")).to_be_visible()

--- a/tests/unit/test_jobs_routes.py
+++ b/tests/unit/test_jobs_routes.py
@@ -147,6 +147,25 @@ def test_jobs_add_get_renders(app, client):
     assert resp.status_code == 200
 
 
+def test_jobs_add_customer_dropdown_lists_add_new_first(app, client):
+    """#133: '+ Add new customer...' must precede every customer option so it's
+    reachable without scrolling past an alphabetized customer list."""
+    admin = make_admin()
+    login(client, admin)
+    make_customer(name="Acme Corp")
+    make_customer(name="Zeta Inc")
+
+    resp = client.get("/jobs/add")
+    assert resp.status_code == 200
+    body = resp.data
+
+    add_new = body.index(b"value='add_new'")
+    assert add_new < body.index(b"Acme Corp")
+    assert add_new < body.index(b"Zeta Inc")
+    # --SELECT-- stays first so it remains the default-selected placeholder
+    assert body.index(b"--SELECT--") < add_new
+
+
 def test_jobs_add_post_creates_job(app, client):
     admin = make_admin()
     login(client, admin)


### PR DESCRIPTION
## Summary
- On the Create Job page, the Customer dropdown appended "+ Add new customer..." after the entire alphabetized customer list, forcing a scroll to reach it once there are 10+ customers (#133).
- Moves the option to render immediately after the "--SELECT--" placeholder instead.
- Template-only change; the `add_new` sentinel handling and customer sort order are unchanged.

## Test plan
- [x] Added `tests/unit/test_jobs_routes.py::test_jobs_add_customer_dropdown_lists_add_new_first` — asserts DOM order on the rendered page; mutation-verified (fails when reverted).
- [x] Added `tests/e2e/test_job_creation.py::test_job_creation_customer_add_new_option_is_first` — Playwright test that seeds a real customer via the UI and asserts dropdown order; verified against a local Docker stack (fails on old ordering, passes on the fix).
- [x] Full suite: `pytest tests/unit tests/security tests/agent_unit` — 1678 passed, 0 failures.
- [x] `ruff check` clean.

Closes #133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)