### PR TITLE
feat: custom hashcat hash-mode entry for hash_only/user_hash (#447)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Notable changes will be documented here
 **Jobs & Hashfiles**
 - Bulk-select and bulk-delete on the hashfiles list
 - Per-hashfile `--hex-salt` option for salted hash types
+- Custom hashcat hash-mode entry for the `$hash` and `$user:$hash` hashfile formats (#447), for operators running a hashcat build with modes not in Hashview's bundled list. No import-time shape validation is performed on a custom mode. An agent whose hashcat can't benchmark a mode reports it as unsupported instead of hanging: the mode is never re-requested from that agent and it is never dispatched tasks of that type
 
 **Testing**
 - Job-creation performance e2e suite (`tests/e2e/test_job_creation_perf.py`) with a tunable volume seeder (`tests/seed_perf_db.py`), covering latency budgets for each wizard step plus strict-xfail scaling guards for the four endpoints in issue #422 whose cost grows with table size rather than page size

--- a/hashview/agents/routes.py
+++ b/hashview/agents/routes.py
@@ -55,7 +55,7 @@ def _agent_benchmarks(agents_):
         by_agent[row.agent_id].append({
             'hash_type': row.hash_type,
             'name': _MODE_NAMES.get(row.hash_type, ''),
-            'speed': fmt_hps(row.speed, places=2),
+            'speed': 'Unsupported' if row.speed == 0 else fmt_hps(row.speed, places=2),
             'updated_at': row.updated_at,
         })
     return by_agent

--- a/hashview/api/routes.py
+++ b/hashview/api/routes.py
@@ -602,6 +602,7 @@ def v1_api_get_agent_benchmarks():
 
     rows = (db.session.query(AgentBenchmarks.hash_type,
                              db.func.min(AgentBenchmarks.speed))
+            .filter(AgentBenchmarks.speed > 0)
             .group_by(AgentBenchmarks.hash_type).all())
     # An empty fleet is not an error: 200 with an empty map, like the other
     # collection endpoints.

--- a/hashview/api/routes.py
+++ b/hashview/api/routes.py
@@ -38,6 +38,7 @@ from hashview.models import (
 from hashview.utils.audit import log_event
 from hashview.utils.utils import (
     MAX_TASKS_PER_GROUP,
+    _job_hash_type,
     build_job_task_commands,
     compress_to_gz,
     decompress_gz,
@@ -448,7 +449,13 @@ def v1_api_set_agent_heartbeat():
                                   func.min(JobTasks.id).label('first_id'))
                               .group_by(JobTasks.job_id, JobTasks.task_id)
                               .subquery())
-                job_task_entry = (db.session.query(JobTasks)
+                # Don't dispatch this agent a task whose hash type it has already
+                # reported unsupported (speed 0) -- it would just re-report 0 and
+                # waste the chunk slot. Walk the ordered candidates and skip those.
+                unsupported = {b.hash_type for b in
+                               AgentBenchmarks.query.filter_by(agent_id=agent.id, speed=0).all()}
+                job_task_entry = None
+                for candidate in (db.session.query(JobTasks)
                                   .join(task_first,
                                         (JobTasks.job_id == task_first.c.job_id)
                                         & (JobTasks.task_id == task_first.c.task_id))
@@ -456,8 +463,12 @@ def v1_api_set_agent_heartbeat():
                                   .order_by(JobTasks.priority.desc(),
                                             task_first.c.first_id.asc(),
                                             JobTasks.chunk_no.asc(),
-                                            JobTasks.id.asc())
-                                  .first())
+                                            JobTasks.id.asc())):
+                    cand_job = Jobs.query.get(candidate.job_id)
+                    if unsupported and cand_job is not None and _job_hash_type(cand_job) in unsupported:
+                        continue
+                    job_task_entry = candidate
+                    break
                 if job_task_entry:
                     # Don't start a fresh chunk of a task that's already over its
                     # runtime cap. This closes the gap where, at the cap moment, no
@@ -528,12 +539,13 @@ def v1_api_post_agent_benchmark():
     for mode in results:
         try:
             m = int(mode)
+            s = int(float(results[mode]))
         except (TypeError, ValueError):
             current_app.logger.debug(
-                'Agent %s benchmark pre-scan: non-integer mode %r; skipping.',
-                agent.id, mode)
+                'Agent %s benchmark pre-scan: unparseable entry %r=%r; skipping.',
+                agent.id, mode, results[mode])
             continue
-        if not slowest_benchmark(m):
+        if s > 0 and not slowest_benchmark(m):
             pending.add(m)
 
     for mode, speed in results.items():

--- a/hashview/api_docs/openapi.yaml
+++ b/hashview/api_docs/openapi.yaml
@@ -1131,7 +1131,12 @@ paths:
           in: path
           required: true
           schema: {type: integer}
-          description: Hashcat hash mode (e.g. 1000 for NTLM).
+          description: >-
+            Hashcat hash mode (e.g. 1000 for NTLM). When file_format is 4
+            (user:hash) or 5 (hash_only), this is not restricted to Hashview's
+            bundled/documented mode list — any hashcat mode number hashcat
+            itself supports may be used, including modes Hashview doesn't
+            otherwise curate a friendly name or structural validator for.
         - name: hashfile_name
           in: path
           required: true

--- a/hashview/customers/routes.py
+++ b/hashview/customers/routes.py
@@ -26,7 +26,7 @@ def _hash_type_names():
         for sel in (f.hash_type, f.pwdump_hash_type, f.netntlm_hash_type,
                     f.kerberos_hash_type, f.shadow_hash_type):
             for v, lab in sel.choices:
-                if v is not None and str(v) and str(v) not in names:
+                if v is not None and str(v) and str(v).isdigit() and str(v) not in names:
                     nm = lab.split(') ', 1)[1] if ') ' in lab else lab
                     names[str(v)] = nm.split(' / ')[0].split(',')[0].strip()
     except Exception:  # pragma: no cover - defensive

--- a/hashview/hashfiles/routes.py
+++ b/hashview/hashfiles/routes.py
@@ -56,7 +56,7 @@ def hashfiles_list():
         for _sel in (_form.hash_type, _form.pwdump_hash_type, _form.netntlm_hash_type,
                      _form.kerberos_hash_type, _form.shadow_hash_type):
             for _val, _label in _sel.choices:
-                if _val is not None and str(_val) not in hash_type_names:
+                if _val is not None and str(_val).isdigit() and str(_val) not in hash_type_names:
                     _name = _label.split(') ', 1)[1] if ') ' in _label else _label
                     hash_type_names[str(_val)] = _name.split(' / ')[0].split(',')[0].strip()
     except Exception:  # pragma: no cover - defensive: never break the list page

--- a/hashview/jobs/forms.py
+++ b/hashview/jobs/forms.py
@@ -3,6 +3,7 @@ from flask_wtf import FlaskForm
 from wtforms import (
 	BooleanField,
 	FileField,
+	IntegerField,
 	SelectField,
 	StringField,
 	SubmitField,
@@ -12,6 +13,7 @@ from wtforms.validators import DataRequired, ValidationError
 
 from hashview.models import Jobs
 from hashview.utils.hashcat_modes import (
+	CUSTOM_HASH_TYPE,
 	HASH_TYPE_CHOICES,
 	KERBEROS_HASH_TYPE_CHOICES,
 	NETNTLM_HASH_TYPE_CHOICES,
@@ -52,7 +54,35 @@ class JobsNewHashFileForm(FlaskForm):
 													('user_hash', '$user:$hash'),
 													('hash_only', '$hash')], validators=[DataRequired()])
 													
-    hash_type = SelectField('Hash Type', choices=HASH_TYPE_CHOICES)
+    hash_type = SelectField('Hash Type', choices=HASH_TYPE_CHOICES + [(CUSTOM_HASH_TYPE, 'Custom (enter mode number)')])
+
+    # custom_hash_type is present (though hidden) on every hash-file upload
+    # submission, not just custom-mode ones, so it is legitimately blank most
+    # of the time. IntegerField's own process_formdata() raises "Not a valid
+    # integer value" on int(''), and that process error lands in field.errors
+    # unconditionally -- before any validators run -- which would fail
+    # validate() on every ordinary (non-custom) submission. Coerce a blank
+    # submitted value to None here instead of erroring, and do the
+    # conditionally-required + range check by hand in validate_custom_hash_type
+    # below (a field-level Optional()/NumberRange() pairing doesn't work here:
+    # Optional() raises StopValidation on blank input, which aborts the
+    # validator chain before the inline validate_custom_hash_type method --
+    # appended to that same chain by WTForms -- ever runs).
+    class _BlankableIntegerField(IntegerField):
+        def process_formdata(self, valuelist):
+            if valuelist and (valuelist[0] is None or not str(valuelist[0]).strip()):
+                self.data = None
+                return
+            super().process_formdata(valuelist)
+
+    custom_hash_type = _BlankableIntegerField('Custom Hash Mode')
+
+    def validate_custom_hash_type(self, field):
+        # Named validate_custom_hash_type per this file's inline-validator convention
+        # (see comment at line 36) so WTForms runs it automatically.
+        if self.hash_type.data == CUSTOM_HASH_TYPE:
+            if field.data is None or not (0 <= field.data <= 99999):
+                raise ValidationError('Enter a hashcat mode number for the custom hash type.')
 
     shadow_hash_type = SelectField('Hash Type', choices=SHADOW_HASH_TYPE_CHOICES)
 

--- a/hashview/jobs/routes.py
+++ b/hashview/jobs/routes.py
@@ -40,6 +40,7 @@ from hashview.models import (
     db,
 )
 from hashview.utils.audit import log_event
+from hashview.utils.hashcat_modes import CUSTOM_HASH_TYPE
 from hashview.utils.utils import (
     apply_name_filter,
     build_job_task_commands,
@@ -57,6 +58,17 @@ from hashview.utils.utils import (
 )
 
 jobs = Blueprint('jobs', __name__)
+
+
+def _resolved_hash_type(form):
+    """Resolve the form's hash_type field to the mode string to store/validate.
+
+    Translates the 'custom' sentinel to the operator-typed mode number so the
+    literal string 'custom' can never reach a validator or the DB.
+    """
+    if form.hash_type.data == CUSTOM_HASH_TYPE:
+        return str(form.custom_hash_type.data)
+    return form.hash_type.data
 
 
 def _job_has_alert_hashes(job):
@@ -134,7 +146,7 @@ def jobs_list():
         for _sel in (_f.hash_type, _f.pwdump_hash_type, _f.netntlm_hash_type,
                      _f.kerberos_hash_type, _f.shadow_hash_type):
             for _v, _lab in _sel.choices:
-                if _v is not None and str(_v) not in hash_type_names:
+                if _v is not None and str(_v).isdigit() and str(_v) not in hash_type_names:
                     _nm = _lab.split(') ', 1)[1] if ') ' in _lab else _lab
                     hash_type_names[str(_v)] = _nm.split(' / ')[0].split(',')[0].strip()
     except Exception:  # pragma: no cover - defensive
@@ -280,7 +292,7 @@ def jobs_assigned_hashfile(job_id):
                  jobs_new_hashfile_form.netntlm_hash_type, jobs_new_hashfile_form.kerberos_hash_type,
                  jobs_new_hashfile_form.shadow_hash_type):
         for _val, _label in _sel.choices:
-            if _val and str(_val) not in hash_type_names:
+            if _val and str(_val).isdigit() and str(_val) not in hash_type_names:
                 _name = _label.split(') ', 1)[1] if ') ' in _label else _label
                 hash_type_names[str(_val)] = _name.split(' / ')[0].split(',')[0].strip()
 
@@ -357,10 +369,10 @@ def jobs_assigned_hashfile(job_id):
                     hash_type = jobs_new_hashfile_form.shadow_hash_type.data
                 elif jobs_new_hashfile_form.file_type.data == 'user_hash':
                     has_problem = validate_user_hash_hashfile(hashfile_path)
-                    hash_type = jobs_new_hashfile_form.hash_type.data
+                    hash_type = _resolved_hash_type(jobs_new_hashfile_form)
                 elif jobs_new_hashfile_form.file_type.data == 'hash_only':
-                    has_problem = validate_hash_only_hashfile(hashfile_path, jobs_new_hashfile_form.hash_type.data)
-                    hash_type = jobs_new_hashfile_form.hash_type.data
+                    hash_type = _resolved_hash_type(jobs_new_hashfile_form)
+                    has_problem = validate_hash_only_hashfile(hashfile_path, hash_type)
                 else:
                     has_problem = 'Invalid File Format'
 
@@ -448,8 +460,8 @@ def jobs_assigned_hashfile(job_id):
             # them instead of receiving the full HTML page.
             msgs = []
             for _field in (jobs_new_hashfile_form.name, jobs_new_hashfile_form.file_type,
-                           jobs_new_hashfile_form.hash_type, jobs_new_hashfile_form.hashfile,
-                           jobs_new_hashfile_form.hashfilehashes):
+                           jobs_new_hashfile_form.hash_type, jobs_new_hashfile_form.custom_hash_type,
+                           jobs_new_hashfile_form.hashfile, jobs_new_hashfile_form.hashfilehashes):
                 msgs.extend(str(m) for m in _field.errors)
             return jsonify({'status': 'error',
                             'msg': '; '.join(msgs) or 'Invalid upload request.'}), 400
@@ -936,7 +948,7 @@ def jobs_summary(job_id):
         for _sel in (_f.hash_type, _f.pwdump_hash_type, _f.netntlm_hash_type,
                      _f.kerberos_hash_type, _f.shadow_hash_type):
             for _v, _lab in _sel.choices:
-                if _v is not None and str(_v) not in _names:
+                if _v is not None and str(_v).isdigit() and str(_v) not in _names:
                     _nm = _lab.split(') ', 1)[1] if ') ' in _lab else _lab
                     _names[str(_v)] = _nm.split(' / ')[0].split(',')[0].strip()
         hashfile_hash_type = _names.get(str(hash_mode), 'mode ' + str(hash_mode))

--- a/hashview/main/routes.py
+++ b/hashview/main/routes.py
@@ -95,7 +95,7 @@ def _recovery_feed():
         for _sel in (_f.hash_type, _f.pwdump_hash_type, _f.netntlm_hash_type,
                      _f.kerberos_hash_type, _f.shadow_hash_type):
             for _v, _lab in _sel.choices:
-                if _v is not None and str(_v) not in hash_type_names:
+                if _v is not None and str(_v).isdigit() and str(_v) not in hash_type_names:
                     _nm = _lab.split(') ', 1)[1] if ') ' in _lab else _lab
                     hash_type_names[str(_v)] = _nm.split(' / ')[0].split(',')[0].strip()
     except Exception:  # pragma: no cover - defensive: never break the dashboard

--- a/hashview/notifications/routes.py
+++ b/hashview/notifications/routes.py
@@ -26,7 +26,7 @@ def _hash_type_names():
     for sel in (form.hash_type, form.pwdump_hash_type, form.netntlm_hash_type,
                 form.kerberos_hash_type, form.shadow_hash_type):
         for value, label in sel.choices:
-            if value is not None and str(value) not in names:
+            if value is not None and str(value).isdigit() and str(value) not in names:
                 name = label.split(') ', 1)[1] if ') ' in label else label
                 names[str(value)] = name.split(' / ')[0].split(',')[0].strip()
     return names

--- a/hashview/templates/jobs_assigned_hashfiles.html.j2
+++ b/hashview/templates/jobs_assigned_hashfiles.html.j2
@@ -54,6 +54,14 @@
         }
     }
 
+    function hvCustomHashType(sel){
+        var d = document.getElementById('custom_hash_type_div');
+        var on = (sel && sel.value === 'custom');
+        d.style.display = on ? 'block' : 'none';
+        var inp = d.querySelector('input'); if (inp) inp.required = on;
+        hvHfGate();
+    }
+
     // show the hash-type select that matches the chosen file format
     function showHashTypeSelected(sel){
         var map = {pwdump:'pwdump_hash_type_div', NetNTLM:'netntlm_hash_type_div', kerberos:'kerberos_hash_type_div',
@@ -73,6 +81,9 @@
         // --hex-salt applies only to the colon-delimited hash_only / user_hash formats
         var hs = document.getElementById('hex_salt_div');
         if (hs) hs.style.display = (sel.value === 'hash_only' || sel.value === 'user_hash') ? 'flex' : 'none';
+        // custom mode entry is only meaningful for hash_only / user_hash; hide it
+        // (and clear its required flag) when switching to any other format
+        if (sel.value !== 'hash_only' && sel.value !== 'user_hash') hvCustomHashType(null);
         hvHfGate();
     }
 
@@ -170,8 +181,14 @@
                         <div id="netntlm_hash_type_div" style="display:none;">{{ jobsNewHashFileForm.netntlm_hash_type(class="select", onchange="hvHashTypeExample(this)") }}</div>
                         <div id="kerberos_hash_type_div" style="display:none;">{{ jobsNewHashFileForm.kerberos_hash_type(class="select", onchange="hvHashTypeExample(this)") }}</div>
                         <div id="shadow_hash_type_div" style="display:none;">{{ jobsNewHashFileForm.shadow_hash_type(class="select", onchange="hvHashTypeExample(this)") }}</div>
-                        <div id="hash_type_div" style="display:none;">{{ jobsNewHashFileForm.hash_type(class="select", onchange="hvHashTypeExample(this)") }}</div>
+                        <div id="hash_type_div" style="display:none;">{{ jobsNewHashFileForm.hash_type(class="select", onchange="hvHashTypeExample(this); hvCustomHashType(this)") }}</div>
                     </div>
+                </div>
+
+                <div id="custom_hash_type_div" style="display:none;">
+                    <label class="field-label" for="custom_hash_type">Custom hashcat mode <span class="req">*</span></label>
+                    {{ jobsNewHashFileForm.custom_hash_type(class=("input is-invalid" if jobsNewHashFileForm.custom_hash_type.errors else "input"), placeholder="e.g. 31337") }}
+                    {% if jobsNewHashFileForm.custom_hash_type.errors %}<div class="invalid-feedback">{% for e in jobsNewHashFileForm.custom_hash_type.errors %}<span>{{ e }}</span>{% endfor %}</div>{% endif %}
                 </div>
 
                 {# --hex-salt: only the colon-delimited hash_only / user_hash formats carry a

--- a/hashview/templates/jobs_assigned_hashfiles.html.j2
+++ b/hashview/templates/jobs_assigned_hashfiles.html.j2
@@ -58,7 +58,9 @@
         var d = document.getElementById('custom_hash_type_div');
         var on = (sel && sel.value === 'custom');
         d.style.display = on ? 'block' : 'none';
-        var inp = d.querySelector('input'); if (inp) inp.required = on;
+        var inp = d.querySelector('input');
+        if (inp) inp.required = on;
+        if (inp && !on) inp.value = '';
         hvHfGate();
     }
 
@@ -82,8 +84,14 @@
         var hs = document.getElementById('hex_salt_div');
         if (hs) hs.style.display = (sel.value === 'hash_only' || sel.value === 'user_hash') ? 'flex' : 'none';
         // custom mode entry is only meaningful for hash_only / user_hash; hide it
-        // (and clear its required flag) when switching to any other format
-        if (sel.value !== 'hash_only' && sel.value !== 'user_hash') hvCustomHashType(null);
+        // (and clear its required flag) when switching to any other format, and
+        // re-evaluate it (in case the hash_type select still holds 'custom' from
+        // an earlier selection) when switching back to hash_only / user_hash.
+        if (sel.value !== 'hash_only' && sel.value !== 'user_hash') {
+            hvCustomHashType(null);
+        } else {
+            hvCustomHashType(vsel);
+        }
         hvHfGate();
     }
 

--- a/hashview/utils/hashcat_modes.py
+++ b/hashview/utils/hashcat_modes.py
@@ -13,6 +13,8 @@ spec table used by hashview.utils.utils.validate_hash_only_hashfile. Specs:
 Only fixed-shape parts are constrained, so legitimate hashes are not rejected.
 """
 
+CUSTOM_HASH_TYPE = 'custom'   # sentinel select value for a manually-entered mode; never persisted to the DB
+
 HASH_TYPE_CHOICES = [
     ('', '------SELECT------'),
     ('0', '(0) MD5'),

--- a/hashview/utils/utils.py
+++ b/hashview/utils/utils.py
@@ -974,10 +974,12 @@ def slowest_benchmark(hash_type):
 
     Chunk sizes are computed from the SLOWEST agent so the weakest hardware still
     finishes a chunk in roughly the target duration. Returns None when no agent
-    has benchmarked this hash type yet (caller then runs the task whole).
+    has benchmarked this hash type yet, or when every agent that tried reported
+    it unsupported (speed 0) -- caller then runs the task whole.
     """
     return db.session.query(db.func.min(AgentBenchmarks.speed)) \
-        .filter(AgentBenchmarks.hash_type == hash_type).scalar()
+        .filter(AgentBenchmarks.hash_type == hash_type, AgentBenchmarks.speed > 0) \
+        .scalar()
 
 
 _SPEED_UNIT_MULT = {'': 1, 'K': 1e3, 'M': 1e6, 'G': 1e9, 'T': 1e12, 'P': 1e15, 'E': 1e18}

--- a/install/hashview-agent/hashview-agent.py
+++ b/install/hashview-agent/hashview-agent.py
@@ -535,13 +535,16 @@ def run_benchmark(hash_modes):
             continue
         results[str(mode)] = speed
         LOG.info('Hash mode %s benchmark: %s H/s', mode, speed)
-    if failed:
-        api.sendError(
-            'hashcat on this agent could not benchmark hash mode(s): '
-            + ', '.join(str(m) for m in failed)
-            + '. These modes will be marked unsupported for this agent.')
     if results:
         report_benchmark(results)
+    if failed:
+        try:
+            api.sendError(
+                'hashcat on this agent could not benchmark hash mode(s): '
+                + ', '.join(str(m) for m in failed)
+                + '. These modes will be marked unsupported for this agent.')
+        except Exception:
+            LOG.exception('Failed to report unsupported hash modes to the server.')
 
 
 def report_benchmark(results):

--- a/install/hashview-agent/hashview-agent.py
+++ b/install/hashview-agent/hashview-agent.py
@@ -499,6 +499,10 @@ def run_benchmark(hash_modes):
 
     Triggered by a heartbeat reply of msg='BENCHMARK'. The server uses these
     per-(agent, hash type) speeds to size task chunks for the slowest agent.
+    A mode this hashcat build can't benchmark is reported as speed 0 (rather
+    than omitted) so the server can record "attempted, unsupported" and stop
+    re-asking for it every heartbeat; see hashview/api/routes.py's
+    heartbeat and slowest_benchmark for the other half of this contract.
     """
     from agent.bench import parse_benchmark_speed, parse_hc_extra_args
     from agent.config import Config
@@ -506,6 +510,7 @@ def run_benchmark(hash_modes):
     # measured rate reflects the same devices that will run the crack.
     hc_args = parse_hc_extra_args(getattr(Config, 'HC_EXTRA_ARGS', ''))
     results = {}
+    failed = []
     for mode in hash_modes or []:
         LOG.info('Benchmarking hash mode %s...', mode)
         try:
@@ -516,16 +521,25 @@ def run_benchmark(hash_modes):
                 capture_output=True,
                 timeout=BENCHMARK_TIMEOUT)
         except Exception:
-            LOG.exception('Benchmark failed for hash mode %s; skipping.', mode)
+            LOG.exception('Benchmark failed for hash mode %s; reporting unsupported.', mode)
+            results[str(mode)] = 0
+            failed.append(mode)
             continue
         output = ((proc.stdout or b'').decode('utf-8', 'replace')
                   + (proc.stderr or b'').decode('utf-8', 'replace'))
         speed = parse_benchmark_speed(output)
         if speed is None:
-            LOG.warning('Could not parse a benchmark speed for hash mode %s.', mode)
+            LOG.warning('Could not parse a benchmark speed for hash mode %s; reporting unsupported.', mode)
+            results[str(mode)] = 0
+            failed.append(mode)
             continue
         results[str(mode)] = speed
         LOG.info('Hash mode %s benchmark: %s H/s', mode, speed)
+    if failed:
+        api.sendError(
+            'hashcat on this agent could not benchmark hash mode(s): '
+            + ', '.join(str(m) for m in failed)
+            + '. These modes will be marked unsupported for this agent.')
     if results:
         report_benchmark(results)
 

--- a/tests/agent_unit/test_run_benchmark.py
+++ b/tests/agent_unit/test_run_benchmark.py
@@ -16,8 +16,6 @@ import types
 from pathlib import Path
 from unittest import mock
 
-import pytest
-
 AGENT_ROOT = Path(__file__).resolve().parents[2] / "install" / "hashview-agent"
 
 

--- a/tests/agent_unit/test_run_benchmark.py
+++ b/tests/agent_unit/test_run_benchmark.py
@@ -211,6 +211,36 @@ def test_run_benchmark_no_failures_does_not_send_error(monkeypatch):
         agent.bench.parse_benchmark_speed = original_parse
 
 
+def test_run_benchmark_report_survives_send_error_exception(monkeypatch):
+    """report_benchmark must run (and run first) even if api.sendError raises.
+
+    sendError posts to /v1/error, which triggers a synchronous notify_admins()
+    server-side. If that call hangs or raises, the speed=0 rows that end the
+    fleet-starvation loop must still get reported -- and the exception must
+    not propagate out of run_benchmark.
+    """
+    failed_mode = 1000
+
+    mock_run = mock.MagicMock()
+    mock_run.side_effect = RuntimeError("hashcat not found")
+    monkeypatch.setattr(agent_main.subprocess, "run", mock_run)
+
+    mock_send_error = mock.MagicMock(side_effect=RuntimeError("notify_admins blew up"))
+    monkeypatch.setattr(agent_main.api, "sendError", mock_send_error)
+    mock_report = mock.MagicMock()
+    monkeypatch.setattr(agent_main, "report_benchmark", mock_report)
+
+    # Must not raise despite sendError blowing up.
+    agent_main.run_benchmark([failed_mode])
+
+    # report_benchmark must have been called with the full results dict,
+    # and sendError must still have been attempted.
+    assert mock_report.call_count == 1
+    results = mock_report.call_args[0][0]
+    assert results == {'1000': 0}
+    assert mock_send_error.call_count == 1
+
+
 def test_run_benchmark_empty_modes_list(monkeypatch):
     """When hash_modes is empty or None, do nothing."""
     mock_send_error = mock.MagicMock()

--- a/tests/agent_unit/test_run_benchmark.py
+++ b/tests/agent_unit/test_run_benchmark.py
@@ -1,0 +1,228 @@
+"""Tests for run_benchmark function in the hashview agent.
+
+When a hashcat build can't benchmark a requested mode (subprocess raises or
+parse_benchmark_speed returns None), the agent now:
+1. Records the mode in results with speed=0
+2. Collects failed modes and calls api.sendError once with all failed modes named
+3. Still calls report_benchmark with the full results dict (including 0 entries)
+
+This ensures the server records "attempted, unsupported" for each mode and stops
+re-asking for it every heartbeat.
+"""
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+AGENT_ROOT = Path(__file__).resolve().parents[2] / "install" / "hashview-agent"
+
+
+def _load_agent_main():
+    if "psutil" not in sys.modules:
+        stub = types.ModuleType("psutil")
+
+        class _PsutilError(Exception):
+            pass
+
+        stub.Error = _PsutilError
+        stub.NoSuchProcess = type("NoSuchProcess", (_PsutilError,), {})
+        stub.AccessDenied = type("AccessDenied", (_PsutilError,), {})
+        stub.ZombieProcess = type("ZombieProcess", (_PsutilError,), {})
+        stub.process_iter = lambda *a, **k: []
+        sys.modules["psutil"] = stub
+
+    real_exists = os.path.exists
+    path = AGENT_ROOT / "hashview-agent.py"
+    with mock.patch.object(sys, "argv", ["hashview-agent.py"]), \
+         mock.patch(
+             "os.path.exists",
+             side_effect=lambda p: True if str(p).endswith("agent/config.conf") else real_exists(p),
+         ):
+        spec = importlib.util.spec_from_file_location("hashview_agent_main_benchmark", path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+    return mod
+
+
+agent_main = _load_agent_main()
+
+
+def test_run_benchmark_subprocess_exception_records_zero_speed_and_sends_error(monkeypatch):
+    """When subprocess.run raises for a mode, record speed=0 and send error."""
+    failed_mode = 1000
+
+    # Mock the dependencies
+    mock_run = mock.MagicMock()
+    mock_run.side_effect = RuntimeError("hashcat not found")
+    monkeypatch.setattr(agent_main.subprocess, "run", mock_run)
+
+    mock_send_error = mock.MagicMock()
+    monkeypatch.setattr(agent_main.api, "sendError", mock_send_error)
+    mock_report = mock.MagicMock()
+    monkeypatch.setattr(agent_main, "report_benchmark", mock_report)
+
+    # Run the benchmark
+    agent_main.run_benchmark([failed_mode])
+
+    # Verify: speed=0 in results, sendError called, report_benchmark called
+    assert mock_report.call_count == 1
+    results = mock_report.call_args[0][0]
+    assert results == {'1000': 0}
+
+    assert mock_send_error.call_count == 1
+    error_msg = mock_send_error.call_args[0][0]
+    assert '1000' in error_msg
+    assert 'could not benchmark' in error_msg
+
+
+def test_run_benchmark_parse_none_records_zero_speed_and_sends_error(monkeypatch):
+    """When parse_benchmark_speed returns None for a mode, record speed=0 and send error."""
+    failed_mode = 2000
+
+    # Mock subprocess to succeed but return output that can't be parsed
+    mock_proc = mock.MagicMock()
+    mock_proc.stdout = b"Some output"
+    mock_proc.stderr = b""
+    mock_run = mock.MagicMock(return_value=mock_proc)
+    monkeypatch.setattr(agent_main.subprocess, "run", mock_run)
+
+    # Mock parse_benchmark_speed to return None
+    import agent.bench
+    original_parse = agent.bench.parse_benchmark_speed
+    mock_parse = mock.MagicMock(return_value=None)
+    agent.bench.parse_benchmark_speed = mock_parse
+
+    mock_send_error = mock.MagicMock()
+    monkeypatch.setattr(agent_main.api, "sendError", mock_send_error)
+    mock_report = mock.MagicMock()
+    monkeypatch.setattr(agent_main, "report_benchmark", mock_report)
+
+    try:
+        agent_main.run_benchmark([failed_mode])
+
+        # Verify: speed=0 in results, sendError called, report_benchmark called
+        assert mock_report.call_count == 1
+        results = mock_report.call_args[0][0]
+        assert results == {'2000': 0}
+
+        assert mock_send_error.call_count == 1
+        error_msg = mock_send_error.call_args[0][0]
+        assert '2000' in error_msg
+        assert 'could not benchmark' in error_msg
+    finally:
+        agent.bench.parse_benchmark_speed = original_parse
+
+
+def test_run_benchmark_mixed_success_and_failure(monkeypatch):
+    """When some modes succeed and some fail, all are in results and sendError only names failed."""
+    success_mode = 0
+    failed_mode = 1000
+
+    # Mock subprocess for the success case
+    mock_proc_success = mock.MagicMock()
+    mock_proc_success.stdout = b"Speed.#1.........: 12345 H/s"
+    mock_proc_success.stderr = b""
+
+    # Subprocess raises for the failure case
+    def subprocess_side_effect(argv, **kwargs):
+        mode = argv[-1]  # last arg is the mode
+        if mode == str(success_mode):
+            return mock_proc_success
+        else:
+            raise RuntimeError("unsupported hash type")
+
+    mock_run = mock.MagicMock(side_effect=subprocess_side_effect)
+    monkeypatch.setattr(agent_main.subprocess, "run", mock_run)
+
+    # Mock parse_benchmark_speed to return speed for success mode
+    import agent.bench
+    original_parse = agent.bench.parse_benchmark_speed
+    mock_parse = mock.MagicMock(side_effect=lambda o: 12345 if "12345" in o else None)
+    agent.bench.parse_benchmark_speed = mock_parse
+
+    mock_send_error = mock.MagicMock()
+    monkeypatch.setattr(agent_main.api, "sendError", mock_send_error)
+    mock_report = mock.MagicMock()
+    monkeypatch.setattr(agent_main, "report_benchmark", mock_report)
+
+    try:
+        agent_main.run_benchmark([success_mode, failed_mode])
+
+        # Verify: both in results, only failed mode in error message
+        assert mock_report.call_count == 1
+        results = mock_report.call_args[0][0]
+        assert results['0'] == 12345
+        assert results['1000'] == 0
+
+        assert mock_send_error.call_count == 1
+        error_msg = mock_send_error.call_args[0][0]
+        assert '1000' in error_msg
+        # Verify that the error message only mentions failed modes, not successful ones.
+        # The error should say "1000" but not list "0" as a separate failed mode.
+        # We can verify this by checking that the message doesn't contain both
+        # the mode number 0 AND a comma-separated mode list that includes it.
+        import re
+        # Extract modes from message using regex for "mode(s): <list>"
+        modes_match = re.search(r'mode\(s\): ([^.]+)', error_msg)
+        assert modes_match
+        modes_text = modes_match.group(1)
+        assert modes_text == '1000', f"Expected only '1000' in failed modes, got: {modes_text}"
+        assert 'could not benchmark' in error_msg
+    finally:
+        agent.bench.parse_benchmark_speed = original_parse
+
+
+def test_run_benchmark_no_failures_does_not_send_error(monkeypatch):
+    """When all modes benchmark successfully, sendError is not called."""
+    success_modes = [0, 1000]
+
+    # Mock subprocess to always succeed
+    mock_proc = mock.MagicMock()
+    mock_proc.stdout = b"Speed.#1.........: 12345 H/s"
+    mock_proc.stderr = b""
+    mock_run = mock.MagicMock(return_value=mock_proc)
+    monkeypatch.setattr(agent_main.subprocess, "run", mock_run)
+
+    # Mock parse_benchmark_speed to always return a speed
+    import agent.bench
+    original_parse = agent.bench.parse_benchmark_speed
+    mock_parse = mock.MagicMock(return_value=12345)
+    agent.bench.parse_benchmark_speed = mock_parse
+
+    mock_send_error = mock.MagicMock()
+    monkeypatch.setattr(agent_main.api, "sendError", mock_send_error)
+    mock_report = mock.MagicMock()
+    monkeypatch.setattr(agent_main, "report_benchmark", mock_report)
+
+    try:
+        agent_main.run_benchmark(success_modes)
+
+        # Verify: sendError not called, report_benchmark called with both modes
+        assert mock_report.call_count == 1
+        results = mock_report.call_args[0][0]
+        assert results == {'0': 12345, '1000': 12345}
+
+        assert mock_send_error.call_count == 0
+    finally:
+        agent.bench.parse_benchmark_speed = original_parse
+
+
+def test_run_benchmark_empty_modes_list(monkeypatch):
+    """When hash_modes is empty or None, do nothing."""
+    mock_send_error = mock.MagicMock()
+    monkeypatch.setattr(agent_main.api, "sendError", mock_send_error)
+    mock_report = mock.MagicMock()
+    monkeypatch.setattr(agent_main, "report_benchmark", mock_report)
+
+    # Both empty list and None should be handled
+    agent_main.run_benchmark([])
+    assert mock_report.call_count == 0
+    assert mock_send_error.call_count == 0
+
+    agent_main.run_benchmark(None)
+    assert mock_report.call_count == 0
+    assert mock_send_error.call_count == 0

--- a/tests/unit/test_benchmark_unsupported_mode.py
+++ b/tests/unit/test_benchmark_unsupported_mode.py
@@ -1,0 +1,197 @@
+"""Regression tests for issue #447's server-side benchmark bookkeeping.
+
+Covers:
+1. slowest_benchmark ignores speed=0 rows (a zero-speed agent must not drag
+   the reported minimum -- and therefore chunk sizing -- to a falsy 0).
+2. The /v1/agents/benchmark pre-scan does not treat a fresh zero-report as
+   "pending work to rechunk" (that was the starvation-loop trigger).
+3. The heartbeat's Idle dispatch never hands an agent a task whose hash type
+   it has already reported unsupported (speed=0); it is dispatched other
+   queued work instead, or 'OK' if nothing else qualifies. A zero-speed row
+   also does not cause the agent to be re-asked to BENCHMARK that hash type.
+
+Reuses the agent/heartbeat fixture patterns from test_api_agent_protocol.py
+(_agent, _set_agent_cookies, DOMAIN) rather than inventing new ones.
+"""
+
+import json
+
+from hashview.models import (
+    AgentBenchmarks,
+    Agents,
+    Customers,
+    Hashes,
+    HashfileHashes,
+    Hashfiles,
+    Jobs,
+    JobTasks,
+    Settings,
+    db,
+)
+from hashview.utils.utils import slowest_benchmark
+
+DOMAIN = "localhost.test"
+
+
+def _agent(uuid="agent-uuid", status="Idle"):
+    a = Agents(name="a1", src_ip="127.0.0.1", uuid=uuid, status=status)
+    db.session.add(a)
+    db.session.commit()
+    return a
+
+
+def _set_agent_cookies(client, uuid):
+    import hashview
+    client.set_cookie("uuid", uuid, domain=DOMAIN)
+    client.set_cookie("agent_version", hashview.__version__, domain=DOMAIN)
+
+
+def _body(resp):
+    return json.loads(resp.get_data(as_text=True))
+
+
+def _job_with_hash_type(hash_type, name="j"):
+    """A Running job whose hashfile contains a single hash of ``hash_type``,
+    so _job_hash_type(job) resolves to it."""
+    cust = Customers(name=f"C-{name}")
+    db.session.add(cust)
+    db.session.commit()
+    hf = Hashfiles(name=f"hf-{name}", customer_id=cust.id, owner_id=1)
+    db.session.add(hf)
+    db.session.commit()
+    h = Hashes(sub_ciphertext=f"{hash_type:032X}", ciphertext="AAA",
+               hash_type=hash_type, cracked=False)
+    db.session.add(h)
+    db.session.commit()
+    db.session.add(HashfileHashes(hash_id=h.id, hashfile_id=hf.id))
+    job = Jobs(name=name, status="Running", customer_id=cust.id, owner_id=1,
+               priority=3, hashfile_id=hf.id)
+    db.session.add(job)
+    db.session.commit()
+    return job
+
+
+# --- slowest_benchmark -------------------------------------------------------
+
+def test_slowest_benchmark_none_when_only_zero_speed_row(app, client):
+    agent = _agent(uuid="sb-agent")
+    db.session.add(AgentBenchmarks(agent_id=agent.id, hash_type=9999, speed=0))
+    db.session.commit()
+    assert slowest_benchmark(9999) is None
+
+
+def test_slowest_benchmark_ignores_zero_among_mixed_rows(app, client):
+    a1 = _agent(uuid="sb-a1")
+    a2 = _agent(uuid="sb-a2")
+    a3 = _agent(uuid="sb-a3")
+    db.session.add_all([
+        AgentBenchmarks(agent_id=a1.id, hash_type=8888, speed=0),
+        AgentBenchmarks(agent_id=a2.id, hash_type=8888, speed=500),
+        AgentBenchmarks(agent_id=a3.id, hash_type=8888, speed=1000),
+    ])
+    db.session.commit()
+    assert slowest_benchmark(8888) == 500
+
+
+# --- benchmark pre-scan: zero report is not "pending" ------------------------
+
+def test_zero_speed_benchmark_does_not_trigger_rechunk(app, client, monkeypatch):
+    called = []
+    monkeypatch.setattr(
+        "hashview.api.routes.rechunk_queued_tasks_for_hashtype",
+        lambda hash_type: called.append(hash_type))
+    agent = _agent(uuid="zero-bench")
+    _set_agent_cookies(client, "zero-bench")
+
+    resp = client.post("/v1/agents/benchmark",
+                       json={"benchmark_results": {"7777": 0}})
+    assert _body(resp)["msg"] == "OK"
+    assert called == []                          # never rechunked
+    row = AgentBenchmarks.query.filter_by(agent_id=agent.id, hash_type=7777).first()
+    assert row is not None and row.speed == 0     # but still recorded (Task 1 contract)
+
+
+def test_nonzero_first_benchmark_still_triggers_rechunk(app, client, monkeypatch):
+    # Sanity check the pre-scan restructure didn't also break the real case.
+    called = []
+    monkeypatch.setattr(
+        "hashview.api.routes.rechunk_queued_tasks_for_hashtype",
+        lambda hash_type: called.append(hash_type))
+    agent = _agent(uuid="nonzero-bench")
+    _set_agent_cookies(client, "nonzero-bench")
+
+    resp = client.post("/v1/agents/benchmark",
+                       json={"benchmark_results": {"6666": 5000}})
+    assert _body(resp)["msg"] == "OK"
+    assert called == [6666]
+
+
+# --- heartbeat dispatch skips a hash type the agent can't run ---------------
+
+def test_heartbeat_does_not_reask_benchmark_for_zero_speed_mode(app, client):
+    # An agent with a recorded (even zero) benchmark for the in-use hash type
+    # is not sent back to BENCHMARK for it.
+    db.session.add(Settings(retention_period=30, max_runtime_tasks=0, max_runtime_jobs=0))
+    db.session.commit()
+    job = _job_with_hash_type(4444, name="zb")
+    agent = _agent(uuid="zb-agent", status="Idle")
+    db.session.add(AgentBenchmarks(agent_id=agent.id, hash_type=4444, speed=0))
+    db.session.commit()
+    _set_agent_cookies(client, "zb-agent")
+
+    body = _body(client.post("/v1/agents/heartbeat",
+                             json={"agent_status": "Idle", "hc_status": ""}))
+    assert body["msg"] != "BENCHMARK"
+
+
+def test_heartbeat_skips_unsupported_hashtype_dispatches_other_task(app, client):
+    # Agent has already reported hash type X (4001) unsupported (speed=0), and
+    # has a real benchmark for hash type Y (4002). Queued work exists for BOTH,
+    # X first in priority/id order. The agent must be dispatched Y's task, not
+    # X's -- and X's task must remain untouched/Queued.
+    db.session.add(Settings(retention_period=30, max_runtime_tasks=0, max_runtime_jobs=0))
+    db.session.commit()
+    job_x = _job_with_hash_type(4001, name="jx")
+    job_y = _job_with_hash_type(4002, name="jy")
+    agent = _agent(uuid="skip-agent", status="Idle")
+    db.session.add_all([
+        AgentBenchmarks(agent_id=agent.id, hash_type=4001, speed=0),
+        AgentBenchmarks(agent_id=agent.id, hash_type=4002, speed=1000),
+    ])
+    # X queued first (lower id / higher precedence in the default ordering)
+    jt_x = JobTasks(job_id=job_x.id, task_id=1, status="Queued", priority=3)
+    db.session.add(jt_x)
+    db.session.commit()
+    jt_y = JobTasks(job_id=job_y.id, task_id=2, status="Queued", priority=3)
+    db.session.add(jt_y)
+    db.session.commit()
+    _set_agent_cookies(client, "skip-agent")
+
+    body = _body(client.post("/v1/agents/heartbeat",
+                             json={"agent_status": "Idle", "hc_status": ""}))
+    assert body["msg"] == "START"
+    assert body["job_task_id"] == jt_y.id
+    assert JobTasks.query.get(jt_x.id).status == "Queued"
+    assert JobTasks.query.get(jt_x.id).agent_id is None
+    assert JobTasks.query.get(jt_y.id).agent_id == agent.id
+
+
+def test_heartbeat_all_queued_work_unsupported_returns_ok(app, client):
+    # Only queued work is for a hash type the agent has already flagged
+    # unsupported -- nothing else qualifies, so it gets OK (not START, not a
+    # wasted BENCHMARK re-ask since it already has a benchmark row for it).
+    db.session.add(Settings(retention_period=30, max_runtime_tasks=0, max_runtime_jobs=0))
+    db.session.commit()
+    job_x = _job_with_hash_type(5001, name="onlyx")
+    agent = _agent(uuid="onlyx-agent", status="Idle")
+    db.session.add(AgentBenchmarks(agent_id=agent.id, hash_type=5001, speed=0))
+    jt_x = JobTasks(job_id=job_x.id, task_id=1, status="Queued", priority=3)
+    db.session.add(jt_x)
+    db.session.commit()
+    _set_agent_cookies(client, "onlyx-agent")
+
+    body = _body(client.post("/v1/agents/heartbeat",
+                             json={"agent_status": "Idle", "hc_status": ""}))
+    assert body["msg"] == "OK"
+    assert JobTasks.query.get(jt_x.id).status == "Queued"
+    assert JobTasks.query.get(jt_x.id).agent_id is None

--- a/tests/unit/test_benchmark_unsupported_mode.py
+++ b/tests/unit/test_benchmark_unsupported_mode.py
@@ -117,7 +117,7 @@ def test_nonzero_first_benchmark_still_triggers_rechunk(app, client, monkeypatch
     monkeypatch.setattr(
         "hashview.api.routes.rechunk_queued_tasks_for_hashtype",
         lambda hash_type: called.append(hash_type))
-    agent = _agent(uuid="nonzero-bench")
+    _agent(uuid="nonzero-bench")
     _set_agent_cookies(client, "nonzero-bench")
 
     resp = client.post("/v1/agents/benchmark",
@@ -133,7 +133,7 @@ def test_heartbeat_does_not_reask_benchmark_for_zero_speed_mode(app, client):
     # is not sent back to BENCHMARK for it.
     db.session.add(Settings(retention_period=30, max_runtime_tasks=0, max_runtime_jobs=0))
     db.session.commit()
-    job = _job_with_hash_type(4444, name="zb")
+    _job_with_hash_type(4444, name="zb")
     agent = _agent(uuid="zb-agent", status="Idle")
     db.session.add(AgentBenchmarks(agent_id=agent.id, hash_type=4444, speed=0))
     db.session.commit()

--- a/tests/unit/test_jobs_assigned_hashfile.py
+++ b/tests/unit/test_jobs_assigned_hashfile.py
@@ -11,7 +11,7 @@ import os
 
 import pytest
 
-from hashview.models import HashfileHashes, Hashfiles, Jobs, db
+from hashview.models import Hashes, HashfileHashes, Hashfiles, Jobs, db
 from tests.unit.helpers import login, make_admin, make_customer
 
 # A valid hash_only line for hash_type '1000' (NTLM): 32 hex characters.
@@ -30,14 +30,18 @@ EMPTY_SUBTYPES = {
 }
 
 
-def _paste_data(name, hashes=VALID_NTLM, hash_type="1000"):
-    return {
+def _paste_data(name, hashes=VALID_NTLM, hash_type="1000", file_type="hash_only",
+                 custom_hash_type=None):
+    data = {
         "name": name,
-        "file_type": "hash_only",
+        "file_type": file_type,
         "hash_type": hash_type,
         "hashfilehashes": hashes,
         **EMPTY_SUBTYPES,
     }
+    if custom_hash_type is not None:
+        data["custom_hash_type"] = str(custom_hash_type)
+    return data
 
 
 def _job(owner, customer, status="Ready", name="j1"):
@@ -225,3 +229,84 @@ def test_page_renders_the_import_progress_modal(app, client):
     assert b'id="hf-import-modal"' in body
     assert b'id="hf-step-upload"' in body
     assert b'id="hf-step-import"' in body
+
+
+def test_custom_hash_type_hash_only_imports_with_typed_mode(app, client, tmp_snapshot):
+    """A hash_only upload with hash_type='custom' + custom_hash_type=31337
+    imports successfully and stores the typed mode number, never the literal
+    string 'custom' (#447)."""
+    tmp_dir, before = tmp_snapshot
+    admin = make_admin()
+    login(client, admin)
+    cust = make_customer()
+    job = _job(admin, cust)
+
+    resp = client.post(
+        f"/jobs/{job.id}/assigned_hashfile/",
+        data=_paste_data("CustomModeHF", hashes="deadbeef", hash_type="custom",
+                          custom_hash_type=31337),
+        headers=AJAX,
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["status"] == "ok"
+
+    hf = Hashfiles.query.filter_by(name="CustomModeHF").first()
+    assert hf is not None
+    hfh = HashfileHashes.query.filter_by(hashfile_id=hf.id).first()
+    assert hfh is not None
+    stored_hash = Hashes.query.get(hfh.hash_id)
+    assert stored_hash is not None
+    assert stored_hash.hash_type == 31337
+    assert stored_hash.hash_type != "custom"
+
+
+def test_custom_hash_type_user_hash_imports_with_typed_mode(app, client, tmp_snapshot):
+    tmp_dir, before = tmp_snapshot
+    admin = make_admin()
+    login(client, admin)
+    cust = make_customer()
+    job = _job(admin, cust)
+
+    resp = client.post(
+        f"/jobs/{job.id}/assigned_hashfile/",
+        data=_paste_data("CustomModeUserHashHF", hashes="someuser:deadbeef",
+                          hash_type="custom", file_type="user_hash",
+                          custom_hash_type=31337),
+        headers=AJAX,
+    )
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["status"] == "ok"
+
+    hf = Hashfiles.query.filter_by(name="CustomModeUserHashHF").first()
+    assert hf is not None
+    hfh = HashfileHashes.query.filter_by(hashfile_id=hf.id).first()
+    assert hfh is not None
+    stored_hash = Hashes.query.get(hfh.hash_id)
+    assert stored_hash is not None
+    assert stored_hash.hash_type == 31337
+
+
+def test_custom_hash_type_missing_number_fails_validation(app, client, tmp_snapshot):
+    """hash_type='custom' without a custom_hash_type fails clean-message
+    validation, and (for the AJAX path) that message reaches the JSON error
+    response the import modal reads."""
+    tmp_dir, before = tmp_snapshot
+    admin = make_admin()
+    login(client, admin)
+    cust = make_customer()
+    job = _job(admin, cust)
+
+    resp = client.post(
+        f"/jobs/{job.id}/assigned_hashfile/",
+        data=_paste_data("NoCustomModeHF", hashes="deadbeef", hash_type="custom"),
+        headers=AJAX,
+    )
+    assert resp.status_code == 400
+    body = resp.get_json()
+    assert body["status"] == "error"
+    assert "Enter a hashcat mode number" in body["msg"]
+
+    assert Hashfiles.query.filter_by(name="NoCustomModeHF").first() is None
+    assert _new_files(tmp_dir, before) == set()

--- a/tests/unit/test_notifications_routes.py
+++ b/tests/unit/test_notifications_routes.py
@@ -18,6 +18,15 @@ def test_hash_type_names_maps_modes(app):
     assert "1000" in names
 
 
+def test_hash_type_names_skips_custom_sentinel(app):
+    """The 'custom' hash_type sentinel (issue #447) has no ') ' in its label
+    and must be skipped by the isdigit() guard, not stored as a bogus name."""
+    from hashview.jobs.forms import CUSTOM_HASH_TYPE
+    from hashview.notifications.routes import _hash_type_names
+    names = _hash_type_names()
+    assert str(CUSTOM_HASH_TYPE) not in names
+
+
 def test_notifications_list_renders_with_seeded_notification(app, client):
     admin = make_admin()
     login(client, admin)

--- a/tests/unit/test_task_viability_endpoints.py
+++ b/tests/unit/test_task_viability_endpoints.py
@@ -136,3 +136,22 @@ def test_get_benchmark_empty_table(client, admin_user):
     _auth(client, admin_user.api_key)
     body = _body(client.get("/v1/agents/benchmark"))
     assert body["status"] == 200 and body["performance"] == {}
+
+
+def test_get_benchmark_fleet_wide_excludes_zero_speed_rows(client, admin_user):
+    """A mode with one unsupported (speed=0) agent report and one real speed
+    must report the real speed, matching slowest_benchmark's own
+    ``AgentBenchmarks.speed > 0`` filter -- a stray 0 here would let a
+    consumer computing work / performance[mode] divide by zero."""
+    _bench(agent_id=1, hash_type=1000, speed=0)
+    _bench(agent_id=2, hash_type=1000, speed=60_000_000_000)
+    # A mode where the ONLY report is unsupported must be absent entirely,
+    # not reported as 0.
+    _bench(agent_id=1, hash_type=2000, speed=0)
+
+    _auth(client, admin_user.api_key)
+    body = _body(client.get("/v1/agents/benchmark"))
+
+    assert body["status"] == 200
+    assert body["performance"]["1000"] == 60_000_000_000
+    assert "2000" not in body["performance"]


### PR DESCRIPTION
## Summary

Closes #447

Lets operators enter a hashcat hash-mode number that isn't in Hashview's bundled ~477-mode list, for the `$hash` (hash_only) and `$user:$hash` (user_hash) import formats only — the other four formats (pwdump/NetNTLM/kerberos/shadow) keep their curated mode lists, since those validators make structural assumptions about the file that a custom mode could silently break.

Per the issue, this intentionally has no import-time shape validation and requires graceful handling when an agent's hashcat build can't actually run the mode:

- **Agent side** (`install/hashview-agent/hashview-agent.py`): when hashcat can't benchmark a requested mode, the agent now reports it as speed `0` (instead of silently dropping it) and notifies the server via the existing error-reporting channel.
- **Server side** (`hashview/api/routes.py`, `hashview/utils/utils.py`, `hashview/agents/routes.py`): a `speed=0` row means "attempted, unsupported" — the heartbeat stops re-requesting a benchmark for that mode from that agent, chunk-sizing (`slowest_benchmark`) ignores zero-speed rows so one unsupported agent can't silently disable chunking fleet-wide, and the task-dispatch loop skips handing that agent a task of a hash type it's already flagged unsupported (falls through to a different queued task, or `OK` if none qualify). Without this, a single unsupported/typo'd custom mode would put an agent into a permanent benchmark loop, taking no work of *any* type, forever.
- **Web UI** (`hashview/jobs/forms.py`, `hashview/jobs/routes.py`, `hashview/templates/jobs_assigned_hashfiles.html.j2`): a "Custom (enter mode number)" option in the Hash Type dropdown, revealing a number field, resolved to the real integer mode before it ever reaches a validator or the database.
- The `/v1` hashfile-upload API already accepted an arbitrary `hash_type` int for these two formats — no API code change was needed there, just doc/test coverage.

## Testing

- `python -m pytest tests/unit tests/agent_unit -q` — 1716 passed, 2 skipped, 61 xfailed, 1 xpassed (pre-existing, confirmed unrelated), no failures.
- New coverage: `tests/agent_unit/test_run_benchmark.py`, `tests/unit/test_benchmark_unsupported_mode.py`, `tests/unit/test_task_viability_endpoints.py`, `tests/unit/test_notifications_routes.py`, extended `tests/unit/test_jobs_assigned_hashfile.py`.
- Went through subagent-driven-development: each of the three implementation stages and the final whole-branch fix wave had an independent task review before merging into this branch; the final review specifically traced the custom-mode lifecycle end-to-end (UI → DB → benchmark request → agent report → dispatch skip) and verified `-m <mode>` still reaches hashcat via an argv list, never shell-interpolated.
- No new Alembic migration — `Hashes.hash_type` and `AgentBenchmarks.hash_type` are already plain integers.
- Not run: the Playwright e2e suite (requires the docker stack) and a live manual test against a real agent/hashcat build.

### Checklist

- [x] This PR targets `v0.8.3-dev` (the current dev branch), **not** `main`
- [x] Commit subjects follow `type(scope): subject`
- [ ] `scripts/preflight.sh` passes locally (not run — pre-push hook ran the full unit/agent_unit suite + ruff + bandit + secret scan, all clean)
- [x] Pushed through the pre-push hook (not `--no-verify`)
- [x] New/changed behavior has test coverage
- [x] If a route changed: `hashview/api_docs/openapi.yaml` is updated
- [x] If a migration was added: N/A, no migration in this PR
- [x] If user-visible: `CHANGELOG.md` has an entry under `## Current Release`
- [x] N/A items above are just left unchecked, not deleted

## Follow-ups noted, out of scope for this PR

- A job whose hash type *no* agent supports now stalls silently (stays `Queued`) with only an admin notification as a signal — no indicator on the job page itself.
- `already_assigned_task` (`hashview/api/routes.py`) doesn't check the unsupported set — a task assigned to an agent before it reported that mode unsupported can still be re-issued `START` on a later heartbeat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)