### PR TITLE
ci: auto-close issues on merge to v0.8.3-dev

### DIFF
--- a/.github/workflows/close-issues-on-dev-merge.yml
+++ b/.github/workflows/close-issues-on-dev-merge.yml
@@ -1,0 +1,67 @@
+name: Close issues on merge to v0.8.3-dev
+
+# GitHub's native "Closes #N" auto-close only fires when a PR merges into the
+# repo's default branch (main). Most fixes here land on v0.8.3-dev instead, so
+# without this workflow those issues stay open after the fix ships. This scans
+# the merged PR's title, body, and commit messages for the standard GitHub
+# closing keywords and closes the referenced issues by hand.
+on:
+  pull_request:
+    types: [closed]
+    branches: [v0.8.3-dev]
+
+jobs:
+  close-issues:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Close issues referenced by closing keywords
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+
+            const commits = await github.paginate(github.rest.pulls.listCommits, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+            });
+            const text = [pr.title, pr.body || '', ...commits.map(c => c.commit.message)].join('\n');
+
+            // Same keyword set GitHub recognizes for auto-close: close(s/d),
+            // fix(es/ed), resolve(s/d).
+            const pattern = /\b(close[sd]?|fix(e[sd])?|resolve[sd]?)\s*:?\s*#(\d+)/gi;
+            const issueNumbers = new Set();
+            let match;
+            while ((match = pattern.exec(text)) !== null) {
+              issueNumbers.add(Number(match[3]));
+            }
+
+            for (const issueNumber of issueNumbers) {
+              try {
+                const { data: issue } = await github.rest.issues.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                });
+                if (issue.state === 'closed') continue;
+
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  body: `Closed automatically: referenced by #${pr.number}, merged into \`${pr.base.ref}\`.`,
+                });
+                await github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  state: 'closed',
+                });
+              } catch (err) {
+                core.warning(`Could not close #${issueNumber}: ${err.message}`);
+              }
+            }


### PR DESCRIPTION
## Summary
- GitHub's native "Closes #N" auto-close only fires for merges into the repo's default branch (`main`). Most fixes land on `v0.8.3-dev` instead, so closing keywords in those PRs silently do nothing — e.g. #450 said "Closes #133" but #133 stayed open until closed by hand.
- Adds `.github/workflows/close-issues-on-dev-merge.yml`, triggered on `pull_request: closed` targeting `v0.8.3-dev`. On merge, it scans the PR title, body, and commit messages for the same closing-keyword set GitHub itself recognizes (`close(s/d)`, `fix(es/ed)`, `resolve(s/d)` + `#N`) and closes each matching open issue with a comment linking back to the PR.

## Test plan
- [x] `actionlint` on the new workflow — clean.
- [x] Verified the closing-keyword regex against sample PR titles/bodies/commit messages (matches `Closes #133`, `fixes #12 and resolves #45`, `Fixes: #200`; correctly ignores incidental `(#133)` PR-title backreferences with no adjacent keyword).
- [x] Full suite unaffected: `pytest tests/unit tests/security tests/agent_unit` — 1698 passed, 0 failures.
- [ ] Live verification happens on the next real merge to `v0.8.3-dev` that references an issue — can't dry-run a `pull_request: closed` event pre-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)