### PR TITLE
fix: bind the dev DB port to loopback and move it off 3306

### DIFF
--- a/.githooks/safe-allowlist.txt
+++ b/.githooks/safe-allowlist.txt
@@ -108,3 +108,7 @@ FCF7C1B8749CF99D88E5F34271D636178FB5D130
 # the shared prefix so the pattern also matches this very line, which the
 # generic secret-assign rule flags whenever it is added or moved.
 api_key="user-api-key-
+
+# 0.0.0.0 is the wildcard bind address, not a real host IP. Flagged whenever a
+# compose file or doc explains why a port no longer binds it (#394).
+0\.0\.0\.0

--- a/TESTING.md
+++ b/TESTING.md
@@ -124,9 +124,12 @@ plain `pytest tests/` (and CI) never writes to a live database.
 ```bash
 docker compose up -d --build
 HASHVIEW_DOCKER_BASE_URL=http://127.0.0.1:5000 \
-HASHVIEW_DOCKER_DB_PORT=3306 \
+HASHVIEW_DOCKER_DB_PORT=3308 \
   python -m pytest tests/integration/test_analytics_docker_bugs.py -v
 ```
+
+The `db` service publishes on `127.0.0.1:3308` (loopback-only, see
+`docker-compose.yml`), so this only works from the same host running the stack.
 
 `HASHVIEW_DOCKER_DB_HOST` / `_PORT` / `_USER` / `_PASSWORD` / `_NAME` override the
 seeding connection (defaults: `127.0.0.1:3307`, `hashview`/`hashview`/`hashview`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,12 @@ services:
       MYSQL_PASSWORD: hashview
       MYSQL_RANDOM_ROOT_PASSWORD: yes
     ports:
-      - '3306:3306'
+      # Loopback-only: nothing outside this host needs to reach the dev DB, and
+      # binding 0.0.0.0 put the hardcoded hashview/hashview credentials on the
+      # network of whoever runs the stack (#394). Moved off 3306 so this stack
+      # and the migration e2e stack (docker-compose.migration.yml, also 3306)
+      # can run at the same time without a port collision.
+      - '127.0.0.1:3308:3306'
     volumes:
       - db:/var/lib/mysql
     healthcheck:


### PR DESCRIPTION
## Summary
`docker-compose.yml` published `3306:3306` with no consumer in the repo (the app reaches MySQL over the compose network as `db:3306`) and no doc pointing at it beyond the analytics docker-bug suite, which only ever connects from the same host. Binding `0.0.0.0` put the hardcoded `hashview`/`hashview` credentials on the network of whoever runs the stack.

- Rebinds to `127.0.0.1:3308:3306` — loopback only, and off 3306 so this stack and `docker-compose.migration.yml` (also `3306`) can run at the same time without a collision.
- Updates `TESTING.md`'s analytics-docker-suite example to `HASHVIEW_DOCKER_DB_PORT=3308` and notes the loopback-only bind.
- Allowlists the `0.0.0.0` wildcard-bind-address false positive in the pre-push scanner (it's not a real host IP).

Closes #394

## Test plan
- [x] `docker compose config` valid
- [x] ruff, bandit (vs baseline), openapi-spec-validator, `pytest tests/unit tests/security tests/agent_unit`: 1725 passed, 2 skipped, 61 xfailed