### PR TITLE
fix: unique constraint on task_groups.name to close a TOCTOU race

### DIFF
--- a/hashview/api/routes.py
+++ b/hashview/api/routes.py
@@ -13,6 +13,7 @@ from flask import (
 )
 from packaging import version
 from sqlalchemy import case, exists, func
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.declarative import DeclarativeMeta
 
 import hashview
@@ -1370,7 +1371,15 @@ def v1_api_add_task_group():
         task_group = TaskGroups(name=name, owner_id=user.id, tasks=json.dumps(ordered))
         db.session.add(task_group)
         db.session.commit()
+    except IntegrityError:
+        db.session.rollback()
+        return jsonify({
+            'status': 400,
+            'type': 'Error',
+            'msg': 'A task group with that name already exists'
+        })
     except Exception:
+        db.session.rollback()
         current_app.logger.exception('API /v1/task_groups: failed to add task group')
         return jsonify({
             'status': 500,

--- a/hashview/models.py
+++ b/hashview/models.py
@@ -322,7 +322,7 @@ class TaskGroups(db.Model):
     """Class object to represent TaskGroups"""
 
     id = db.Column(db.Integer, primary_key=True)
-    name = db.Column(db.String(50), nullable=False, unique=True)
+    name = db.Column(db.String(50), nullable=False)
     owner_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
     # Ordered JSON list of task ids. TEXT (65,535 bytes) rather than VARCHAR so
     # a large membership can't silently overflow. The number of entries is
@@ -330,6 +330,12 @@ class TaskGroups(db.Model):
     # so see the constant's comment for where the column is still the tighter
     # limit.
     tasks = db.Column(db.Text, nullable=False)
+    # Named (not bare unique=True) so a model-built schema and the
+    # b5c8d9e1f2a4 migration agree on the constraint name — see that
+    # migration and the uix_agent_hashtype precedent above.
+    __table_args__ = (
+        db.UniqueConstraint('name', name='uq_task_groups_name'),
+    )
 
 class Hashes(db.Model):
     """Class object to represent Hashes"""

--- a/hashview/models.py
+++ b/hashview/models.py
@@ -322,7 +322,7 @@ class TaskGroups(db.Model):
     """Class object to represent TaskGroups"""
 
     id = db.Column(db.Integer, primary_key=True)
-    name = db.Column(db.String(50), nullable=False)
+    name = db.Column(db.String(50), nullable=False, unique=True)
     owner_id = db.Column(db.Integer, db.ForeignKey('users.id'), nullable=False)
     # Ordered JSON list of task ids. TEXT (65,535 bytes) rather than VARCHAR so
     # a large membership can't silently overflow. The number of entries is

--- a/hashview/task_groups/routes.py
+++ b/hashview/task_groups/routes.py
@@ -3,6 +3,7 @@ import json
 
 from flask import Blueprint, abort, flash, redirect, render_template, request, session, url_for
 from flask_login import current_user, login_required
+from sqlalchemy.exc import IntegrityError
 
 from hashview.models import Hashes, TaskGroups, Tasks, Users, db
 from hashview.task_groups.forms import TaskGroupsForm
@@ -114,14 +115,28 @@ def task_groups_add():
                 return redirect(url_for('task_groups.task_groups_list'))
             task_group = TaskGroups(name=task_group_form.name.data, owner_id=current_user.id, tasks=json.dumps(ordered))
             db.session.add(task_group)
-            db.session.commit()
+            try:
+                db.session.commit()
+            except IntegrityError:
+                db.session.rollback()
+                _form_error(
+                    'new-group-modal',
+                    {'name': task_group_form.name.data or ''},
+                    ['That task group name is taken. Please choose a different one.'],
+                    request.form.get('task_ids', ''),
+                )
+                return redirect(url_for('task_groups.task_groups_list'))
             log_event('task_group.create', target=f'task_group:{task_group.id} {task_group.name!r}')
             flash(f'Task group {task_group_form.name.data} created!', 'success')
             return redirect(url_for('task_groups.task_groups_list'))
         # Legacy flow: create an empty group then go to the assign-tasks page.
         task_group = TaskGroups(name=task_group_form.name.data, owner_id=current_user.id, tasks=json.dumps([]))
         db.session.add(task_group)
-        db.session.commit()
+        try:
+            db.session.commit()
+        except IntegrityError:
+            db.session.rollback()
+            return render_template('task_groups_add.html.j2', title='Tasks Add', tasks=tasks, task_group_form=task_group_form, error_message='That task group name is taken. Please choose a different one.')
         log_event('task_group.create', target=f'task_group:{task_group.id} {task_group.name!r}')
         flash(f'Task {task_group_form.name.data} created!', 'success')
         return redirect("assigned_tasks/"+str(task_group.id))
@@ -173,7 +188,17 @@ def task_groups_edit():
             return redirect(url_for('task_groups.task_groups_list'))
         task_group.name = task_group_form.name.data
         task_group.tasks = json.dumps(ordered)
-        db.session.commit()
+        try:
+            db.session.commit()
+        except IntegrityError:
+            db.session.rollback()
+            _form_error(
+                'edit-group-modal',
+                {'name': task_group_form.name.data or '', 'group_id': task_group.id},
+                ['That task group name is taken. Please choose a different one.'],
+                request.form.get('task_ids', ''),
+            )
+            return redirect(url_for('task_groups.task_groups_list'))
         log_event('task_group.edit', target=f'task_group:{task_group.id} {task_group.name!r}')
         flash(f'Task group {task_group_form.name.data} updated!', 'success')
         return redirect(url_for('task_groups.task_groups_list'))

--- a/hashview/task_groups/routes.py
+++ b/hashview/task_groups/routes.py
@@ -136,7 +136,13 @@ def task_groups_add():
             db.session.commit()
         except IntegrityError:
             db.session.rollback()
-            return render_template('task_groups_add.html.j2', title='Tasks Add', tasks=tasks, task_group_form=task_group_form, error_message='That task group name is taken. Please choose a different one.')
+            # phos_field() (macros.html.j2) renders field.errors, not a
+            # standalone message. WTForms populates it as a tuple (immutable),
+            # so append via reassignment rather than a mutating .append().
+            task_group_form.name.errors = tuple(task_group_form.name.errors) + (
+                'That task group name is taken. Please choose a different one.',
+            )
+            return render_template('task_groups_add.html.j2', title='Tasks Add', tasks=tasks, task_group_form=task_group_form)
         log_event('task_group.create', target=f'task_group:{task_group.id} {task_group.name!r}')
         flash(f'Task {task_group_form.name.data} created!', 'success')
         return redirect("assigned_tasks/"+str(task_group.id))

--- a/migrations/versions/b5c8d9e1f2a4_add_unique_constraint_task_groups_name.py
+++ b/migrations/versions/b5c8d9e1f2a4_add_unique_constraint_task_groups_name.py
@@ -1,0 +1,82 @@
+"""add unique constraint on task_groups.name
+
+Revision ID: b5c8d9e1f2a4
+Revises: d3a4a6a7b352
+Create Date: 2026-09-05 00:00:00.000000
+
+Adds a unique constraint on task_groups.name to prevent race conditions in
+check-then-act patterns in both the UI and API routes. The application layer
+currently queries for duplicate names before inserting, but a concurrent insert
+can slip between the check and the commit (TOCTOU). A database-level unique
+index closes the race.
+
+Before applying the constraint, checks for pre-existing duplicate names (which
+would prevent the constraint creation). If duplicates exist, raises RuntimeError
+with a list of them, so the operator can manually rename them before re-running
+the migration. MySQL DDL is non-transactional, so a constraint violation would
+strand mid-apply otherwise.
+
+Guarded on apply (idempotent under schema drift) using sa.inspect so an already-
+constrained column or a table that's absent doesn't cause errors.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'b5c8d9e1f2a4'
+down_revision = 'd3a4a6a7b352'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Check for pre-existing duplicates before creating the constraint.
+    # On a real deployment with actual data, a duplicate-name conflict would
+    # strand the migration mid-apply (MySQL DDL is non-transactional).
+    insp = sa.inspect(op.get_bind())
+    if 'task_groups' not in insp.get_table_names():
+        return  # Table absent; nothing to do.
+
+    # Query for duplicates: SELECT name, COUNT(*) FROM task_groups
+    # GROUP BY name HAVING COUNT(*) > 1
+    bind = op.get_bind()
+    dup_rows = bind.execute(sa.text(
+        'SELECT name, COUNT(*) as cnt FROM task_groups GROUP BY name HAVING COUNT(*) > 1'
+    )).fetchall()
+
+    if dup_rows:
+        dup_names = [row[0] for row in dup_rows]
+        raise RuntimeError(
+            f'Cannot add unique constraint to task_groups.name: '
+            f'duplicate names exist: {dup_names}. '
+            f'Rename them manually before re-running this migration.'
+        )
+
+    # Check if the unique constraint already exists (e.g. schema drift or
+    # a prior partial run).
+    constraint_exists = False
+    for constraint in insp.get_unique_constraints('task_groups'):
+        if 'name' in constraint['column_names']:
+            constraint_exists = True
+            break
+
+    if not constraint_exists:
+        op.create_unique_constraint('uq_task_groups_name', 'task_groups', ['name'])
+
+
+def downgrade():
+    # On downgrade, drop the unique constraint if it exists.
+    insp = sa.inspect(op.get_bind())
+    if 'task_groups' not in insp.get_table_names():
+        return
+
+    constraint_exists = False
+    constraint_name = None
+    for constraint in insp.get_unique_constraints('task_groups'):
+        if 'name' in constraint['column_names']:
+            constraint_exists = True
+            constraint_name = constraint['name']
+            break
+
+    if constraint_exists:
+        op.drop_constraint(constraint_name, 'task_groups', type_='unique')

--- a/migrations/versions/b5c8d9e1f2a4_add_unique_constraint_task_groups_name.py
+++ b/migrations/versions/b5c8d9e1f2a4_add_unique_constraint_task_groups_name.py
@@ -61,7 +61,13 @@ def upgrade():
             break
 
     if not constraint_exists:
-        op.create_unique_constraint('uq_task_groups_name', 'task_groups', ['name'])
+        # batch_alter_table: SQLite has no ALTER TABLE ADD CONSTRAINT, so
+        # op.create_unique_constraint() raises NotImplementedError there
+        # outside batch mode. Batch mode is a plain passthrough on MySQL and a
+        # copy-and-move table rebuild on SQLite -- see dba208b9344c and
+        # c8b3f0a14d27 for the same pattern in this tree.
+        with op.batch_alter_table('task_groups') as batch_op:
+            batch_op.create_unique_constraint('uq_task_groups_name', ['name'])
 
 
 def downgrade():
@@ -79,4 +85,5 @@ def downgrade():
             break
 
     if constraint_exists:
-        op.drop_constraint(constraint_name, 'task_groups', type_='unique')
+        with op.batch_alter_table('task_groups') as batch_op:
+            batch_op.drop_constraint(constraint_name, type_='unique')

--- a/tests/integration/test_migration_e2e.py
+++ b/tests/integration/test_migration_e2e.py
@@ -12,7 +12,7 @@ from sqlalchemy import create_engine, text
 
 from tests.migration.expected_hex import PLAINTEXT_CASES, USERNAME_CASES
 
-DEV_HEAD = "d3a4a6a7b352"
+DEV_HEAD = "b5c8d9e1f2a4"
 
 pytestmark = [pytest.mark.mysql, pytest.mark.migration]
 

--- a/tests/run_migration_e2e.sh
+++ b/tests/run_migration_e2e.sh
@@ -20,7 +20,7 @@ export DOCKER_PLATFORM="${DOCKER_PLATFORM:-linux/amd64}"
 COMPOSE="${COMPOSE_BIN:-docker compose} -f docker-compose.migration.yml"
 KEEP="${HASHVIEW_MIGRATION_KEEP:-0}"
 MAIN_REF="${HASHVIEW_MAIN_REF:-origin/main}"
-DEV_HEAD="d3a4a6a7b352"
+DEV_HEAD="b5c8d9e1f2a4"
 
 TMP_ROOT="$(mktemp -d)"
 MAIN_WT="$TMP_ROOT/hv-main"

--- a/tests/unit/test_api_task_groups.py
+++ b/tests/unit/test_api_task_groups.py
@@ -238,6 +238,55 @@ def test_add_duplicate_name_returns_400(client, admin_user):
 
 
 @pytest.mark.security
+def test_add_duplicate_name_via_race_returns_400(client, admin_user, monkeypatch):
+    """Test that IntegrityError from a race past the pre-check is handled.
+
+    The application-level pre-check (TaskGroups.query.filter_by(name).first())
+    is a TOCTOU race: two requests can both pass the check, then only one can
+    actually commit. This test monkeypatches the pre-check to return None,
+    allowing two adds with the same name to get to db.session.commit(). The
+    first commit succeeds; the second hits the database unique constraint and
+    must return a 400, not a 500.
+    """
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+
+    # Monkeypatch TaskGroups.query.filter_by(name=...).first() to return None,
+    # bypassing the pre-check. This simulates the TOCTOU race.
+    original_filter_by = TaskGroups.query.filter_by
+
+    def mock_filter_by(**kwargs):
+        query_obj = original_filter_by(**kwargs)
+
+        def mock_first():
+            return None  # Always bypass the pre-check
+
+        query_obj.first = mock_first
+        return query_obj
+
+    monkeypatch.setattr(TaskGroups.query, 'filter_by', mock_filter_by)
+
+    # First request with name="RaceName" should succeed (no duplicate yet).
+    resp1 = client.post(
+        "/v1/task_groups/add",
+        data=json.dumps({"name": "RaceName"}),
+        content_type="application/json",
+    )
+    body1 = _json_body(resp1)
+    assert body1["status"] == 200
+
+    # Second request with same name should fail with IntegrityError -> 400,
+    # not 500.
+    resp2 = client.post(
+        "/v1/task_groups/add",
+        data=json.dumps({"name": "RaceName"}),
+        content_type="application/json",
+    )
+    body2 = _json_body(resp2)
+    assert body2["status"] == 400
+    assert body2["msg"] == "A task group with that name already exists"
+
+
+@pytest.mark.security
 def test_add_tasks_not_a_list_returns_400(client, admin_user):
     client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
     resp = client.post(

--- a/tests/unit/test_api_task_groups.py
+++ b/tests/unit/test_api_task_groups.py
@@ -250,20 +250,20 @@ def test_add_duplicate_name_via_race_returns_400(client, admin_user, monkeypatch
     """
     client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
 
-    # Monkeypatch TaskGroups.query.filter_by(name=...).first() to return None,
-    # bypassing the pre-check. This simulates the TOCTOU race.
-    original_filter_by = TaskGroups.query.filter_by
+    # TaskGroups.query is a descriptor (flask_sqlalchemy._QueryProperty) that
+    # builds a NEW Query object on every access, so patching an attribute on
+    # one accessed instance (as a prior version of this test did) never
+    # touches the Query the route actually calls -- the pre-check would just
+    # silently run unpatched and this test would pass for the wrong reason.
+    # Replacing the class attribute itself intercepts every access.
+    class _BypassPreCheckQuery:
+        def filter_by(self, **kwargs):
+            class _NoMatch:
+                def first(self_inner):
+                    return None  # Always bypass the pre-check
+            return _NoMatch()
 
-    def mock_filter_by(**kwargs):
-        query_obj = original_filter_by(**kwargs)
-
-        def mock_first():
-            return None  # Always bypass the pre-check
-
-        query_obj.first = mock_first
-        return query_obj
-
-    monkeypatch.setattr(TaskGroups.query, 'filter_by', mock_filter_by)
+    monkeypatch.setattr(TaskGroups, 'query', _BypassPreCheckQuery())
 
     # First request with name="RaceName" should succeed (no duplicate yet).
     resp1 = client.post(

--- a/tests/unit/test_migration_drift_idempotency.py
+++ b/tests/unit/test_migration_drift_idempotency.py
@@ -24,7 +24,7 @@ from sqlalchemy import text
 
 MIGRATIONS_DIR = str(Path(__file__).resolve().parents[2] / "migrations")
 BASE_REV = "8027c2d2b40a"      # what the drifted field DB was stamped at
-DEV_HEAD = "d3a4a6a7b352"
+DEV_HEAD = "b5c8d9e1f2a4"
 
 
 def _drifted_app(tmp_path, drop_columns=()):

--- a/tests/unit/test_task_groups_routes.py
+++ b/tests/unit/test_task_groups_routes.py
@@ -461,3 +461,47 @@ def test_task_groups_list_exposes_the_cap_to_the_modal_js(app, client):
     assert b"var CAP = 10000" in resp.data
     assert b'id="ng-cap-warn"' in resp.data
     assert b'id="eg-cap-warn"' in resp.data
+
+
+def test_task_groups_add_modal_duplicate_name_via_race_returns_form_error(app, client, monkeypatch):
+    """Test that IntegrityError from a race past the form pre-check is handled.
+
+    The form validator (TaskGroupsForm.validate_name) is a TOCTOU race: two
+    requests can both pass validation, then only one can actually commit. This
+    test monkeypatches the validator to bypass the check, allowing two adds
+    with the same name to get to db.session.commit(). The first commit
+    succeeds; the second hits the database unique constraint and must surface
+    an error through the modal error session dict, not a 500.
+    """
+    admin = make_admin()
+    login(client, admin)
+
+    # Monkeypatch TaskGroupsForm.validate_name to do nothing (always pass).
+    # This simulates the TOCTOU race where validation passes but a concurrent
+    # insert gets there first.
+    def mock_validate_name(self, name):
+        pass  # Skip the check
+
+    monkeypatch.setattr(TaskGroupsForm, 'validate_name', mock_validate_name)
+
+    # First request with name="RaceGroup" should succeed.
+    resp1 = client.post("/task_groups/add", data={
+        "name": "RaceGroup", "from_modal": "1", "task_ids": "", "submit": "Create",
+    }, follow_redirects=False)
+    assert resp1.status_code in (301, 302)
+    tg1 = TaskGroups.query.filter_by(name="RaceGroup").first()
+    assert tg1 is not None
+
+    # Second request with same name should redirect and set the form error
+    # in the session, not return a 500.
+    resp2 = client.post("/task_groups/add", data={
+        "name": "RaceGroup", "from_modal": "1", "task_ids": "", "submit": "Create",
+    }, follow_redirects=False)
+    assert resp2.status_code in (301, 302)
+
+    # Follow the redirect to verify the error appears in the response.
+    resp3 = client.get("/task_groups")
+    assert resp3.status_code == 200
+    # The form error should be visible in the page (e.g. flashed or in the modal
+    # error).
+    assert b"taken" in resp3.data or b"RaceGroup" in resp3.data

--- a/tests/unit/test_task_groups_routes.py
+++ b/tests/unit/test_task_groups_routes.py
@@ -499,9 +499,77 @@ def test_task_groups_add_modal_duplicate_name_via_race_returns_form_error(app, c
     }, follow_redirects=False)
     assert resp2.status_code in (301, 302)
 
-    # Follow the redirect to verify the error appears in the response.
+    # The IntegrityError handler must have set the modal error session dict
+    # directly -- not just left something plausible-looking on the listing
+    # page, which would also be true after the first (successful) POST.
+    with client.session_transaction() as sess:
+        err = sess.get('task_groups_form_err')
+    assert err is not None
+    assert err['modal'] == 'new-group-modal'
+    assert any('taken' in e for e in err['errors'])
+
+    # And it actually renders on the listing page.
     resp3 = client.get("/task_groups")
     assert resp3.status_code == 200
-    # The form error should be visible in the page (e.g. flashed or in the modal
-    # error).
-    assert b"taken" in resp3.data or b"RaceGroup" in resp3.data
+    assert b"taken" in resp3.data
+
+
+def test_task_groups_add_legacy_flow_duplicate_name_via_race_shows_inline_error(app, client, monkeypatch):
+    """Same TOCTOU race as the modal path, but through the legacy standalone
+    /task_groups/add page (no task_ids field). That branch re-renders
+    task_groups_add.html.j2 directly rather than going through the session
+    error mechanism, so the IntegrityError message must land on
+    task_group_form.name.errors -- the only thing phos_field() (macros.html.j2)
+    actually renders -- or it is silently dropped and the user sees no error at
+    all on a lost race.
+    """
+    admin = make_admin()
+    login(client, admin)
+
+    def mock_validate_name(self, name):
+        pass  # Skip the check, simulating a race past validation.
+
+    monkeypatch.setattr(TaskGroupsForm, 'validate_name', mock_validate_name)
+
+    resp1 = client.post("/task_groups/add", data={
+        "name": "LegacyRaceGroup", "submit": "Create",
+    }, follow_redirects=False)
+    assert resp1.status_code in (301, 302, 303)
+    assert TaskGroups.query.filter_by(name="LegacyRaceGroup").first() is not None
+
+    resp2 = client.post("/task_groups/add", data={
+        "name": "LegacyRaceGroup", "submit": "Create",
+    })
+    assert resp2.status_code == 200
+    assert b"taken" in resp2.data
+
+
+def test_task_groups_edit_duplicate_name_via_race_returns_form_error(app, client, monkeypatch):
+    """Same TOCTOU race, but through task_groups_edit: renaming a group to a
+    name another group already holds. The pre-check (_editing_id exemption in
+    TaskGroupsForm.validate_name) is bypassed here the same way the create
+    tests bypass it, so the request reaches db.session.commit() and must hit
+    the IntegrityError branch at task_groups/routes.py, not a 500.
+    """
+    admin = make_admin()
+    login(client, admin)
+    _group(admin, [], name="TakenName")
+    mine = _group(admin, [], name="MyGroup")
+
+    def mock_validate_name(self, name):
+        pass  # Skip the check, simulating a race past validation.
+
+    monkeypatch.setattr(TaskGroupsForm, 'validate_name', mock_validate_name)
+
+    resp = client.post("/task_groups/edit", data={
+        "group_id": mine.id, "name": "TakenName", "task_ids": "", "submit": "Update",
+    }, follow_redirects=False)
+    assert resp.status_code in (301, 302, 303)
+
+    # The rename must not have taken effect.
+    db.session.refresh(mine)
+    assert mine.name == "MyGroup"
+
+    resp2 = client.get("/task_groups")
+    assert resp2.status_code == 200
+    assert b"taken" in resp2.data


### PR DESCRIPTION
## Summary
`TaskGroups.name` had no unique DB constraint — only a check-then-act query in both the UI form and the `/v1` API — so two concurrent creates with the same name could both pass validation and both commit.

- `hashview/models.py` — named unique constraint `uq_task_groups_name` on `TaskGroups.name`.
- New migration `b5c8d9e1f2a4` (chained onto head `d3a4a6a7b352`), guarded and dialect-neutral. It scans for pre-existing duplicate names before applying and raises a clear error naming them if found (MySQL DDL is non-transactional, so a blind `ADD CONSTRAINT` would strand mid-apply on a real deployment). Uses `op.batch_alter_table` — plain `create_unique_constraint` raises `NotImplementedError` on SQLite outside batch mode, which would have made the real DDL line untestable and untested outside a live MySQL run. Verified by forcing the actual downgrade/upgrade DDL cycle against SQLite.
- `DEV_HEAD` bumped to `b5c8d9e1f2a4` in `tests/run_migration_e2e.sh`, `tests/unit/test_migration_drift_idempotency.py`, `tests/integration/test_migration_e2e.py`.
- `hashview/task_groups/routes.py` — `task_groups_add` (both the modal flow and the legacy standalone page) and `task_groups_edit` now catch `IntegrityError`, roll back, and surface "That task group name is taken." The legacy page needed its own fix: the template only renders `field.errors`, not an arbitrary message kwarg.
- `hashview/api/routes.py` — `v1_api_add_task_group` catches `IntegrityError` before the generic handler and returns the same 400 message the existing pre-check already returns (`{'status': 400, 'msg': 'A task group with that name already exists'}`), with a rollback the old generic handler was missing.
- New tests force real races (bypassing the app-level pre-check) for all four write paths: API, modal create, legacy create, edit. Verified via coverage that each actually executes its `except IntegrityError` branch, not just the ordinary pre-check.

Closes #439

## Test plan
- [x] ruff, bandit (vs baseline), openapi-spec-validator, `pytest tests/unit tests/security tests/agent_unit`: 1729 passed, 2 skipped, 61 xfailed
- [x] Manual SQLite check: constraint enforced (duplicate insert → IntegrityError), guarded upgrade is idempotent (second upgrade no-ops), and the real batch-mode DDL (not just the guard) verified via forced downgrade→upgrade cycle
- [ ] `tests/run_migration_e2e.sh` (real MySQL) not run in this environment — a pre-existing unrelated container was occupying port 3306. Recommend running it before merge.