### PR TITLE
fix: show task-group membership in info modal, disable delete when blocked

### DIFF
--- a/hashview/tasks/routes.py
+++ b/hashview/tasks/routes.py
@@ -124,6 +124,14 @@ def tasks_list():
     # them); the list view padlocks these so the checkbox isn't offered.
     tasks_in_task_groups = _task_group_task_ids(task_groups)
 
+    # Task groups each task belongs to, for the info modal's "In N task groups"
+    # panel. Uses the same exact-JSON-parse logic as _task_group_task_ids (not a
+    # substring match on the raw TEXT column).
+    task_groups_by_task = {}
+    for tg in task_groups:
+        for tid in _task_group_task_ids([tg]):
+            task_groups_by_task.setdefault(tid, []).append(tg)
+
     # DISTINCT jobs each task is used in, for the info modal's "Used in N jobs"
     # panel. Collapse chunk rows so a job the task was split across is listed once
     # (not once per chunk); a task used more than once in the same job also lists
@@ -141,7 +149,7 @@ def tasks_list():
         seen.add(job.id)
         jobs_by_task.setdefault(jt.task_id, []).append(job)
 
-    return render_template('tasks.html.j2', title='tasks', tasks=tasks, users=users, jobs=jobs, job_tasks=job_tasks, jobs_by_task=jobs_by_task, wordlists=wordlists, task_groups=task_groups, task_recovery_performance=task_recovery_performance, pagination=pagination, sort_by=sort_by, sort_order=sort_order, name_filter=name_filter, rules=Rules.query.all(), wl_filesize=wl_filesize, tasks_in_jobs=tasks_in_jobs, tasks_in_task_groups=tasks_in_task_groups, tasksForm=TasksForm(), form_err=session.pop('tasks_form_err', None))
+    return render_template('tasks.html.j2', title='tasks', tasks=tasks, users=users, jobs=jobs, job_tasks=job_tasks, jobs_by_task=jobs_by_task, task_groups_by_task=task_groups_by_task, wordlists=wordlists, task_groups=task_groups, task_recovery_performance=task_recovery_performance, pagination=pagination, sort_by=sort_by, sort_order=sort_order, name_filter=name_filter, rules=Rules.query.all(), wl_filesize=wl_filesize, tasks_in_jobs=tasks_in_jobs, tasks_in_task_groups=tasks_in_task_groups, tasksForm=TasksForm(), form_err=session.pop('tasks_form_err', None))
 
 @tasks.route("/tasks/add", methods=['GET', 'POST'])
 @login_required

--- a/hashview/templates/tasks.html.j2
+++ b/hashview/templates/tasks.html.j2
@@ -207,7 +207,13 @@
                         {% else %}
                         <button type="button" class="icon-btn" title="Edit" onclick='hvEditTask({id:{{ task.id }}, name:{{ task.name|tojson }}, mode:{{ task.hc_attackmode|tojson }}, wl_id:{{ task.wl_id|tojson }}, wl_id_2:{{ task.wl_id_2|tojson }}, rule_id:{{ task.rule_id|tojson }}, mask:{{ task.hc_mask|tojson }}, j_rule:{{ task.j_rule|tojson }}, k_rule:{{ task.k_rule|tojson }}, loopback:{{ task.loopback|tojson }}})'>{{ icon('edit', size=15) }}</button>
                         {% endif %}
+                        {% if in_job %}
+                        <span class="icon-btn" style="opacity:.4; cursor:not-allowed;" title="Locked — task is assigned to a job — remove it from the job before deleting">{{ icon('trash', size=15) }}</span>
+                        {% elif in_group %}
+                        <span class="icon-btn" style="opacity:.4; cursor:not-allowed;" title="Locked — task is in a task group — remove it from the group before deleting">{{ icon('trash', size=15) }}</span>
+                        {% else %}
                         <button type="button" class="icon-btn act-del" title="Delete" onclick="document.getElementById('del-{{ task.id }}').showModal()">{{ icon('trash', size=15) }}</button>
+                        {% endif %}
                     </div>
                 </td>
             </tr>
@@ -423,6 +429,22 @@
             {% endfor %}
             {% else %}
             <div class="mono" style="color:var(--text-mute);">Not used in any jobs yet.</div>
+            {% endif %}
+        </div>
+
+        {# task-group membership: which group(s), if any, this task belongs to #}
+        {% set groups = (task_groups_by_task.get(task.id, []) if task_groups_by_task is defined else []) %}
+        <div style="margin-top:24px;">
+            <div class="mono" style="display:flex; align-items:center; gap:8px; font-size:10px; letter-spacing:1px; text-transform:uppercase; color:var(--text-mute); margin-bottom:11px;">{{ icon('lock', size=14) }} In {{ groups|length | commafy }} task group{{ '' if groups|length == 1 else 's' }}</div>
+            {% if groups %}
+            {% for tg in groups %}
+            <div class="card" style="margin-bottom:8px; padding:12px 14px; display:flex; align-items:center; gap:10px;">
+                <span class="mono" style="color:var(--text-mute);">#{{ tg.id }}</span>
+                <span style="font-weight:600; color:var(--text);">{{ tg.name }}</span>
+            </div>
+            {% endfor %}
+            {% else %}
+            <div class="mono" style="color:var(--text-mute);">Not in any task groups.</div>
             {% endif %}
         </div>
     </div>

--- a/tests/unit/test_tasks_routes_guards.py
+++ b/tests/unit/test_tasks_routes_guards.py
@@ -178,6 +178,51 @@ def test_tasks_list_padlocks_in_group_task(app, client):
     assert b"In a task group" in resp.data
 
 
+def test_tasks_list_info_modal_names_task_group(app, client):
+    """The info modal's task-groups panel names the group(s) a task belongs to,
+    and shows a 'not in any' fallback for a free task."""
+    owner = _nonadmin()
+    _login(client, owner)
+    free = _make_task(owner.id, name="tinfo-free")
+    in_group = _make_task(owner.id, name="tinfo-ingroup")
+    db.session.add(TaskGroups(name="tg-info", owner_id=owner.id, tasks=str([in_group.id])))
+    db.session.commit()
+
+    resp = client.get("/tasks")
+    assert resp.status_code == 200
+    assert b"tg-info" in resp.data
+    assert b"In 1 task group" in resp.data
+    assert b"Not in any task groups" in resp.data
+
+
+def test_tasks_list_no_active_delete_button_when_blocked(app, client):
+    """A task assigned to a job or in a task group renders a dimmed, disabled
+    delete affordance -- not the active act-del button -- so the row can't
+    trigger a delete the backend would reject anyway."""
+    owner = _nonadmin()
+    _login(client, owner)
+    free = _make_task(owner.id, name="tdel-free")
+    in_job = _make_task(owner.id, name="tdel-injob")
+    db.session.add(JobTasks(job_id=1, task_id=in_job.id, status="Not Started"))
+    in_group = _make_task(owner.id, name="tdel-ingroup")
+    db.session.add(TaskGroups(name="tg-del", owner_id=owner.id, tasks=str([in_group.id])))
+    db.session.commit()
+
+    resp = client.get("/tasks")
+    assert resp.status_code == 200
+    body = resp.data.decode()
+
+    def active_del_button_present(task_id):
+        marker = f'class="icon-btn act-del" title="Delete" onclick="document.getElementById(\'del-{task_id}\')'
+        return marker in body
+
+    assert active_del_button_present(free.id)
+    assert not active_del_button_present(in_job.id)
+    assert not active_del_button_present(in_group.id)
+    assert b"Locked \xe2\x80\x94 task is assigned to a job" in resp.data
+    assert b"Locked \xe2\x80\x94 task is in a task group" in resp.data
+
+
 def test_tasks_list_substring_id_not_falsely_padlocked(app, client):
     """A group containing task 10 must not padlock task 1 -- the membership check
     parses the JSON list rather than substring-matching the stored string."""

--- a/tests/unit/test_tasks_routes_guards.py
+++ b/tests/unit/test_tasks_routes_guards.py
@@ -193,6 +193,8 @@ def test_tasks_list_info_modal_names_task_group(app, client):
     assert b"tg-info" in resp.data
     assert b"In 1 task group" in resp.data
     assert b"Not in any task groups" in resp.data
+    # control: the free task is still selectable (not padlocked by this group)
+    assert f'task-check" value="{free.id}"'.encode() in resp.data
 
 
 def test_tasks_list_no_active_delete_button_when_blocked(app, client):


### PR DESCRIPTION
## Summary
Issue #369's original complaint — deleting a task in a group showed the wrong ("assigned to a job") error message — is already fixed on `v0.8.3-dev` (commit 35b26ae; `hashview/tasks/routes.py:438` already flashes a distinct task-group message). This PR closes the two remaining asks from that issue:

- The task info modal now shows which task group(s) a task belongs to, alongside the existing "Used in N jobs" panel.
- The per-row delete button is now dimmed and disabled (matching the existing Edit-button pattern) when a task is blocked by a job or a task group, instead of always being clickable and only failing after the confirm modal.

Closes #369

## Test plan
- [x] New tests in `test_tasks_routes_guards.py` render the real `/tasks` route and assert the info modal names the group, and that a blocked task (by job or by group) renders no active delete button
- [x] Confirmed the existing group/job flash strings are untouched (a prior test asserts on them verbatim)
- [x] Full unit suite: 1538 passed, 2 skipped, 46 xfailed, 1 xpassed (pre-existing, unrelated flake)
- [x] ruff clean