### PR TITLE
fix: replace agent-download os.system with tarfile, stop leaking control/tmp scratch files

### DIFF
--- a/.bandit-baseline.json
+++ b/.bandit-baseline.json
@@ -603,26 +603,6 @@
   },
   "results": [
     {
-      "code": "165     cmd = 'tar -czf hashview/control/tmp/' + filename + ' -C install hashview-agent'\n166     os.system(cmd)\n167 \n",
-      "col_offset": 4,
-      "end_col_offset": 18,
-      "filename": "hashview/agents/routes.py",
-      "issue_confidence": "HIGH",
-      "issue_cwe": {
-        "id": 78,
-        "link": "https://cwe.mitre.org/data/definitions/78.html"
-      },
-      "issue_severity": "HIGH",
-      "issue_text": "Starting a process with a shell, possible injection detected, security issue.",
-      "line_number": 166,
-      "line_range": [
-        166
-      ],
-      "more_info": "https://bandit.readthedocs.io/en/1.9.4/plugins/b605_start_process_with_a_shell.html",
-      "test_id": "B605",
-      "test_name": "start_process_with_a_shell"
-    },
-    {
       "code": "384     # TODO\n385     os.system(cmd)\n386     return send_from_directory('control/tmp', rules_name + '.gz', mimetype = 'application/octet-stream')\n",
       "col_offset": 4,
       "end_col_offset": 18,

--- a/hashview/agents/routes.py
+++ b/hashview/agents/routes.py
@@ -1,5 +1,6 @@
 """Flask routes to handle Agents"""
 import os
+import tarfile
 
 from flask import (
     Blueprint,
@@ -7,7 +8,6 @@ from flask import (
     flash,
     redirect,
     render_template,
-    send_from_directory,
     url_for,
 )
 from flask_login import current_user, login_required
@@ -24,7 +24,7 @@ from hashview.utils.hashcat_modes import (
     NETNTLM_HASH_TYPE_CHOICES,
     SHADOW_HASH_TYPE_CHOICES,
 )
-from hashview.utils.utils import agent_telemetry, fmt_hps, try_commit
+from hashview.utils.utils import agent_telemetry, fmt_hps, send_generated_file, try_commit
 
 agents = Blueprint('agents', __name__)
 
@@ -239,7 +239,10 @@ def agents_download():
     """Function to download agent"""
     version = hashview.__version__
     filename = 'hashview-agent.' + version + '.tgz'
-    cmd = 'tar -czf hashview/control/tmp/' + filename + ' -C install hashview-agent'
-    os.system(cmd)
+    tmp_path = os.path.join('hashview', 'control', 'tmp', filename)
 
-    return send_from_directory('control/tmp', filename, as_attachment=True)
+    # Build the tarball using tarfile instead of shell command
+    with tarfile.open(tmp_path, 'w:gz') as tf:
+        tf.add('install/hashview-agent', arcname='hashview-agent')
+
+    return send_generated_file('control/tmp', filename, as_attachment=True)

--- a/hashview/agents/routes.py
+++ b/hashview/agents/routes.py
@@ -1,5 +1,5 @@
 """Flask routes to handle Agents"""
-import os
+import io
 import tarfile
 
 from flask import (
@@ -8,6 +8,7 @@ from flask import (
     flash,
     redirect,
     render_template,
+    send_file,
     url_for,
 )
 from flask_login import current_user, login_required
@@ -24,7 +25,7 @@ from hashview.utils.hashcat_modes import (
     NETNTLM_HASH_TYPE_CHOICES,
     SHADOW_HASH_TYPE_CHOICES,
 )
-from hashview.utils.utils import agent_telemetry, fmt_hps, send_generated_file, try_commit
+from hashview.utils.utils import agent_telemetry, fmt_hps, try_commit
 
 agents = Blueprint('agents', __name__)
 
@@ -239,10 +240,20 @@ def agents_download():
     """Function to download agent"""
     version = hashview.__version__
     filename = 'hashview-agent.' + version + '.tgz'
-    tmp_path = os.path.join('hashview', 'control', 'tmp', filename)
 
-    # Build the tarball using tarfile instead of shell command
-    with tarfile.open(tmp_path, 'w:gz') as tf:
+    # Built entirely in memory -- never touches control/tmp, so there is
+    # nothing to leak (#421) and no partial/torn archive left on disk if
+    # install/hashview-agent is missing (tarfile would otherwise create the
+    # output file before the missing-source error, and two concurrent
+    # downloads would share one deterministic on-disk path).
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode='w:gz') as tf:
         tf.add('install/hashview-agent', arcname='hashview-agent')
+    buf.seek(0)
 
-    return send_generated_file('control/tmp', filename, as_attachment=True)
+    return send_file(
+        buf,
+        mimetype='application/gzip',
+        as_attachment=True,
+        download_name=filename,
+    )

--- a/hashview/analytics/routes.py
+++ b/hashview/analytics/routes.py
@@ -1,6 +1,5 @@
 """Flask routes to handle Analytics"""
 import io
-import os
 import re
 import zipfile
 from collections import Counter, defaultdict
@@ -8,12 +7,13 @@ from datetime import timedelta
 
 from flask import (
     Blueprint,
+    Response,
     abort,
     redirect,
     render_template,
     request,
     send_file,
-    send_from_directory,
+    stream_with_context,
 )
 from flask_login import login_required
 from sqlalchemy import func, select
@@ -534,36 +534,18 @@ def _download_scope_ids():
     return _opt_int('customer_id'), _opt_int('hashfile_id')
 
 
-def _tmp_download_path(filename):
-    """Resolve a download temp file inside control/tmp, refusing path traversal.
-
-    Defense-in-depth on top of the int-coerced ids: run the name through
-    secure_filename and confirm the resolved path stays within control/tmp.
-    Returns (safe_name, abs_path) -- write to abs_path, serve safe_name from
-    'control/tmp'.
-    """
-    safe_name = secure_filename(filename)
-    tmp_dir = os.path.realpath(os.path.join('hashview', 'control', 'tmp'))
-    abs_path = os.path.realpath(os.path.join(tmp_dir, safe_name))
-    if os.path.commonpath((tmp_dir, abs_path)) != tmp_dir:
-        abort(400)
-    return safe_name, abs_path
-
-
 # serve a list of cracks
 @analytics.route('/analytics/download', methods=['GET'])
 @login_required
 def analytics_download_hashes():
     """Function to download hashes"""
 
-    filename = ''
+    # Validate type parameter early and return if invalid (fixes #389)
+    download_type = request.args.get('type')
+    if download_type not in ('found', 'left'):
+        return redirect('/analytics')
 
-    if request.args.get('type') == 'found':
-        filename += 'found'
-    elif request.args.get('type') == 'left':
-        filename += 'left'
-    else:
-        redirect('/analytics')
+    filename = download_type
 
     # customer_id / hashfile_id are coerced to int so a crafted value can't
     # escape control/tmp via the output filename (#216).
@@ -591,25 +573,25 @@ def analytics_download_hashes():
         cracked_hashes = db.session.query(Hashes, HashfileHashes).join(HashfileHashes, Hashes.id==HashfileHashes.hash_id).filter(Hashes.cracked=='1').all()
         uncracked_hashes = db.session.query(Hashes, HashfileHashes).join(HashfileHashes, Hashes.id==HashfileHashes.hash_id).filter(Hashes.cracked=='0').all()
 
-    safe_name, outfile_path = _tmp_download_path(filename)
-    outfile = open(outfile_path, 'w')
+    def generate():
+        if download_type == 'found':
+            for entry in cracked_hashes:
+                if entry[1].username:
+                    yield str(entry[1].username) + ":" + str(entry[0].ciphertext) + ':' + str(entry[0].plaintext) + "\n"
+                else:
+                    yield str(entry[0].ciphertext) + ':' + str(entry[0].plaintext) + "\n"
+        elif download_type == 'left':
+            for entry in uncracked_hashes:
+                if entry[1].username:
+                    yield str(entry[1].username) + ":" + str(entry[0].ciphertext) + "\n"
+                else:
+                    yield str(entry[0].ciphertext) + "\n"
 
-    if request.args.get('type') == 'found':
-        for entry in cracked_hashes:
-            if entry[1].username:
-                outfile.write(str(entry[1].username) + ":" + str(entry[0].ciphertext) + ':' + str(entry[0].plaintext) + "\n")
-            else:
-                outfile.write(str(entry[0].ciphertext) + ':' + str(entry[0].plaintext) + "\n")
-
-    if request.args.get('type') == 'left':
-        for entry in uncracked_hashes:
-            if entry[1].username:
-                outfile.write(str(entry[1].username) + ":" + str(entry[0].ciphertext) + "\n")
-            else:
-                outfile.write(str(entry[0].ciphertext) + "\n")
-
-    outfile.close()
-    return send_from_directory('control/tmp', safe_name, as_attachment=True)
+    return Response(
+        stream_with_context(generate()),
+        mimetype='text/plain',
+        headers={'Content-Disposition': f'attachment; filename="{filename}"'}
+    )
 
 # Download the list of accounts that share the same password or password hash (fig9)
 @analytics.route('/analytics/download/fig9', methods=['GET'])
@@ -635,8 +617,6 @@ def analytics_download_fig9():
     filename += '.txt'
 
     # Gather the usernames from fig9_table logic (same as in the template)
-    fig9_usernames = []
-
     if customer_id:
         # we have a customer
         if hashfile_id:
@@ -697,19 +677,16 @@ def analytics_download_fig9():
             .all()
         )
 
-    # Write usernames to the file
-    safe_name, outfile_path = _tmp_download_path(filename)
-    with open(outfile_path, 'w') as outfile:
+    def generate():
         for entry in fig9_usernames:
             if entry:
-                # Decode possible hex‑encoded usernames
-                try:
-                    decoded = entry
-                except Exception:
-                    decoded = entry
-                outfile.write(f"{decoded}\n")
+                yield f"{entry}\n"
 
-    return send_from_directory('control/tmp', safe_name, as_attachment=True)
+    return Response(
+        stream_with_context(generate()),
+        mimetype='text/plain',
+        headers={'Content-Disposition': f'attachment; filename="{filename}"'}
+    )
 
 @analytics.route('/analytics/download/fig8', methods=['GET'])
 @login_required
@@ -732,8 +709,6 @@ def analytics_download_fig8():
     filename += '.txt'
 
     # Gather the usernames where password == username using the same logic as fig8_table
-    fig8_usernames = []
-
     if customer_id:
         if hashfile_id:
             # Specific hashfile
@@ -760,30 +735,29 @@ def analytics_download_fig8():
             .with_entities(Hashes.plaintext, HashfileHashes.username) \
             .all()
 
-    for entry in fig8_cracked_hashes:
-        if entry[1] and entry[0]:
-            # Decode username (handle possible domain delimiters)
-            raw_username = entry[1]
-            if '\\' in raw_username:
-                username = raw_username.split('\\')[1]
-            elif '*' in raw_username:
-                username = raw_username.split('*')[1]
-            else:
-                username = raw_username
+    def generate():
+        for entry in fig8_cracked_hashes:
+            if entry[1] and entry[0]:
+                # Decode username (handle possible domain delimiters)
+                raw_username = entry[1]
+                if '\\' in raw_username:
+                    username = raw_username.split('\\')[1]
+                elif '*' in raw_username:
+                    username = raw_username.split('*')[1]
+                else:
+                    username = raw_username
 
-            # Decode password
-            password = entry[0]
+                # Decode password
+                password = entry[0]
 
-            if username == password:
-                fig8_usernames.append(username)
+                if username == password:
+                    yield f"{username}\n"
 
-    # Write usernames to the file
-    safe_name, outfile_path = _tmp_download_path(filename)
-    with open(outfile_path, 'w') as outfile:
-        for uname in fig8_usernames:
-            outfile.write(f"{uname}\n")
-
-    return send_from_directory('control/tmp', safe_name, as_attachment=True)
+    return Response(
+        stream_with_context(generate()),
+        mimetype='text/plain',
+        headers={'Content-Disposition': f'attachment; filename="{filename}"'}
+    )
 
 
 # --- Shared-password downloads (per-group txt and an all-groups zip) ---------

--- a/hashview/analytics/routes.py
+++ b/hashview/analytics/routes.py
@@ -17,7 +17,6 @@ from flask import (
 )
 from flask_login import login_required
 from sqlalchemy import func, select
-from werkzeug.utils import secure_filename
 
 from hashview.models import Customers, Hashes, HashfileHashes, Hashfiles, Jobs, Tasks, db
 from hashview.utils.utils import decode_hex_plain

--- a/tests/integration/test_analytics_docker_bugs.py
+++ b/tests/integration/test_analytics_docker_bugs.py
@@ -375,13 +375,10 @@ def test_fig8_download_matches_the_username_equals_password_card(client, stack_u
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.xfail(strict=True, reason=(
-    "BUG (issue #389): /analytics/download builds redirect('/analytics') for an unknown ?type "
-    "and never returns it, so the request scans every hash and serves an empty attachment. "
-    "Remove this marker once the redirect (or abort) is returned before the queries."))
 def test_unknown_download_type_does_not_serve_a_file(client, stack_url, seeded):
     """?type=bogus is not 'found' or 'left'; the route must bail out rather than
-    fall through and serve an empty attachment."""
+    fall through and serve an empty attachment. Fixed in #421 by validating ?type
+    early and returning a redirect before any database queries."""
     response = client.get(
         f"{stack_url}/analytics/download",
         params={"type": "bogus", "customer_id": seeded["customer_a"]},

--- a/tests/integration/test_analytics_docker_bugs.py
+++ b/tests/integration/test_analytics_docker_bugs.py
@@ -377,8 +377,9 @@ def test_fig8_download_matches_the_username_equals_password_card(client, stack_u
 
 def test_unknown_download_type_does_not_serve_a_file(client, stack_url, seeded):
     """?type=bogus is not 'found' or 'left'; the route must bail out rather than
-    fall through and serve an empty attachment. Fixed in #421 by validating ?type
-    early and returning a redirect before any database queries."""
+    fall through and serve an empty attachment. Fixed in #389, as a side effect
+    of #421's streaming rewrite: validating ?type early and returning a
+    redirect before any database queries."""
     response = client.get(
         f"{stack_url}/analytics/download",
         params={"type": "bogus", "customer_id": seeded["customer_a"]},

--- a/tests/security/test_security_hardening.py
+++ b/tests/security/test_security_hardening.py
@@ -212,27 +212,44 @@ def _seed_job_with_task(attackmode, *, hc_mask=None, j_rule=None, k_rule=None,
 
 
 @pytest.mark.security
-def test_agents_download_no_shell_execution(nocsrf_app):
+def test_agents_download_no_shell_execution(nocsrf_app, monkeypatch):
     """The agents download route must not shell out or execute any shell commands.
 
-    The tarfile is built using Python's tarfile module, never via os.system or
-    subprocess with shell=True. This test verifies there is no shell command
-    execution in the agents routes module.
+    The tarfile is built using Python's tarfile module, never via os.system,
+    os.popen, or subprocess (which all funnel through subprocess.Popen).
+    Tripwiring the actual sinks catches any regression regardless of alias
+    (e.g. `import os as _o; _o.system(...)`) or mechanism (e.g.
+    `subprocess.run(..., shell=True)`) -- a source-string check for the
+    literal text "os.system" would miss both.
     """
+    import os
+    import subprocess
+
     app = nocsrf_app
     user = _seed_user(admin=True)
     client = app.test_client()
     _login(client, user)
 
-    import hashview.agents.routes as agents_routes
-    source = inspect.getsource(agents_routes.agents_download)
-    assert "os.system" not in source, "agents_download must not use os.system"
+    def _fail_popen(*args, **kwargs):
+        pytest.fail(f"shell-out via subprocess.Popen: args={args!r} kwargs={kwargs!r}")
 
-    # Make the request and verify it succeeds
+    def _fail_system(cmd):
+        pytest.fail(f"shell-out via os.system: {cmd!r}")
+
+    def _fail_popen_builtin(*args, **kwargs):
+        pytest.fail(f"shell-out via os.popen: args={args!r} kwargs={kwargs!r}")
+
+    monkeypatch.setattr(subprocess, "Popen", _fail_popen)
+    monkeypatch.setattr(os, "system", _fail_system)
+    monkeypatch.setattr(os, "popen", _fail_popen_builtin)
+
     resp = client.get("/agents/download")
     assert resp.status_code == 200
-    # Verify it's a gzip stream
     assert resp.data[:2] == b"\x1f\x8b", "Response must be a gzip stream"
+
+    import hashview.agents.routes as agents_routes
+    source = inspect.getsource(agents_routes)
+    assert "shell=True" not in source, "agents/routes.py must not shell out"
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/security/test_security_hardening.py
+++ b/tests/security/test_security_hardening.py
@@ -211,47 +211,31 @@ def _seed_job_with_task(attackmode, *, hc_mask=None, j_rule=None, k_rule=None,
 
 
 @pytest.mark.security
-def test_agents_download_os_system_uses_trusted_version_only(nocsrf_app, monkeypatch):
-    """The only live os.system() sink (agents/routes.py:243) builds its command
-    from hashview.__version__, which is a package constant — NOT user input.
+def test_agents_download_no_shell_execution(nocsrf_app):
+    """The agents download route must not shell out or execute any shell commands.
 
-    Pin that no request data reaches it: we tripwire os.system to capture the
-    string and assert it is exactly the version-templated tar command with no
-    user-controlled component. (We do not actually run tar.)
+    The tarfile is built using Python's tarfile module, never via os.system or
+    subprocess with shell=True. This test verifies there is no shell command
+    execution in the agents routes module.
     """
     app = nocsrf_app
     user = _seed_user(admin=True)
     client = app.test_client()
     _login(client, user)
 
-    from flask import Response
-
     import hashview.agents.routes as agents_routes
 
-    captured = {}
+    # Assert that os.system is not called during the request
+    # by checking it doesn't appear in the agents_routes source
+    import inspect
+    source = inspect.getsource(agents_routes.agents_download)
+    assert "os.system" not in source, "agents_download must not use os.system"
 
-    def fake_system(cmd):
-        captured["cmd"] = cmd
-        return 0
-
-    monkeypatch.setattr(agents_routes.os, "system", fake_system)
-    # Don't actually serve a file off disk; the os.system cmd is what we inspect.
-    monkeypatch.setattr(
-        agents_routes,
-        "send_from_directory",
-        lambda *a, **k: Response("ok", status=200),
-    )
-
+    # Make the request and verify it succeeds
     resp = client.get("/agents/download")
     assert resp.status_code == 200
-    cmd = captured["cmd"]
-    # version is e.g. '0.8.3' — no shell metacharacters, fixed template.
-    import hashview
-
-    assert hashview.__version__ in cmd
-    assert cmd.startswith("tar -czf hashview/control/tmp/hashview-agent.")
-    for meta in (";", "|", "&", "$(", "`", "\n"):
-        assert meta not in cmd, f"unexpected shell metachar {meta!r} in os.system cmd: {cmd!r}"
+    # Verify it's a gzip stream
+    assert resp.data[:2] == b"\x1f\x8b", "Response must be a gzip stream"
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/security/test_security_hardening.py
+++ b/tests/security/test_security_hardening.py
@@ -25,6 +25,7 @@ their own per-issue modules so each tracks a GitHub issue:
 This module deliberately contains only PASSING security tests.
 """
 
+import inspect
 
 import pytest
 
@@ -224,10 +225,6 @@ def test_agents_download_no_shell_execution(nocsrf_app):
     _login(client, user)
 
     import hashview.agents.routes as agents_routes
-
-    # Assert that os.system is not called during the request
-    # by checking it doesn't appear in the agents_routes source
-    import inspect
     source = inspect.getsource(agents_routes.agents_download)
     assert "os.system" not in source, "agents_download must not use os.system"
 

--- a/tests/unit/test_agent_and_analytics_tmp_cleanup.py
+++ b/tests/unit/test_agent_and_analytics_tmp_cleanup.py
@@ -1,0 +1,221 @@
+"""Regression tests for #421/#424: agent and analytics downloads must not leave files in control/tmp.
+
+Agent download uses tarfile instead of os.system, and analytics downloads stream
+instead of writing to disk. Both must clean up or never touch control/tmp.
+"""
+
+import os
+
+from hashview.models import (
+    Customers,
+    Hashes,
+    HashfileHashes,
+    Hashfiles,
+    Users,
+    db,
+)
+
+
+def _admin(email=None):
+    """Create and return an admin user."""
+    if email is None:
+        email = "a@e.com"
+    u = Users(
+        first_name="A",
+        last_name="D",
+        email_address=email,
+        password="x" * 60,
+        admin=True,
+    )
+    db.session.add(u)
+    db.session.commit()
+    return u
+
+
+def _login(client, user):
+    """Log in a user."""
+    with client.session_transaction() as sess:
+        sess["_user_id"] = str(user.id)
+        sess["_fresh"] = True
+
+
+def _tmp_dir_entries(app):
+    """Snapshot the current contents of control/tmp."""
+    return set(os.listdir(os.path.join(app.root_path, "control", "tmp")))
+
+
+def _seed_analytics(owner_id=None):
+    """Create a customer, hashfile, and some hashes for analytics tests."""
+    customer = Customers(name="test_customer")
+    db.session.add(customer)
+    db.session.commit()
+
+    if owner_id is None:
+        owner_id = _admin(email="analytics_seed@e.com").id
+
+    hashfile = Hashfiles(name="test_hashfile", customer_id=customer.id, owner_id=owner_id)
+    db.session.add(hashfile)
+    db.session.commit()
+
+    # Add both cracked and uncracked hashes
+    for i, (ct, pt) in enumerate([
+        ("aaa111", "Password1"),
+        ("bbb222", "SecretPass"),
+        ("ccc333", None),
+    ]):
+        h = Hashes(
+            sub_ciphertext=f"{i}" * 8,
+            ciphertext=ct,
+            hash_type=1000,
+            cracked=pt is not None,
+            plaintext=pt,
+        )
+        db.session.add(h)
+        db.session.commit()
+        db.session.add(HashfileHashes(hash_id=h.id, hashfile_id=hashfile.id))
+        db.session.commit()
+
+    return customer, hashfile
+
+
+# ---------------------------------------------------------------------------
+# Agent download
+# ---------------------------------------------------------------------------
+
+
+def test_agent_download_leaves_no_temp_files(app, client):
+    """Agent download builds the tarball and streams it without leaving
+    temp files in control/tmp."""
+    user = _admin()
+    _login(client, user)
+
+    before = _tmp_dir_entries(app)
+    resp = client.get("/agents/download")
+    after = _tmp_dir_entries(app)
+
+    assert resp.status_code == 200
+    assert resp.data[:2] == b"\x1f\x8b"  # gzip magic bytes
+    # No new files should be left behind
+    assert before == after, f"Agent download left new files: {after - before}"
+
+
+# ---------------------------------------------------------------------------
+# Analytics downloads
+# ---------------------------------------------------------------------------
+
+
+def test_analytics_download_hashes_leaves_no_temp_files(app, client):
+    """Analytics hash download (type=found) streams without touching disk."""
+    user = _admin(email="analytics_found@e.com")
+    _login(client, user)
+    customer, hashfile = _seed_analytics(owner_id=user.id)
+
+    before = _tmp_dir_entries(app)
+    resp = client.get(
+        f"/analytics/download?type=found&customer_id={customer.id}&hashfile_id={hashfile.id}"
+    )
+    after = _tmp_dir_entries(app)
+
+    assert resp.status_code == 200
+    assert b"Password1" in resp.data
+    # No new files should be left behind
+    assert before == after, f"Analytics download left new files: {after - before}"
+
+
+def test_analytics_download_hashes_left_leaves_no_temp_files(app, client):
+    """Analytics hash download (type=left) streams without touching disk."""
+    user = _admin(email="analytics_left@e.com")
+    _login(client, user)
+    customer, hashfile = _seed_analytics(owner_id=user.id)
+
+    before = _tmp_dir_entries(app)
+    resp = client.get(
+        f"/analytics/download?type=left&customer_id={customer.id}&hashfile_id={hashfile.id}"
+    )
+    after = _tmp_dir_entries(app)
+
+    assert resp.status_code == 200
+    assert b"ccc333" in resp.data  # uncracked hash
+    # No new files should be left behind
+    assert before == after, f"Analytics download left new files: {after - before}"
+
+
+def test_analytics_download_fig8_leaves_no_temp_files(app, client):
+    """Analytics fig8 (password == username) download streams without touching disk."""
+    user = _admin(email="analytics_fig8@e.com")
+    _login(client, user)
+
+    # Create a hashfile with a user whose password matches username
+    customer = Customers(name="test_customer_fig8")
+    db.session.add(customer)
+    db.session.commit()
+
+    hashfile = Hashfiles(name="test_hashfile_fig8", customer_id=customer.id, owner_id=user.id)
+    db.session.add(hashfile)
+    db.session.commit()
+
+    h = Hashes(
+        sub_ciphertext="0" * 8,
+        ciphertext="aaa111",
+        hash_type=1000,
+        cracked=True,
+        plaintext="testuser",  # password = username
+    )
+    db.session.add(h)
+    db.session.commit()
+
+    db.session.add(HashfileHashes(
+        hash_id=h.id,
+        hashfile_id=hashfile.id,
+        username="testuser",
+    ))
+    db.session.commit()
+
+    before = _tmp_dir_entries(app)
+    resp = client.get(f"/analytics/download/fig8?customer_id={customer.id}")
+    after = _tmp_dir_entries(app)
+
+    assert resp.status_code == 200
+    assert b"testuser" in resp.data
+    # No new files should be left behind
+    assert before == after, f"Analytics fig8 download left new files: {after - before}"
+
+
+def test_analytics_download_fig9_leaves_no_temp_files(app, client):
+    """Analytics fig9 (shared passwords) download streams without touching disk."""
+    user = _admin(email="analytics_fig9@e.com")
+    _login(client, user)
+
+    # Create a hashfile with accounts that share the same hash
+    customer = Customers(name="test_customer_fig9")
+    db.session.add(customer)
+    db.session.commit()
+
+    hashfile = Hashfiles(name="test_hashfile_fig9", customer_id=customer.id, owner_id=user.id)
+    db.session.add(hashfile)
+    db.session.commit()
+
+    # Create one hash that is referenced by two usernames (shared password scenario)
+    h = Hashes(
+        sub_ciphertext="0" * 8,
+        ciphertext="aaa111",
+        hash_type=1000,
+        cracked=True,
+        plaintext="SharedPass",
+    )
+    db.session.add(h)
+    db.session.commit()
+
+    db.session.add(HashfileHashes(hash_id=h.id, hashfile_id=hashfile.id, username="user1"))
+    db.session.add(HashfileHashes(hash_id=h.id, hashfile_id=hashfile.id, username="user2"))
+    db.session.commit()
+
+    before = _tmp_dir_entries(app)
+    resp = client.get(f"/analytics/download/fig9?customer_id={customer.id}")
+    after = _tmp_dir_entries(app)
+
+    assert resp.status_code == 200
+    # Should contain both usernames that share the same password
+    assert b"user1" in resp.data or b"user2" in resp.data
+    # No new files should be left behind
+    assert before == after, f"Analytics fig9 download left new files: {after - before}"

--- a/tests/unit/test_agent_and_analytics_tmp_cleanup.py
+++ b/tests/unit/test_agent_and_analytics_tmp_cleanup.py
@@ -84,18 +84,42 @@ def _seed_analytics(owner_id=None):
 
 
 def test_agent_download_leaves_no_temp_files(app, client):
-    """Agent download builds the tarball and streams it without leaving
-    temp files in control/tmp."""
+    """Agent download builds the tarball in memory and streams it without
+    ever touching control/tmp.
+
+    The filename is deterministic (hashview-agent.<version>.tgz), so a plain
+    before/after set comparison is vacuously true if a prior run already left
+    that exact file behind -- which is exactly how the original disk-based
+    implementation's leak (write path and send_generated_file's delete path
+    disagreed on 'hashview/control/tmp/...' vs 'control/tmp/...", so the
+    unlink silently no-op'd on FileNotFoundError) went undetected. Assert the
+    specific filename is absent both before and after, not just that the two
+    snapshots match.
+    """
+    import hashview
+
     user = _admin()
     _login(client, user)
 
+    expected_name = f"hashview-agent.{hashview.__version__}.tgz"
+    tmp_dir = os.path.join(app.root_path, "control", "tmp")
+    stale = os.path.join(tmp_dir, expected_name)
+    if os.path.exists(stale):
+        os.remove(stale)  # clean up a leak from a previous (buggy) run
+
     before = _tmp_dir_entries(app)
+    assert expected_name not in before
+
     resp = client.get("/agents/download")
+
     after = _tmp_dir_entries(app)
 
     assert resp.status_code == 200
     assert resp.data[:2] == b"\x1f\x8b"  # gzip magic bytes
-    # No new files should be left behind
+    assert expected_name not in after, (
+        f"{expected_name} was left in control/tmp -- the agent download "
+        "wrote it to disk instead of building it in memory"
+    )
     assert before == after, f"Agent download left new files: {after - before}"
 
 
@@ -215,7 +239,8 @@ def test_analytics_download_fig9_leaves_no_temp_files(app, client):
     after = _tmp_dir_entries(app)
 
     assert resp.status_code == 200
-    # Should contain both usernames that share the same password
-    assert b"user1" in resp.data or b"user2" in resp.data
+    # Both usernames share the one password, so both must be present.
+    assert b"user1" in resp.data
+    assert b"user2" in resp.data
     # No new files should be left behind
     assert before == after, f"Analytics fig9 download left new files: {after - before}"

--- a/tests/unit/test_agent_download.py
+++ b/tests/unit/test_agent_download.py
@@ -5,7 +5,6 @@ Verifies the produced tarball expands to ``./hashview-agent/`` (no
 at commit ``34cdd15``.
 """
 
-import os
 import tarfile
 
 import pytest
@@ -14,9 +13,9 @@ from hashview.models import Users, db
 
 
 @pytest.mark.security
-def test_agents_download_tarball_starts_at_hashview_agent(app, client, tmp_path, monkeypatch):
+def test_agents_download_tarball_starts_at_hashview_agent(app, client, tmp_path):
     """The ``.tgz`` returned by ``/agents/download`` should NOT have a
-    leading ``install/`` directory."""
+    leading ``install/`` directory. Exercises real tarfile implementation."""
     # Build an admin user and a logged-in session.
     admin = Users(
         first_name="A",
@@ -28,42 +27,12 @@ def test_agents_download_tarball_starts_at_hashview_agent(app, client, tmp_path,
     db.session.add(admin)
     db.session.commit()
 
-    # Force the actual tar command to run in a temp working dir with a
-    # synthetic ``install/hashview-agent/`` tree, so the test doesn't
-    # depend on what's in the real repo at run time.
-    workdir = tmp_path / "work"
-    (workdir / "install" / "hashview-agent").mkdir(parents=True)
-    (workdir / "install" / "hashview-agent" / "marker.txt").write_text("ok")
-    (workdir / "hashview" / "control" / "tmp").mkdir(parents=True)
-
-    original_system = os.system
-
-    def fake_system(cmd):
-        # Run the produced ``tar -czf ... -C install hashview-agent`` from
-        # our isolated workdir so we don't touch the real repo.
-        prev = os.getcwd()
-        try:
-            os.chdir(workdir)
-            return original_system(cmd)
-        finally:
-            os.chdir(prev)
-
-    monkeypatch.setattr("hashview.agents.routes.os.system", fake_system)
-
-    # Also redirect send_from_directory to read from our workdir
-    import hashview.agents.routes as agent_routes
-    real_send = agent_routes.send_from_directory
-
-    def fake_send(_dir, filename, **kw):
-        return real_send(str(workdir / "hashview" / "control" / "tmp"), filename, **kw)
-
-    monkeypatch.setattr(agent_routes, "send_from_directory", fake_send)
-
-    # Log the admin in.
+    # Log the admin in
     with client.session_transaction() as sess:
         sess["_user_id"] = str(admin.id)
         sess["_fresh"] = True
 
+    # Make the request
     resp = client.get("/agents/download", follow_redirects=False)
     assert resp.status_code == 200, f"expected 200, got {resp.status_code}"
     body = resp.data

--- a/tests/unit/test_analytics_view.py
+++ b/tests/unit/test_analytics_view.py
@@ -184,11 +184,13 @@ def test_analytics_download_recovered_scoped(app, client):
 
 def test_analytics_download_unknown_type_redirects_without_serving_a_file(app, client):
     """Issue #389: an unknown ?type must bail out before any query runs, not
-    fall through and serve an empty attachment. The docker-integration suite
-    (tests/integration/test_analytics_docker_bugs.py) carries the same
-    assertion as a strict xfail against issue #421's fix, but that suite is
-    opt-in and skips without a live docker stack -- this is the only coverage
-    that runs in a plain `pytest tests/`.
+    fall through and serve an empty attachment. This bug was fixed as a side
+    effect of #421's streaming rewrite (the redirect that used to be built
+    and discarded is now returned early). The docker-integration suite
+    (tests/integration/test_analytics_docker_bugs.py) used to carry the same
+    assertion as a strict xfail against #389, removed in this same change,
+    but that suite is opt-in and skips without a live docker stack -- this is
+    the only coverage that runs in a plain `pytest tests/`.
     """
     user = _admin()
     _login(client, user)

--- a/tests/unit/test_analytics_view.py
+++ b/tests/unit/test_analytics_view.py
@@ -182,6 +182,25 @@ def test_analytics_download_recovered_scoped(app, client):
     assert "Password1" in body                       # cracked export contains plaintext
 
 
+def test_analytics_download_unknown_type_redirects_without_serving_a_file(app, client):
+    """Issue #389: an unknown ?type must bail out before any query runs, not
+    fall through and serve an empty attachment. The docker-integration suite
+    (tests/integration/test_analytics_docker_bugs.py) carries the same
+    assertion as a strict xfail against issue #421's fix, but that suite is
+    opt-in and skips without a live docker stack -- this is the only coverage
+    that runs in a plain `pytest tests/`.
+    """
+    user = _admin()
+    _login(client, user)
+    customer_id, hashfile_id = _seed()
+    resp = client.get(
+        f"/analytics/download?type=bogus&customer_id={customer_id}&hashfile_id={hashfile_id}",
+        follow_redirects=False,
+    )
+    assert resp.status_code in (301, 302, 303)
+    assert resp.headers["Location"].endswith("/analytics")
+
+
 def test_analytics_summary_above_donuts(app, client):
     """The scope summary card (with its download buttons) sits above the donuts."""
     user = _admin()


### PR DESCRIPTION
## Summary
Two related issues fixed together, since #424's fix edits the exact lines #421 does.

**#424** — `agents_download()` built a tar command by string concatenation and ran it via `os.system` (bandit B605 HIGH), discarding the exit code. Rewritten to build the tarball with Python's `tarfile` module — in memory (`io.BytesIO`), never touching disk, served via `send_file`.

**#421** — Four routes wrote a scratch file into `control/tmp` and never deleted it:
- `analytics_download_hashes`, `analytics_download_fig9`, and the fig8 route — all three contain recovered plaintext credentials, so this was a real data-retention problem, not just disk usage. Rewritten to stream the response directly (`Response(stream_with_context(generator()), ...)`), removing the retention window entirely rather than shortening it.
- `agents_download` — see above; also fixed by going in-memory.

As a side effect, this also fixes **#389** (unknown `?type` on `/analytics/download` fell through and served an empty attachment) — the redirect that used to be built and discarded is now returned early, before any query runs. Verified with a new unit test since the docker-integration suite that owns the `#389` xfail is opt-in and wasn't run live.

**Caught in review, not by the implementer's own tests:** the first version of the agent-download fix still wrote the tarball to disk at `hashview/control/tmp/<name>` while `send_generated_file`'s delete path resolved a different base path (`control/tmp/<name>`), so the unlink silently no-op'd on `FileNotFoundError` — the #421 fix for this route wasn't actually applying, and I found the leaked tarball still sitting on disk. The regression test couldn't catch it either, since the filename is deterministic and a leftover from a prior run made the before/after snapshot vacuously pass. Fixed by going fully in-memory (consistent with the analytics approach), and tightened the test to assert the specific filename is absent both before and after.

Also fixed from review: a security regression test that only checked for the literal string `"os.system"` in source (bypassable via `subprocess(shell=True)` or an aliased import) now tripwires the actual sinks; a vacuous `or` assertion in a fig9 test where both usernames must be present; two comments citing the wrong issue number.

Closes #424, Closes #421

## Test plan
- [x] ruff, bandit (vs baseline), openapi-spec-validator, `pytest tests/unit tests/security tests/agent_unit`: 1731 passed, 2 skipped, 61 xfailed
- [x] Manually confirmed `control/tmp` stays empty across an agent download and all four analytics export routes (ran the tests, inspected the directory)
- [x] Confirmed the strengthened shell-execution tripwire and the #389 redirect fix both pass against the real route (not mocked)
- [ ] `tests/integration/test_analytics_docker_bugs.py` — opt-in, skips without `HASHVIEW_DOCKER_BASE_URL`; not run against a live stack in this environment