### PR TITLE
fix: get_linecount/gz_linecount over-count newline-terminated files by one

### DIFF
--- a/hashview/setup/__init__.py
+++ b/hashview/setup/__init__.py
@@ -12,8 +12,14 @@ from hashview.utils.utils import (
     get_filehash,
     get_filesize,
     get_linecount,
+    gz_linecount,
     is_gzip,
 )
+
+# Bumped when the recomputation logic for backfilled `.size` values changes, so
+# a fixed-but-still-wrong backfill can be re-run once against installs that
+# already have the (stale) marker from an earlier version of this pass.
+LINECOUNT_BACKFILL_MARKER = '.linecount_backfill_v1_done'
 
 DEFAULT_PASSWORD = 'hashview'
 
@@ -123,10 +129,26 @@ def compress_existing_wordlists_if_needed(db :SQLAlchemy):
     each row is handled in its own try/except with a per-row commit, a truly
     missing file is logged and skipped (never deletes the DB row), and any
     failure is contained so it can never abort startup.
+
+    Also does a ONE-TIME backfill (#435) of `.size` for rows whose stored
+    line count was computed with the old off-by-one get_linecount/gz_linecount
+    (which always added 1, even for newline-terminated files). This can't be a
+    migration -- reaching the wordlist/rule files on disk needs an app context
+    and real paths, which Alembic doesn't have -- so it rides this same
+    startup pass instead:
+      - static + already gzip: recompute `.size` from the existing .gz via
+        gz_linecount (previously this branch only backfilled byte_size).
+      - Rules: recompute `.size` from the rule file via get_linecount.
+    Recomputing from the actual file (rather than blindly subtracting 1) is
+    correct for both terminated and unterminated files. Guarded by a marker
+    file in the wordlists dir so a 14M-line rockyou.txt.gz is only ever
+    re-counted once, not on every boot.
     """
     from flask import current_app
     logger = current_app.logger
     wordlists_dir = os.path.join(current_app.root_path, 'control/wordlists')
+    linecount_backfill_marker = os.path.join(wordlists_dir, LINECOUNT_BACKFILL_MARKER)
+    needs_linecount_backfill = not os.path.exists(linecount_backfill_marker)
 
     def _resolve(path):
         """Locate a wordlist file, tolerating a relative/legacy stored path.
@@ -167,9 +189,16 @@ def compress_existing_wordlists_if_needed(db :SQLAlchemy):
             # static
             if is_gzip(resolved):
                 # Already compressed (new uploads, or a prior run). No-op aside
-                # from backfilling byte_size if it was never recorded.
+                # from backfilling byte_size if it was never recorded, and the
+                # one-time #435 line-count recompute below.
+                changed = False
                 if wordlist.byte_size is None:
                     wordlist.byte_size = get_filesize(resolved)
+                    changed = True
+                if needs_linecount_backfill:
+                    wordlist.size = gz_linecount(resolved)
+                    changed = True
+                if changed:
                     db.session.commit()
                 continue
 
@@ -194,6 +223,30 @@ def compress_existing_wordlists_if_needed(db :SQLAlchemy):
         except Exception:
             db.session.rollback()
             logger.exception('Failed to process wordlist %s; leaving it untouched.', getattr(wordlist, 'id', '?'))
+
+    if needs_linecount_backfill:
+        for rule in db.session.query(Rules).all():
+            try:
+                if not rule.path or not os.path.exists(rule.path):
+                    logger.warning('Rule %s file not found (path=%s); leaving the DB row '
+                                   'untouched.', rule.id, rule.path)
+                    continue
+                rule.size = get_linecount(rule.path)
+                db.session.commit()
+            except Exception:
+                db.session.rollback()
+                logger.exception('Failed to recompute line count for rule %s; leaving it untouched.',
+                                 getattr(rule, 'id', '?'))
+
+        # Mark the one-time #435 line-count backfill done so a 14M-line
+        # rockyou.txt.gz (or a large rule file) isn't re-counted on every boot.
+        try:
+            os.makedirs(wordlists_dir, exist_ok=True)
+            with open(linecount_backfill_marker, 'w') as fh:
+                fh.write('done')
+        except OSError:
+            logger.exception('Failed to write line-count backfill marker %s; the backfill '
+                             'may re-run on next startup.', linecount_backfill_marker)
 
 
 def _decode_hex_column(db, model, col_name, logger):

--- a/hashview/utils/utils.py
+++ b/hashview/utils/utils.py
@@ -112,12 +112,26 @@ def _count_generator(reader):
         b = reader(1024 * 1024)
 
 def get_linecount(filepath):
-    """Function to return line count of file"""
+    """Function to return line count of file.
+
+    Counts '\\n' bytes and adds one only when the file is non-empty AND its
+    final byte is not '\\n' (an unterminated last line still counts as a
+    line). A file that ends with '\\n' has no such dangling line, so no +1.
+    An empty file has zero lines. The last byte is tracked across the
+    streamed 1 MiB chunks, not read separately, so multi-GB files still
+    never load fully into memory.
+    """
 
     with open(filepath, 'rb') as fp:
         c_generator = _count_generator(fp.raw.read)
-        count = sum(buffer.count(b'\n') for buffer in c_generator)
-        return count + 1
+        count = 0
+        last_byte = b''
+        for buffer in c_generator:
+            count += buffer.count(b'\n')
+            last_byte = buffer[-1:]
+        if last_byte and last_byte != b'\n':
+            count += 1
+        return count
 
 def get_filehash(filepath):
     """Function to sha256 hash of file"""
@@ -187,13 +201,20 @@ def gz_linecount(filepath):
     """Return the line count of a gzipped text file.
 
     Streams the decompressed content (the "zcat | wc -l" equivalent) and uses
-    the SAME semantics as get_linecount (count of '\\n' + 1) so a wordlist's
-    reported line count is identical whether it arrived as plain text or gzip.
-    Raises on a malformed gzip stream (validation).
+    the SAME semantics as get_linecount (count of '\\n', +1 only when the
+    decompressed content is non-empty and its final byte is not '\\n') so a
+    wordlist's reported line count is identical whether it arrived as plain
+    text or gzip. Raises on a malformed gzip stream (validation).
     """
+    count = 0
+    last_byte = b''
     with gzip.open(filepath, 'rb') as f:
-        count = sum(buffer.count(b'\n') for buffer in iter(lambda: f.read(_CHUNK), b''))
-    return count + 1
+        for buffer in iter(lambda: f.read(_CHUNK), b''):
+            count += buffer.count(b'\n')
+            last_byte = buffer[-1:]
+    if last_byte and last_byte != b'\n':
+        count += 1
+    return count
 
 
 def ingest_static_wordlist_file(src_path, owner_id, name):

--- a/tests/unit/test_chunking.py
+++ b/tests/unit/test_chunking.py
@@ -90,6 +90,32 @@ def test_plan_wordlist_with_rules_splits_and_tiles():
     _assert_tiles_wordlist(specs, size)
 
 
+def test_plan_wordlist_exact_multiple_has_no_trailing_one_word_chunk(tmp_path):
+    """#435 regression: get_linecount used to over-report a newline-terminated
+    wordlist's line count by one. Feeding that inflated size into plan_chunks
+    produced a spurious trailing 1-word chunk even when the TRUE line count
+    was an exact multiple of words_per_chunk. Build a real terminated
+    wordlist, get its (now-correct) line count via get_linecount, and confirm
+    plan_chunks tiles it into clean equal-sized chunks with no leftover."""
+    from hashview.utils.utils import get_linecount
+
+    lines_per_chunk = 100
+    num_lines = lines_per_chunk * 10   # exact multiple -> 10 whole chunks
+    wl_path = tmp_path / "exact.txt"
+    wl_path.write_bytes(b"".join(b"word%d\n" % i for i in range(num_lines)))
+
+    wordlist_size = get_linecount(str(wl_path))
+    assert wordlist_size == num_lines   # the #435 fix: no off-by-one
+
+    # rule_count=1 -> per_word=1; slowest_speed*target_seconds == 100 ->
+    # words_per_chunk == 100, dividing num_lines evenly.
+    specs = plan_chunks(0, wordlist_size=wordlist_size, rule_count=1,
+                        slowest_speed=100, target_seconds=1, max_chunks=50)
+    assert len(specs) == 10
+    _assert_tiles_wordlist(specs, num_lines)
+    assert specs[-1]['limit'] == lines_per_chunk   # no dangling 1-word tail chunk
+
+
 def test_plan_wordlist_chunk_count_scales_with_speed():
     size = 1_000_000
     slow = plan_chunks(0, wordlist_size=size, rule_count=10,

--- a/tests/unit/test_wordlist_encoding.py
+++ b/tests/unit/test_wordlist_encoding.py
@@ -179,7 +179,7 @@ def test_ingest_utf8_multibyte_roundtrips(app, tmp_path):
     content = "café\nnaïve\n🔑emoji\nüber\n".encode()
     wl, src = _ingest(content, tmp_path, "utf8")
     assert _stored_bytes(wl) == content                 # verbatim
-    assert wl.size == content.count(b"\n") + 1 == 5
+    assert wl.size == content.count(b"\n") == 4
     assert wl.size == get_linecount(str(src))
     assert wl.checksum == get_filehash(wl.path)
 
@@ -192,7 +192,7 @@ def test_ingest_utf8_bom_is_preserved_not_stripped(app, tmp_path):
     stored = _stored_bytes(wl)
     assert stored == content
     assert stored.startswith(UTF8_BOM)
-    assert wl.size == 3                                  # 2 newlines + 1
+    assert wl.size == 2                                  # 2 newlines (terminated)
 
 
 def test_ingest_latin1_high_bytes_preserved(app, tmp_path):
@@ -202,7 +202,7 @@ def test_ingest_latin1_high_bytes_preserved(app, tmp_path):
     assert b"\xe9" in content                            # é in latin-1
     wl, _ = _ingest(content, tmp_path, "latin1")
     assert _stored_bytes(wl) == content
-    assert wl.size == 3
+    assert wl.size == 2
 
 
 def test_ingest_crlf_counted_by_newline_byte(app, tmp_path):
@@ -211,13 +211,13 @@ def test_ingest_crlf_counted_by_newline_byte(app, tmp_path):
     content = b"alpha\r\nbravo\r\ncharlie\r\n"
     wl, src = _ingest(content, tmp_path, "crlf")
     assert _stored_bytes(wl) == content                  # \r kept
-    assert wl.size == content.count(b"\n") + 1 == 4
+    assert wl.size == content.count(b"\n") == 3
     assert wl.size == get_linecount(str(src))
 
 
 def test_ingest_no_trailing_newline_line_count(app, tmp_path):
-    # get_linecount semantics are (count of '\n') + 1, so a file with no
-    # trailing newline still counts its last line.
+    # get_linecount counts '\n' bytes, +1 for a dangling unterminated last
+    # line, so a file with no trailing newline still counts its last line.
     content = b"one\ntwo\nthree"
     wl, _ = _ingest(content, tmp_path, "notrail")
     assert wl.size == 3
@@ -232,7 +232,10 @@ def test_ingest_utf16le_accepted_and_roundtrips(app, tmp_path):
     wl, src = _ingest(content, tmp_path, "utf16")
     assert _stored_bytes(wl) == content
     assert wl.size == get_linecount(str(src))
-    assert wl.size == 4                                  # 3 LF bytes + 1
+    # UTF-16LE encodes '\n' (U+000A) as the two bytes 0x0A 0x00, so the file's
+    # FINAL byte is 0x00, not 0x0A -- byte-oriented counting sees this as
+    # unterminated (dangling last "line"), hence 3 LF bytes + 1.
+    assert wl.size == 4
 
 
 # ---------------------------------------------------------------------------
@@ -247,7 +250,7 @@ def test_ingest_hashcat_hex_format_roundtrips_verbatim(app, tmp_path):
     assert stored == HEX_LINES                           # literal, not decoded
     assert b"$HEX[68656c6c6f]" in stored
     assert b"$HEX[]" in stored
-    assert wl.size == HEX_LINES.count(b"\n") + 1 == 7
+    assert wl.size == HEX_LINES.count(b"\n") == 6
     assert wl.size == get_linecount(str(src))
 
 
@@ -261,7 +264,7 @@ def test_ingest_hex_line_with_encoded_newline_is_not_expanded(app, tmp_path):
     stored = _stored_bytes(wl)
     assert stored == content
     assert stored.count(b"\n") == 1                       # hex added no newline
-    assert wl.size == content.count(b"\n") + 1 == 2       # get_linecount semantics
+    assert wl.size == content.count(b"\n") == 1       # get_linecount semantics
 
 
 def test_ingest_hex_format_gzip_upload_roundtrips(app, tmp_path):
@@ -272,7 +275,7 @@ def test_ingest_hex_format_gzip_upload_roundtrips(app, tmp_path):
         f.write(HEX_LINES)
     wl = ingest_static_wordlist_file(str(gz), _make_user().id, "HexGz")
     assert _stored_bytes(wl) == HEX_LINES
-    assert wl.size == HEX_LINES.count(b"\n") + 1
+    assert wl.size == HEX_LINES.count(b"\n")
 
 
 # ---------------------------------------------------------------------------
@@ -327,7 +330,7 @@ def test_ui_upload_hashcat_hex_roundtrips(app, client):
     assert wl is not None and is_gzip(wl.path)
     with gzip.open(wl.path, "rb") as f:
         assert f.read() == HEX_LINES
-    assert wl.size == HEX_LINES.count(b"\n") + 1
+    assert wl.size == HEX_LINES.count(b"\n")
 
 
 def test_ui_upload_utf8_bom_roundtrips(app, client):
@@ -366,6 +369,8 @@ def test_api_upload_utf16_accepted_and_roundtrips(app, client):
     assert is_gzip(wl.path)
     with gzip.open(wl.path, "rb") as f:
         assert f.read() == content
+    # UTF-16LE's final byte is 0x00 (the low byte of the trailing '\n'), not
+    # 0x0A, so this is byte-unterminated: 3 LF bytes + 1.
     assert wl.size == content.count(b"\n") + 1 == 4
 
 
@@ -379,7 +384,7 @@ def test_api_upload_hashcat_hex_roundtrips(app, client):
     wl = Wordlists.query.get(body["wordlist_id"])
     with gzip.open(wl.path, "rb") as f:
         assert f.read() == HEX_LINES                      # literal, not decoded
-    assert wl.size == HEX_LINES.count(b"\n") + 1
+    assert wl.size == HEX_LINES.count(b"\n")
 
 
 def test_api_upload_utf8_bom_preserved(app, client):
@@ -400,18 +405,19 @@ def test_api_upload_utf8_bom_preserved(app, client):
 # ---------------------------------------------------------------------------
 
 def test_ingest_empty_file(app, tmp_path):
-    # An empty wordlist stores empty bytes; get_linecount's (count + 1) reports 1.
+    # An empty wordlist stores empty bytes and has zero lines.
     wl, _ = _ingest(b"", tmp_path, "empty")
     assert _stored_bytes(wl) == b""
-    assert wl.size == 1
+    assert wl.size == 0
 
 
 def test_ingest_only_newlines(app, tmp_path):
-    # Blank lines are real lines under the '\n'-count semantics.
+    # Blank lines are real lines under the '\n'-count semantics; the file is
+    # terminated, so the count is exactly the number of newlines (no +1).
     content = b"\n\n\n"
     wl, _ = _ingest(content, tmp_path, "blanks")
     assert _stored_bytes(wl) == content
-    assert wl.size == 4                                    # 3 newlines + 1
+    assert wl.size == 3                                    # 3 newlines, terminated
 
 
 def test_ingest_bom_only_file(app, tmp_path):
@@ -428,7 +434,7 @@ def test_ingest_binary_with_nul_accepted_by_ingest(app, tmp_path):
     assert not looks_like_text_or_gz(str(_write(tmp_path, content)))  # drop-folder would refuse
     wl, _ = _ingest(content, tmp_path, "binary")
     assert _stored_bytes(wl) == content
-    assert wl.size == content.count(b"\n") + 1
+    assert wl.size == content.count(b"\n")
 
 
 def test_ingest_mixed_lf_and_crlf(app, tmp_path):
@@ -436,7 +442,7 @@ def test_ingest_mixed_lf_and_crlf(app, tmp_path):
     content = b"unix\nwindows\r\nunix2\n"
     wl, _ = _ingest(content, tmp_path, "mixed")
     assert _stored_bytes(wl) == content
-    assert wl.size == content.count(b"\n") + 1 == 4
+    assert wl.size == content.count(b"\n") == 3
 
 
 # ---------------------------------------------------------------------------
@@ -552,7 +558,7 @@ def test_api_upload_utf8_multibyte_roundtrips(app, client):
     body = resp.get_json()
     assert body["status"] == 200
     wl = Wordlists.query.get(body["wordlist_id"])
-    assert wl.size == content.count(b"\n") + 1
+    assert wl.size == content.count(b"\n")
     with gzip.open(wl.path, "rb") as f:
         assert f.read() == content
 

--- a/tests/unit/test_wordlist_gzip_storage.py
+++ b/tests/unit/test_wordlist_gzip_storage.py
@@ -126,6 +126,29 @@ def test_helpers_roundtrip(app, tmp_path):
     assert ensure_gz("d.txt") == "d.txt.gz"
 
 
+@pytest.mark.parametrize("data", [
+    pytest.param(b"a\nb\nc\n", id="terminated"),
+    pytest.param(b"a\nb\nc", id="unterminated"),
+    pytest.param(b"", id="empty"),
+    pytest.param(b"\n\n\n", id="newlines-only"),
+])
+def test_get_linecount_and_gz_linecount_match_splitlines_oracle(app, tmp_path, data):
+    """#435: get_linecount/gz_linecount must count real lines, not '\\n' + 1
+    unconditionally. len(data.splitlines()) is the oracle: it counts a
+    trailing-newline-terminated file's lines correctly AND still counts a
+    final unterminated line, exactly matching the intended semantics."""
+    expected = len(data.splitlines())
+
+    plain = tmp_path / "wl.txt"       # tmp_path is unique per parametrized call
+    plain.write_bytes(data)
+    assert get_linecount(str(plain)) == expected
+
+    gz = tmp_path / "wl.gz"
+    with gzip.open(str(gz), "wb") as f:
+        f.write(data)
+    assert gz_linecount(str(gz)) == expected
+
+
 def test_ingest_plaintext(app, tmp_path):
     user = _make_user()
     content = b"password\n123456\nletmein\n"
@@ -154,7 +177,7 @@ def test_ingest_gzip_recompresses_to_max(app, tmp_path):
     wl = ingest_static_wordlist_file(str(weak), user.id, "GzList")
 
     assert is_gzip(wl.path)
-    assert wl.size == content.count(b"\n") + 1
+    assert wl.size == content.count(b"\n")
     assert wl.checksum == get_filehash(wl.path)
     with gzip.open(wl.path, "rb") as f:
         assert f.read() == content
@@ -189,7 +212,7 @@ def test_ui_upload_plaintext(app, client):
     assert wl is not None
     assert wl.path.endswith(".gz") and is_gzip(wl.path)
     assert wl.checksum == get_filehash(wl.path)
-    assert wl.size == content.count(b"\n") + 1
+    assert wl.size == content.count(b"\n")
     assert wl.byte_size == os.path.getsize(wl.path)
 
 
@@ -356,7 +379,7 @@ def test_api_upload_plaintext(app, client):
     assert body["status"] == 200
     wl = Wordlists.query.get(body["wordlist_id"])
     assert wl.name == "ApiText" and is_gzip(wl.path)
-    assert wl.size == content.count(b"\n") + 1
+    assert wl.size == content.count(b"\n")
     with gzip.open(wl.path, "rb") as f:
         assert f.read() == content
 
@@ -509,11 +532,21 @@ def test_launch_migration(app, tmp_path):
     miss_wl = Wordlists(name="Missing", owner_id=user.id, type="static",
                         path=str(tmp_path / "nope.txt"), checksum="0" * 64, size=0)
 
-    db.session.add_all([static_wl, gz_wl, dyn_wl, miss_wl])
+    # 5) Rules row (#435): stored size simulates a pre-fix (count + 1) value,
+    # which the backfill must recompute from the actual rule file.
+    r_content = b"r1\nr2\nr3\n"
+    r_path = tmp_path / "old.rule"
+    r_path.write_bytes(r_content)
+    rule = Rules(name="OldRule", owner_id=user.id, path=str(r_path),
+                checksum=get_filehash(str(r_path)), size=r_content.count(b"\n") + 1)
+
+    db.session.add_all([static_wl, gz_wl, dyn_wl, miss_wl, rule])
     db.session.commit()
     ids = (static_wl.id, gz_wl.id, dyn_wl.id, miss_wl.id)
+    rule_id = rule.id
     gz_checksum_before = gz_wl.checksum
     dyn_checksum_before = dyn_wl.checksum
+    rule_checksum_before = rule.checksum
 
     # Called directly (no nested app_context): the test already runs inside the
     # app fixture's context, and per-row commits expire our tracked objects so
@@ -534,10 +567,13 @@ def test_launch_migration(app, tmp_path):
     with gzip.open(static_wl.path, "rb") as f:
         assert f.read() == s_content
 
-    # already gzip -> untouched except byte_size backfill
+    # already gzip -> path/checksum untouched, byte_size backfilled, and
+    # (#435) .size recomputed from the actual .gz content -- this row's
+    # size=3 simulated a pre-fix (count + 1) value; the correct count is 2.
     assert gz_wl.path == str(g_path)
     assert gz_wl.checksum == gz_checksum_before
     assert gz_wl.byte_size == os.path.getsize(g_path)
+    assert gz_wl.size == g_content.count(b"\n") == 2
 
     # dynamic -> never compressed, byte_size backfilled, checksum unchanged
     assert dyn_wl.path == str(d_path)
@@ -549,13 +585,32 @@ def test_launch_migration(app, tmp_path):
     assert miss_wl.byte_size is None
     assert miss_wl.path.endswith("nope.txt")
 
+    # Rules row (#435) -> size recomputed from the actual rule file, checksum
+    # and path untouched.
+    rule = Rules.query.get(rule_id)
+    assert rule.path == str(r_path)
+    assert rule.checksum == rule_checksum_before
+    assert rule.size == r_content.count(b"\n") == 3
+
     # idempotent: second run is a no-op
     path_after = static_wl.path
     checksum_after = static_wl.checksum
+    # (#435) the one-time line-count backfill is marker-guarded: deliberately
+    # corrupt gz_wl.size and rule.size and confirm the second run does NOT
+    # touch either again (a 14M-line rockyou.txt.gz must not be re-counted
+    # every boot).
+    gz_wl = Wordlists.query.get(ids[1])
+    gz_wl.size = 999
+    rule.size = 998
+    db.session.commit()
     compress_existing_wordlists_if_needed(db)
     static_wl = Wordlists.query.get(ids[0])
+    gz_wl = Wordlists.query.get(ids[1])
+    rule = Rules.query.get(rule_id)
     assert static_wl.path == path_after
     assert static_wl.checksum == checksum_after
+    assert gz_wl.size == 999                          # untouched: marker already set
+    assert rule.size == 998                           # untouched: marker already set
 
 
 def test_migration_normalizes_relative_wordlist_path(app, client, tmp_path):

--- a/tests/unit/test_wordlist_import.py
+++ b/tests/unit/test_wordlist_import.py
@@ -122,7 +122,7 @@ def test_import_plaintext_creates_row_and_removes_original(app, drop, audit):
     assert wl is not None
     assert wl.type == "static" and wl.owner_id == user.id
     assert wl.path.endswith(".gz") and is_gzip(wl.path)
-    assert wl.size == content.count(b"\n") + 1      # get_linecount semantics
+    assert wl.size == content.count(b"\n")          # get_linecount semantics
     with gzip.open(wl.path, "rb") as fh:
         assert fh.read() == content
     # the original drop file is gone (consumed on success)
@@ -149,7 +149,7 @@ def test_import_gz_recompresses(app, drop):
     assert summary["imported"] == ["big.gz"]
     wl = Wordlists.query.filter_by(name="big").first()   # trailing .gz dropped
     assert wl is not None and is_gzip(wl.path)
-    assert wl.size == content.count(b"\n") + 1
+    assert wl.size == content.count(b"\n")
     with gzip.open(wl.path, "rb") as fh:
         assert fh.read() == content
     assert not src.exists()


### PR DESCRIPTION
## Summary
- `get_linecount`/`gz_linecount` unconditionally added 1 to the newline count, which is only correct for a file whose last line has no trailing newline. Every wordlist the app generates itself (and effectively every wordlist in the wild) is newline-terminated, so the stored `size` was one too high in the common case; an empty file reported 1.
- Fixed both functions to add 1 only when the file is non-empty and its final byte is not `\n`, tracked correctly across chunked/streamed reads.
- `Wordlists.size` feeds the hashcat `--skip`/`--limit` chunking keyspace (`plan_chunks()`); when the true line count was an exact multiple of the per-chunk word count, the inflated count produced a trailing chunk covering one nonexistent word — a JobTask dispatched, started, and completed doing no work.
- Backfilled already-ingested rows: extended the existing one-time startup normalization pass (`compress_existing_wordlists_if_needed`) to recompute `size` for already-gzip static wordlists and for `Rules` rows, guarded by a marker file so a large wordlist isn't re-counted on every boot. No Alembic migration — a migration can't reliably reach wordlist files on disk.

Closes #435

Also found two call sites the original issue report missed: `hashview.py:196,221` (seed-wordlist/seed-rule paths), both covered by the same fix since they call the shared functions.

## Test plan
- [x] New table-driven test: terminated / unterminated / empty / newlines-only, both functions, oracle = `len(data.splitlines())`
- [x] Existing tests that hard-coded the old `+1` arithmetic updated (test_wordlist_encoding.py, test_wordlist_import.py, test_wordlist_gzip_storage.py); already-correct unterminated-file assertions left untouched
- [x] New chunking regression test: exact-multiple wordlist no longer produces a trailing one-word chunk
- [x] Backfill marker-guard regression test: corrupts sizes, confirms a second startup pass doesn't touch them again
- [x] Full unit suite: 1541 passed, 2 skipped, 46 xfailed, 1 xpassed (pre-existing, unrelated flake)