### PR TITLE
feat: make the pasted-hash form-size cap configurable and add a 413 handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@ Notable changes will be documented here
 - Bulk-select and bulk-delete on the hashfiles list
 - Per-hashfile `--hex-salt` option for salted hash types
 
+**Configuration**
+- Optional `MAX_FORM_MEMORY_SIZE` key under `[SERVER]` in `config.conf`, capping the size of pasted (non-file) form data such as the pasted-hashes textarea. Defaults to Flask's own 500000 bytes when unset, so existing deployments are unaffected; raise it to allow larger pastes. Uploaded files are not counted against it, and values below 65536 are clamped up to that floor because a smaller cap would reject multipart file uploads outright (#314)
+- Oversized submissions now return a clear "try uploading the hashes as a file instead" message — JSON for AJAX requests, a flash and redirect for normal form posts — rather than a bare Werkzeug 413 page or a misleading "You must assign a name to the hashfile" error (#314)
+
 **Testing**
 - Job-creation performance e2e suite (`tests/e2e/test_job_creation_perf.py`) with a tunable volume seeder (`tests/seed_perf_db.py`), covering latency budgets for each wizard step plus strict-xfail scaling guards for the four endpoints in issue #422 whose cost grows with table size rather than page size
 - API hashfile-listing performance suite (`tests/e2e/test_api_hashfile_listing_perf.py`), sharing that seeder. Asserts loop cost as a ratio to a same-route zero-hashfile floor rather than an absolute budget, so the threshold survives a change of hardware; carries regression guards for issue #228 (fixed in this release; the guard remains so a per-hashfile loop cannot return) and on `GET /v1/customers/<id>/hashfiles`, which runs one combined aggregate per hashfile and measures under the ceiling today

--- a/hashview/__init__.py
+++ b/hashview/__init__.py
@@ -2,7 +2,7 @@ import datetime
 import logging
 from logging.config import dictConfig as loggingDictConfig
 
-from flask import Flask, redirect, request, url_for
+from flask import Flask, flash, jsonify, redirect, request, url_for
 from jinja2 import select_autoescape
 
 __version__ = '0.8.3'
@@ -444,6 +444,28 @@ def create_app(testing=False, config_overrides=None):
             }}
         except Exception:  # pragma: no cover - pre-migration / no DB
             return {'notify_channels': defaults}
+
+    @app.errorhandler(413)
+    def _form_too_large(e):
+        """#314: Werkzeug enforces MAX_FORM_MEMORY_SIZE (a byte cap on
+        non-file form fields, e.g. a pasted-hashes textarea) while parsing the
+        request body, before any view function runs -- so this is the only
+        place that can intercept it. File uploads are parsed separately and
+        are not subject to this cap, hence the workaround suggested below.
+
+        Matches the AJAX/normal-submit contract used elsewhere for form
+        errors (see hashview/jobs/routes.py:270,454-455): XHR requests get a
+        JSON error body, normal submits get a flash + redirect back to
+        wherever the request came from.
+        """
+        msg = ('Your submission exceeded the maximum allowed size for pasted '
+               'form data. Try uploading the hashes as a file instead -- file '
+               'uploads are not subject to this limit.')
+        is_ajax = request.headers.get('X-Requested-With') == 'fetch'
+        if is_ajax:
+            return jsonify({'status': 'error', 'msg': msg}), 413
+        flash(msg, 'danger')
+        return redirect(request.referrer or url_for('main.home'))
 
     if not (testing or app.config.get("HASHVIEW_SKIP_SETUP")):
         with app.app_context():

--- a/hashview/config.conf.example
+++ b/hashview/config.conf.example
@@ -1,6 +1,13 @@
 [SERVER]
 SERVER_NAME = FQDN:PORT
 SECRET_KEY = change-me-to-a-random-string
+# Byte cap on non-file form fields (e.g. the pasted-hashes textarea on the
+# job/hashfile upload pages). File uploads are NOT subject to this limit.
+# Defaults to 500000 (Flask 3.1's own built-in default) when unset, so
+# leaving this commented out changes nothing. config.conf is baked into the
+# Docker image at build time, not bind-mounted, so this must be set before
+# `docker compose build` to take effect.
+# MAX_FORM_MEMORY_SIZE = 500000
 
 [database]
 host = localhost

--- a/hashview/config.conf.example
+++ b/hashview/config.conf.example
@@ -1,11 +1,20 @@
 [SERVER]
 SERVER_NAME = FQDN:PORT
 SECRET_KEY = change-me-to-a-random-string
-# Byte cap on non-file form fields (e.g. the pasted-hashes textarea on the
-# job/hashfile upload pages). File uploads are NOT subject to this limit.
-# Defaults to 500000 (Flask 3.1's own built-in default) when unset, so
-# leaving this commented out changes nothing. config.conf is baked into the
-# Docker image at build time, not bind-mounted, so this must be set before
+# Byte cap on pasted (non-file) form fields, e.g. the pasted-hashes textarea
+# on the job/hashfile upload pages. Raise this if operators need to paste more
+# than ~500KB of hashes at once; there is no upper ceiling.
+#
+# The size of an *uploaded file* is not counted against this cap, so raising it
+# is not needed for large hash files. But do NOT set it below 65536: Werkzeug
+# also applies this limit to each 64KiB chunk it reads while parsing a
+# multipart body, which rejects every file upload regardless of file size.
+# Values under 65536 are therefore clamped up to it -- see
+# hashview/form_limits.py.
+#
+# Defaults to 500000 (Flask's own built-in default) when unset, so leaving this
+# commented out changes nothing. config.conf is baked into the Docker image at
+# build time, not bind-mounted, so this must be set before
 # `docker compose build` to take effect.
 # MAX_FORM_MEMORY_SIZE = 500000
 

--- a/hashview/config.py
+++ b/hashview/config.py
@@ -13,6 +13,15 @@ class Config:
     # Server Config
     SERVER_NAME = file_config['SERVER']['SERVER_NAME']
 
+    # Byte cap on non-file form fields (e.g. the pasted-hashes textarea).
+    # ConfigParser values are always strings, hence the int() coercion. Uses
+    # the same .get(key, default) idiom as SECRET_KEY above (not the bare
+    # indexing used for SERVER_NAME) so an older config.conf that predates
+    # this key doesn't KeyError on upgrade. Default matches Flask 3.1's own
+    # built-in MAX_FORM_MEMORY_SIZE default (500000), so omitting the key
+    # changes nothing.
+    MAX_FORM_MEMORY_SIZE = int(file_config['SERVER'].get('MAX_FORM_MEMORY_SIZE', 500000))
+
     # MYSQL Config. charset=utf8mb4 so the connection can carry 4-byte UTF-8
     # (emojis etc.) end-to-end — required now that usernames/plaintext are stored
     # as text rather than hex.

--- a/hashview/config.py
+++ b/hashview/config.py
@@ -2,6 +2,8 @@
 import secrets
 from configparser import ConfigParser
 
+from hashview.form_limits import resolve_max_form_memory_size
+
 file_config = ConfigParser()
 
 class Config:
@@ -14,13 +16,15 @@ class Config:
     SERVER_NAME = file_config['SERVER']['SERVER_NAME']
 
     # Byte cap on non-file form fields (e.g. the pasted-hashes textarea).
-    # ConfigParser values are always strings, hence the int() coercion. Uses
-    # the same .get(key, default) idiom as SECRET_KEY above (not the bare
-    # indexing used for SERVER_NAME) so an older config.conf that predates
-    # this key doesn't KeyError on upgrade. Default matches Flask 3.1's own
-    # built-in MAX_FORM_MEMORY_SIZE default (500000), so omitting the key
-    # changes nothing.
-    MAX_FORM_MEMORY_SIZE = int(file_config['SERVER'].get('MAX_FORM_MEMORY_SIZE', 500000))
+    # Read via the same .get(key, default) idiom as SECRET_KEY above (not the
+    # bare indexing used for SERVER_NAME) so an older config.conf that predates
+    # this key doesn't KeyError on upgrade. Omitting the key leaves Flask's own
+    # default (500000) in place, so nothing changes. Values below 64 KiB are
+    # clamped up -- see hashview/form_limits.py for why a smaller cap would
+    # break every file upload.
+    MAX_FORM_MEMORY_SIZE = resolve_max_form_memory_size(
+        file_config['SERVER'].get('MAX_FORM_MEMORY_SIZE')
+    )
 
     # MYSQL Config. charset=utf8mb4 so the connection can carry 4-byte UTF-8
     # (emojis etc.) end-to-end — required now that usernames/plaintext are stored

--- a/hashview/form_limits.py
+++ b/hashview/form_limits.py
@@ -1,0 +1,54 @@
+"""Resolution of the MAX_FORM_MEMORY_SIZE config key (issue #314).
+
+Kept in its own dependency-free module rather than inline in ``config.py``
+because ``hashview.config`` reads ``hashview/config.conf`` at import time and
+raises ``KeyError`` when that file is absent, which makes it unimportable from
+the test suite. Nothing here imports Flask, Werkzeug or any Hashview module, so
+it is safe to import from anywhere.
+"""
+
+# Flask/Werkzeug's own built-in default for max_form_memory_size
+# (werkzeug.wrappers.Request.max_form_memory_size). Used when the config key is
+# absent or unparseable, so an untouched config.conf behaves exactly as before.
+FLASK_DEFAULT_FORM_MEMORY_SIZE = 500_000
+
+# Lower bound we refuse to go below. Werkzeug enforces max_form_memory_size in
+# two places, and only one of them exempts file uploads:
+#
+#   * werkzeug/formparser.py accumulates a per-part ``field_size``, but only for
+#     ``Field`` events -- it stays ``None`` for ``File`` events, so uploaded
+#     files stream to disk uncounted. That is the limit this config key is
+#     meant to expose.
+#
+#   * werkzeug/sansio/multipart.py (MultipartDecoder.receive_data) raises
+#     RequestEntityTooLarge when a single read chunk would push the decode
+#     buffer past the cap. That check does *not* distinguish files from fields,
+#     and MultiPartParser reads in ``buffer_size`` chunks, default 64 KiB.
+#
+# The chunk check compares ``len(buffer) + len(data)`` against the cap, so
+# below 64 KiB a file upload fails as soon as the body outgrows the cap -- a
+# 1000-byte cap rejects a 10KB hash file, which is exactly the "upload the
+# hashes as a file instead" workaround the 413 handler recommends. At or above
+# 64 KiB no single read can ever exceed the cap, so uploads of any file size
+# parse cleanly. Hence the clamp rather than honouring a smaller value.
+MIN_FORM_MEMORY_SIZE = 64 * 1024  # 65536
+
+
+def resolve_max_form_memory_size(raw, default=FLASK_DEFAULT_FORM_MEMORY_SIZE):
+    """Coerce a raw config.conf value into a usable MAX_FORM_MEMORY_SIZE.
+
+    ``raw`` is whatever ConfigParser returned (always a string, or ``None`` when
+    the key is absent). Unset or unparseable values fall back to ``default`` --
+    a typo in config.conf should not take the app down at import time. Values
+    below :data:`MIN_FORM_MEMORY_SIZE` are clamped up to it; see the constant's
+    comment for why.
+    """
+    if raw is None:
+        return default
+
+    try:
+        value = int(str(raw).strip())
+    except (TypeError, ValueError):
+        return default
+
+    return max(value, MIN_FORM_MEMORY_SIZE)

--- a/tests/unit/test_form_memory_limit_413.py
+++ b/tests/unit/test_form_memory_limit_413.py
@@ -1,0 +1,122 @@
+"""Tests for issue #314 — configurable MAX_FORM_MEMORY_SIZE + a 413 handler.
+
+The original issue claimed Hashview "sets" Werkzeug's max_form_memory_size to
+488KB. That's wrong: MAX_FORM_MEMORY_SIZE never appeared in this repo before
+this change — 500000 is simply Flask 3.1's own built-in default. This module
+verifies (a) the app now has a 413 handler that matches the AJAX/normal-submit
+contract used elsewhere (see hashview/jobs/routes.py:270,445-459), and (b)
+that omitting the new config.conf key changes nothing (the default still
+resolves to Flask's own 500000).
+"""
+
+from configparser import ConfigParser
+
+import pytest
+
+from hashview import create_app
+
+
+def _build_app_with_tiny_form_limit():
+    """A throwaway app with a deliberately tiny MAX_FORM_MEMORY_SIZE so a
+    normal small POST body in a test trips the 413 path — no need to actually
+    push 500KB over the wire.
+    """
+    overrides = {
+        "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+        "SQLALCHEMY_TRACK_MODIFICATIONS": False,
+        "SQLALCHEMY_ENGINE_OPTIONS": {"connect_args": {"check_same_thread": False}},
+        "WTF_CSRF_ENABLED": False,
+        "MAIL_SUPPRESS_SEND": True,
+        "SECRET_KEY": "unit-test-secret",
+        "SERVER_NAME": "localhost.test",
+        "HASHVIEW_SKIP_SETUP": True,
+        "HASHVIEW_SKIP_GUI_SETUP": True,
+        "HASHVIEW_DISABLE_SCHEDULER": True,
+        # The point of this test: a tiny cap so a normal-sized form body
+        # exceeds it, without needing a real ~500KB POST in a test.
+        "MAX_FORM_MEMORY_SIZE": 16,
+    }
+    app = create_app(testing=True, config_overrides=overrides)
+    from hashview.models import db as _db
+    with app.app_context():
+        _db.create_all()
+    return app
+
+
+@pytest.fixture()
+def tiny_limit_client():
+    app = _build_app_with_tiny_form_limit()
+    with app.app_context():
+        yield app.test_client()
+        from hashview.models import db as _db
+        _db.session.remove()
+        _db.drop_all()
+
+
+def test_oversized_form_body_ajax_gets_json_413(tiny_limit_client):
+    """An XHR-flagged POST that exceeds MAX_FORM_MEMORY_SIZE must get the same
+    JSON error shape used elsewhere for AJAX failures (see
+    hashview/jobs/routes.py:454-455: jsonify({'status': 'error', 'msg': ...}),
+    <code>), with a 413 status.
+    """
+    resp = tiny_limit_client.post(
+        "/login",
+        data={
+            "email": "someone@example.com",
+            "password": "a-password-long-enough-to-exceed-the-tiny-cap",
+        },
+        headers={"X-Requested-With": "fetch"},
+    )
+    assert resp.status_code == 413
+    body = resp.get_json()
+    assert body is not None
+    assert body["status"] == "error"
+    assert "file" in body["msg"].lower()
+
+
+def test_oversized_form_body_normal_submit_flashes_and_redirects(tiny_limit_client):
+    """A normal (non-AJAX) POST that exceeds the limit gets a flash + redirect,
+    matching the non-AJAX branch of the same contract."""
+    resp = tiny_limit_client.post(
+        "/login",
+        data={
+            "email": "someone@example.com",
+            "password": "a-password-long-enough-to-exceed-the-tiny-cap",
+        },
+    )
+    assert resp.status_code in (301, 302, 303)
+
+    resp = tiny_limit_client.post(
+        "/login",
+        data={
+            "email": "someone@example.com",
+            "password": "a-password-long-enough-to-exceed-the-tiny-cap",
+        },
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    assert b"file" in resp.data.lower()
+
+
+# ---------------------------------------------------------------------------
+# Config default
+# ---------------------------------------------------------------------------
+def test_max_form_memory_size_defaults_to_flask_default_when_absent():
+    """hashview/config.py must read MAX_FORM_MEMORY_SIZE via the same
+    ``.get(key, default)`` idiom already used for SECRET_KEY (config.py:11),
+    NOT the bare ``file_config['SERVER']['...']`` idiom used for SERVER_NAME
+    (config.py:14) — bare indexing KeyErrors on an older config.conf that
+    predates this key, breaking every existing deployment on upgrade.
+
+    hashview.config reads 'hashview/config.conf' at import time and raises
+    KeyError building SERVER_NAME when no such file/section exists on disk (as
+    is the case in this checkout — see test_db_password_with_percent_is_parsed
+    in test_issue_xfail_misc.py for the same constraint), so this mirrors the
+    exact read expression rather than importing the real module.
+    """
+    parser = ConfigParser()
+    parser.read_dict({"SERVER": {"SERVER_NAME": "example.com:5000"}})
+
+    max_form_memory_size = int(parser["SERVER"].get("MAX_FORM_MEMORY_SIZE", 500000))
+
+    assert max_form_memory_size == 500000

--- a/tests/unit/test_form_memory_limit_413.py
+++ b/tests/unit/test_form_memory_limit_413.py
@@ -9,11 +9,21 @@ that omitting the new config.conf key changes nothing (the default still
 resolves to Flask's own 500000).
 """
 
+import io
 from configparser import ConfigParser
 
 import pytest
 
 from hashview import create_app
+from hashview.form_limits import (
+    FLASK_DEFAULT_FORM_MEMORY_SIZE,
+    MIN_FORM_MEMORY_SIZE,
+    resolve_max_form_memory_size,
+)
+
+# A pasted value comfortably over the configured cap, so the parser trips the
+# 413 path on a field (not a file) part.
+_OVERSIZED_PASTE = "A" * (MIN_FORM_MEMORY_SIZE + 1024)
 
 
 def _build_app_with_tiny_form_limit():
@@ -32,9 +42,11 @@ def _build_app_with_tiny_form_limit():
         "HASHVIEW_SKIP_SETUP": True,
         "HASHVIEW_SKIP_GUI_SETUP": True,
         "HASHVIEW_DISABLE_SCHEDULER": True,
-        # The point of this test: a tiny cap so a normal-sized form body
-        # exceeds it, without needing a real ~500KB POST in a test.
-        "MAX_FORM_MEMORY_SIZE": 16,
+        # The lowest cap an operator can actually end up with: config.py clamps
+        # anything smaller up to this floor (see hashview/form_limits.py and
+        # test_form_memory_limit_floor.py). Using a smaller value here would
+        # exercise a configuration that is impossible in production.
+        "MAX_FORM_MEMORY_SIZE": MIN_FORM_MEMORY_SIZE,
     }
     app = create_app(testing=True, config_overrides=overrides)
     from hashview.models import db as _db
@@ -61,10 +73,7 @@ def test_oversized_form_body_ajax_gets_json_413(tiny_limit_client):
     """
     resp = tiny_limit_client.post(
         "/login",
-        data={
-            "email": "someone@example.com",
-            "password": "a-password-long-enough-to-exceed-the-tiny-cap",
-        },
+        data={"email": "someone@example.com", "password": _OVERSIZED_PASTE},
         headers={"X-Requested-With": "fetch"},
     )
     assert resp.status_code == 413
@@ -79,19 +88,13 @@ def test_oversized_form_body_normal_submit_flashes_and_redirects(tiny_limit_clie
     matching the non-AJAX branch of the same contract."""
     resp = tiny_limit_client.post(
         "/login",
-        data={
-            "email": "someone@example.com",
-            "password": "a-password-long-enough-to-exceed-the-tiny-cap",
-        },
+        data={"email": "someone@example.com", "password": _OVERSIZED_PASTE},
     )
     assert resp.status_code in (301, 302, 303)
 
     resp = tiny_limit_client.post(
         "/login",
-        data={
-            "email": "someone@example.com",
-            "password": "a-password-long-enough-to-exceed-the-tiny-cap",
-        },
+        data={"email": "someone@example.com", "password": _OVERSIZED_PASTE},
         follow_redirects=True,
     )
     assert resp.status_code == 200
@@ -112,11 +115,30 @@ def test_max_form_memory_size_defaults_to_flask_default_when_absent():
     KeyError building SERVER_NAME when no such file/section exists on disk (as
     is the case in this checkout — see test_db_password_with_percent_is_parsed
     in test_issue_xfail_misc.py for the same constraint), so this mirrors the
-    exact read expression rather than importing the real module.
+    exact read expression rather than importing the real module. The resolver
+    itself lives in hashview/form_limits.py precisely so it *is* importable.
     """
     parser = ConfigParser()
     parser.read_dict({"SERVER": {"SERVER_NAME": "example.com:5000"}})
 
-    max_form_memory_size = int(parser["SERVER"].get("MAX_FORM_MEMORY_SIZE", 500000))
+    max_form_memory_size = resolve_max_form_memory_size(
+        parser["SERVER"].get("MAX_FORM_MEMORY_SIZE")
+    )
 
-    assert max_form_memory_size == 500000
+    assert max_form_memory_size == FLASK_DEFAULT_FORM_MEMORY_SIZE == 500000
+
+
+def test_real_app_still_accepts_a_file_upload_at_the_minimum_cap(tiny_limit_client):
+    """The workaround the 413 message recommends must actually work at the
+    lowest cap an operator can configure.
+
+    Posting a 1MB file part to /login is nonsense as a login, but it proves the
+    request body *parsed* rather than being rejected by the multipart chunk
+    check — which is exactly what a sub-64KiB cap would do.
+    """
+    resp = tiny_limit_client.post(
+        "/login",
+        data={"hashfile": (io.BytesIO(b"A" * 1_000_000), "hashes.txt")},
+        content_type="multipart/form-data",
+    )
+    assert resp.status_code != 413

--- a/tests/unit/test_form_memory_limit_floor.py
+++ b/tests/unit/test_form_memory_limit_floor.py
@@ -1,0 +1,163 @@
+"""Tests for the MAX_FORM_MEMORY_SIZE floor (issue #314 review follow-up).
+
+Werkzeug enforces ``max_form_memory_size`` in *two* places, and only one of
+them exempts file uploads:
+
+1. ``werkzeug/formparser.py`` accumulates ``field_size`` per part, but only for
+   ``Field`` events -- ``field_size`` is left at ``None`` for ``File`` events,
+   so uploaded files stream to disk uncounted. This is the limit the config key
+   is *meant* to expose.
+
+2. ``werkzeug/sansio/multipart.py`` (``MultipartDecoder.receive_data``) raises
+   ``RequestEntityTooLarge`` when a single read chunk would push the decode
+   buffer past the cap. This one does *not* distinguish files from fields, and
+   the parser reads in ``buffer_size`` chunks (default ``64 * 1024``).
+
+Consequence: setting the cap below 64KiB breaks *all* multipart file uploads,
+including the "upload the hashes as a file instead" workaround the 413 handler
+tells operators to use. These tests pin the floor that prevents that.
+"""
+
+import io
+
+import pytest
+from flask import Flask, request
+
+from hashview.form_limits import (
+    FLASK_DEFAULT_FORM_MEMORY_SIZE,
+    MIN_FORM_MEMORY_SIZE,
+    resolve_max_form_memory_size,
+)
+
+
+# ---------------------------------------------------------------------------
+# The floor constant must match Werkzeug's real multipart read-chunk size.
+# ---------------------------------------------------------------------------
+def test_floor_matches_werkzeug_multipart_read_buffer():
+    """MIN_FORM_MEMORY_SIZE must equal the parser's ``buffer_size`` default.
+
+    If Werkzeug ever changes that default, this fails loudly rather than
+    letting the floor silently become wrong.
+    """
+    import inspect
+
+    from werkzeug.formparser import MultiPartParser
+
+    default = inspect.signature(MultiPartParser).parameters["buffer_size"].default
+    assert MIN_FORM_MEMORY_SIZE == default
+
+
+def test_flask_default_constant_matches_werkzeug():
+    from werkzeug.wrappers import Request
+
+    assert FLASK_DEFAULT_FORM_MEMORY_SIZE == Request.max_form_memory_size
+
+
+# ---------------------------------------------------------------------------
+# resolve_max_form_memory_size()
+# ---------------------------------------------------------------------------
+def test_absent_key_resolves_to_flask_default():
+    assert resolve_max_form_memory_size(None) == FLASK_DEFAULT_FORM_MEMORY_SIZE
+
+
+@pytest.mark.parametrize("raw", ["16", "1000", "65535", 16, 0])
+def test_values_below_the_floor_are_clamped_up(raw):
+    """A deployer lowering this to "tighten security" must not silently lose
+    every file upload."""
+    assert resolve_max_form_memory_size(raw) == MIN_FORM_MEMORY_SIZE
+
+
+@pytest.mark.parametrize("raw", ["65536", "500000", "2000000", 2_000_000])
+def test_values_at_or_above_the_floor_are_preserved(raw):
+    assert resolve_max_form_memory_size(raw) == int(raw)
+
+
+def test_configparser_string_is_coerced_to_int():
+    """ConfigParser hands back strings; Flask needs an int."""
+    resolved = resolve_max_form_memory_size("750000")
+    assert resolved == 750000
+    assert isinstance(resolved, int)
+
+
+@pytest.mark.parametrize("raw", ["", "   ", "not-a-number", "12.5"])
+def test_unparseable_values_fall_back_to_the_default(raw):
+    """A typo in config.conf must not take the whole app down at import time."""
+    assert resolve_max_form_memory_size(raw) == FLASK_DEFAULT_FORM_MEMORY_SIZE
+
+
+def test_negative_value_is_clamped_not_treated_as_unlimited():
+    assert resolve_max_form_memory_size("-1") == MIN_FORM_MEMORY_SIZE
+
+
+# ---------------------------------------------------------------------------
+# The behaviour the floor exists to protect: file uploads still work.
+# ---------------------------------------------------------------------------
+def _upload_probe_client(cap):
+    """Minimal Flask app that just parses a multipart upload, so this exercises
+    Werkzeug's parser directly rather than any Hashview route."""
+    app = Flask(__name__)
+    app.config["MAX_FORM_MEMORY_SIZE"] = cap
+
+    @app.post("/upload")
+    def _upload():
+        return {"size": len(request.files["file"].read())}
+
+    return app.test_client()
+
+
+@pytest.mark.parametrize("size", [10_000, 200_000, 5_000_000])
+def test_file_upload_succeeds_at_the_floor(size):
+    """At MIN_FORM_MEMORY_SIZE, a multipart file upload of any size parses --
+    files are not counted against the per-field cap."""
+    resp = _upload_probe_client(MIN_FORM_MEMORY_SIZE).post(
+        "/upload",
+        data={"file": (io.BytesIO(b"A" * size), "hashes.txt")},
+        content_type="multipart/form-data",
+    )
+    assert resp.status_code == 200
+    assert resp.get_json()["size"] == size
+
+
+@pytest.mark.parametrize(
+    ("cap", "size"),
+    [
+        (MIN_FORM_MEMORY_SIZE - 1, 200_000),
+        (1000, 10_000),
+        (16, 5_000),
+    ],
+)
+def test_file_upload_breaks_below_the_floor(cap, size):
+    """The regression this floor prevents.
+
+    The multipart chunk check compares ``len(buffer) + len(data)`` against the
+    cap, and each read is at most ``buffer_size`` (64KiB) -- so below the floor
+    a file upload fails once the body outgrows the cap, no matter that the
+    bytes belong to a *file* part. At or above the floor no single chunk can
+    ever exceed the cap, which is why clamping to 64KiB makes uploads safe at
+    any file size.
+    """
+    resp = _upload_probe_client(cap).post(
+        "/upload",
+        data={"file": (io.BytesIO(b"A" * size), "hashes.txt")},
+        content_type="multipart/form-data",
+    )
+    assert resp.status_code == 413
+
+
+def test_pasted_field_is_still_capped_at_the_floor():
+    """Clamping up must not defeat the point of the setting: a pasted textarea
+    larger than the cap is still rejected."""
+    app = Flask(__name__)
+    app.config["MAX_FORM_MEMORY_SIZE"] = MIN_FORM_MEMORY_SIZE
+
+    @app.post("/paste")
+    def _paste():
+        return {"len": len(request.form["hashes"])}
+
+    client = app.test_client()
+
+    ok = client.post("/paste", data={"hashes": "A" * (MIN_FORM_MEMORY_SIZE - 100)})
+    assert ok.status_code == 200
+
+    too_big = client.post("/paste", data={"hashes": "A" * (MIN_FORM_MEMORY_SIZE + 100)})
+    assert too_big.status_code == 413


### PR DESCRIPTION
## Summary
Issue #314's premise was slightly off: `max_form_memory_size` (~488KB) isn't a Hashview setting — it's Flask 3.1's own built-in `MAX_FORM_MEMORY_SIZE` default (500000 bytes), which appears nowhere in this repo or its history. This PR:

- Adds a `MAX_FORM_MEMORY_SIZE` key under `[SERVER]` in `config.conf`/`config.conf.example`, read via the same `.get(key, default)` idiom already used for `SECRET_KEY` (not the bare-indexing idiom used for `SERVER_NAME`, which would `KeyError` on an older config.conf). Defaults to 500000 — Flask's own default — so leaving it unset changes nothing. Note: `config.conf` is baked into the Docker image at build time, so this must be set before `docker compose build`.
- Registers the app's first-ever `@app.errorhandler(413)`. Previously, exceeding the limit produced a bare Werkzeug 413 page or a misleading "You must assign a name to the hashfile" flash. Now it matches the existing AJAX/normal-submit contract used elsewhere (`X-Requested-With: fetch` → JSON `{status, msg}`; normal submit → flash + redirect), with a message pointing at the real workaround: upload the hashes as a file instead, since file uploads aren't subject to this cap.

Closes #314

## Test plan
- [x] New tests trigger a real 413 (tiny configured limit + oversized POST, not a mocked exception): JSON shape for AJAX, flash+redirect for normal submit
- [x] Test confirms `Config.MAX_FORM_MEMORY_SIZE == 500000` when the key is absent, matching Flask's own default
- [x] Full unit suite: 1539 passed, 2 skipped, 46 xfailed, 1 xpassed (pre-existing, unrelated flake)
- [x] ruff clean