### PR TITLE
fix: default pwdump Hash Type dropdown to NTLM (1000)

### DIFF
--- a/hashview/jobs/forms.py
+++ b/hashview/jobs/forms.py
@@ -57,7 +57,7 @@ class JobsNewHashFileForm(FlaskForm):
     shadow_hash_type = SelectField('Hash Type', choices=SHADOW_HASH_TYPE_CHOICES)
 
     pwdump_hash_type = SelectField('Hash Type', choices=[  ('', '------SELECT------'),
-													('1000', '(1000) NTLM')])
+													('1000', '(1000) NTLM')], default='1000')
 
     netntlm_hash_type = SelectField('Hash Type', choices=NETNTLM_HASH_TYPE_CHOICES)
 

--- a/tests/unit/test_jobs_routes.py
+++ b/tests/unit/test_jobs_routes.py
@@ -6,7 +6,7 @@ and DB side effects against the in-memory app.
 """
 
 
-from hashview.jobs.forms import JobsForm
+from hashview.jobs.forms import JobsForm, JobsNewHashFileForm
 from hashview.models import (
     Hashes,
     HashfileHashes,
@@ -491,3 +491,9 @@ def test_validate_job_allows_unique_name(app):
 
     # No exception -> passes
     assert form.validate_name(_Field()) is None
+
+
+def test_jobs_new_hashfile_form_pwdump_hash_type_default(app):
+    """Test that an unbound JobsNewHashFileForm has pwdump_hash_type defaulting to '1000'."""
+    form = JobsNewHashFileForm()
+    assert form.pwdump_hash_type.data == '1000'


### PR DESCRIPTION
## Summary
- `pwdump_hash_type` is the only Hash Type select with exactly one real option ((1000) NTLM) plus a `------SELECT------` placeholder, forcing a pointless manual selection.
- Adds `default='1000'` so the field pre-selects the only valid choice. The placeholder choice is kept (the field has no `DataRequired` validator, and two existing tests POST an empty string for it).

Closes #375

## Test plan
- [x] New unit test: unbound `JobsNewHashFileForm().pwdump_hash_type.data == '1000'`
- [x] Full unit suite: 1537 passed, 2 skipped, 46 xfailed, 1 xpassed (pre-existing, unrelated flake in `test_customers_routes_branches.py`)