### PR TITLE
perf(#422): job summary looks up only assigned task names, not the whole table

### DIFF
--- a/hashview/jobs/routes.py
+++ b/hashview/jobs/routes.py
@@ -929,7 +929,6 @@ def jobs_summary(job_id):
     form = JobSummaryForm()
 
     settings = Settings.query.first()
-    tasks = Tasks.query.all()
     hashfile = Hashfiles.query.get(job.hashfile_id)
     customer = Customers.query.get(job.customer_id)
     cracked_cnt = db.session.query(Hashes).outerjoin(HashfileHashes, Hashes.id==HashfileHashes.hash_id).filter(Hashes.cracked == '1').filter(HashfileHashes.hashfile_id==hashfile.id).count()
@@ -954,8 +953,6 @@ def jobs_summary(job_id):
         hashfile_hash_type = _names.get(str(hash_mode), 'mode ' + str(hash_mode))
     hash_notification_cnt = db.session.query(HashNotifications).join(HashfileHashes, HashNotifications.hash_id==HashfileHashes.hash_id).filter(HashfileHashes.hashfile_id == hashfile.id).count()
     hash_notification = db.session.query(HashNotifications).join(HashfileHashes, HashNotifications.hash_id==HashfileHashes.hash_id).filter(HashfileHashes.hashfile_id == hashfile.id).first()
-    job_notification = JobNotifications.query.filter_by(job_id = job.id).first()
-
     job_notification = JobNotifications.query.filter_by(job_id=job_id).first()
 
     if form.validate_on_submit():
@@ -977,7 +974,16 @@ def jobs_summary(job_id):
     # each attack once (matches the assign-tasks step), not once per chunk.
     assigned = _assigned_tasks(job_id)
 
-    return render_template('jobs_summary.html.j2', title='Job Summary', job=job, form=form, job_notification=job_notification, cracked_rate=cracked_rate, cracked_cnt=cracked_cnt, hash_total=hash_total, hashfile_hash_type=hashfile_hash_type, job_tasks=job_tasks, assigned=assigned, hash_notification_cnt=hash_notification_cnt, customer=customer, hashfile=hashfile, tasks=tasks, hash_notification=hash_notification, settings=settings)
+    # Build a dict mapping assigned task id -> task name. Queries only the assigned
+    # tasks rather than the entire tasks table, so response size scales with assigned
+    # count, not total task library size.
+    assigned_task_ids = [a['task_id'] for a in assigned]
+    task_names = {}
+    if assigned_task_ids:
+        for task in Tasks.query.filter(Tasks.id.in_(assigned_task_ids)).all():
+            task_names[task.id] = task.name
+
+    return render_template('jobs_summary.html.j2', title='Job Summary', job=job, form=form, job_notification=job_notification, cracked_rate=cracked_rate, cracked_cnt=cracked_cnt, hash_total=hash_total, hashfile_hash_type=hashfile_hash_type, job_tasks=job_tasks, assigned=assigned, hash_notification_cnt=hash_notification_cnt, customer=customer, hashfile=hashfile, task_names=task_names, hash_notification=hash_notification, settings=settings)
 
 @jobs.route("/jobs/start/<int:job_id>", methods=['POST'])
 @login_required

--- a/hashview/templates/jobs_summary.html.j2
+++ b/hashview/templates/jobs_summary.html.j2
@@ -63,11 +63,7 @@
                         <td>
                             {% for a in (assigned if assigned is defined else []) %}
                                 {% set order = loop.index %}
-                                {% for task in tasks %}
-                                    {% if task.id == a.task_id %}
-                                        <span class="mono" style="color:var(--text-mute); margin-right:8px;">{{ '%02d' % order }}</span>{{ task.name }}{% if a.chunks > 1 %} <span class="mono" style="color:var(--text-mute);">({{ a.chunks | commafy }} chunks)</span>{% endif %} <br>
-                                    {% endif %}
-                                {% endfor %}
+                                <span class="mono" style="color:var(--text-mute); margin-right:8px;">{{ '%02d' % order }}</span>{{ task_names.get(a.task_id, '') }}{% if a.chunks > 1 %} <span class="mono" style="color:var(--text-mute);">({{ a.chunks | commafy }} chunks)</span>{% endif %} <br>
                             {% endfor %}
                         </td>
                     </tr>

--- a/tests/unit/test_jobs_routes.py
+++ b/tests/unit/test_jobs_routes.py
@@ -473,31 +473,49 @@ def test_jobs_summary_scales_with_assigned_tasks_not_library(app, client, tmp_pa
     db.session.add(Settings(enabled_job_weights=False))
     db.session.commit()
 
-    # Render the summary page.
-    resp = client.get(f"/jobs/{job.id}/summary")
+    # The old nested-loop template only ever *rendered* task.name for rows
+    # where task.id == a.task_id, so absence of "ignored-N" text and a
+    # response-size threshold cannot distinguish the fix from the O(assigned
+    # x library) bug at this fixture's scale (2 assigned x 52 library tasks is
+    # only ~4KB of loop whitespace either way). What actually distinguishes
+    # them is the query issued: the fixed route filters Tasks by the assigned
+    # ids; the old route loaded every row via Tasks.query.all(). Inspect the
+    # SQL the same way test_rules_pagination.py does for the equivalent bug.
+    from sqlalchemy import event
+
+    statements = []
+
+    def record(conn, cursor, statement, parameters, context, executemany):
+        statements.append(" ".join(statement.split()).lower())
+
+    engine = db.engine
+    event.listen(engine, "before_cursor_execute", record)
+    try:
+        resp = client.get(f"/jobs/{job.id}/summary")
+    finally:
+        event.remove(engine, "before_cursor_execute", record)
+
     assert resp.status_code == 200
 
-    # Verify both assigned task names appear in the rendered output.
+    # Verify both assigned task names appear in the rendered output, in order.
     assert b"assigned-1" in resp.data
     assert b"assigned-2" in resp.data
+    assert b"01</span>assigned-1" in resp.data
+    assert b"02</span>assigned-2" in resp.data
 
-    # Verify the first assigned task appears with order=01, second with order=02.
-    assert b"01assigned-1" in resp.data or b"01</span>assigned-1" in resp.data
-    assert b"02assigned-2" in resp.data or b"02</span>assigned-2" in resp.data
-
-    # Verify that ignored tasks do NOT appear.
+    # Verify that ignored (unassigned) library tasks do NOT appear.
     for i in range(50):
         assert f"ignored-{i}".encode() not in resp.data
 
-    # Verify the response size is reasonable. With the old O(assigned × library)
-    # nested loop, 2 assigned tasks and 52 library tasks would produce ~12 KB
-    # of whitespace (loop indentation). With the fix (dict lookup), response
-    # should be much smaller.
-    response_kb = len(resp.data) / 1024
-    assert response_kb < 100, (
-        f"Response is {response_kb:.0f}KB; if this scales with task library "
-        "size, the O(assigned × library) loop is still present."
-    )
+    # The decisive check: no query against `tasks` may be an unfiltered
+    # full-table scan (Tasks.query.all() has no WHERE clause at all).
+    row_loads = [s for s in statements
+                 if s.startswith("select") and " from tasks" in s
+                 and "count(" not in s]
+    assert any("id in" in s for s in row_loads), \
+        f"no id-scoped task lookup found; saw: {row_loads}"
+    unfiltered = [s for s in row_loads if " where " not in s]
+    assert not unfiltered, f"unrestricted scan of tasks: {unfiltered}"
 
 
 def test_jobs_start_queues_job(app, client, tmp_path):

--- a/tests/unit/test_jobs_routes.py
+++ b/tests/unit/test_jobs_routes.py
@@ -449,6 +449,57 @@ def test_jobs_summary_without_tasks_redirects(app, client):
     assert resp.status_code in (301, 302)
 
 
+def test_jobs_summary_scales_with_assigned_tasks_not_library(app, client, tmp_path):
+    """Issue #422: job summary should only query assigned task names, not the
+    entire tasks table. Response size must scale with assigned task count, not
+    total task library size."""
+    admin = make_admin()
+    login(client, admin)
+    cust = make_customer()
+    hf, _ = _hashfile_with_hash(cust, admin)
+    job = _job(admin, cust, hashfile_id=hf.id)
+
+    # Seed 50 extra tasks in the library.
+    wl = _static_wl(admin, tmp_path)
+    for i in range(50):
+        _task(admin, name=f"ignored-{i}", wl_id=wl.id)
+
+    # Assign exactly 2 tasks to the job.
+    assigned_task1 = _task(admin, name="assigned-1", wl_id=wl.id)
+    assigned_task2 = _task(admin, name="assigned-2", wl_id=wl.id)
+    _assign(job, assigned_task1)
+    _assign(job, assigned_task2)
+
+    db.session.add(Settings(enabled_job_weights=False))
+    db.session.commit()
+
+    # Render the summary page.
+    resp = client.get(f"/jobs/{job.id}/summary")
+    assert resp.status_code == 200
+
+    # Verify both assigned task names appear in the rendered output.
+    assert b"assigned-1" in resp.data
+    assert b"assigned-2" in resp.data
+
+    # Verify the first assigned task appears with order=01, second with order=02.
+    assert b"01assigned-1" in resp.data or b"01</span>assigned-1" in resp.data
+    assert b"02assigned-2" in resp.data or b"02</span>assigned-2" in resp.data
+
+    # Verify that ignored tasks do NOT appear.
+    for i in range(50):
+        assert f"ignored-{i}".encode() not in resp.data
+
+    # Verify the response size is reasonable. With the old O(assigned × library)
+    # nested loop, 2 assigned tasks and 52 library tasks would produce ~12 KB
+    # of whitespace (loop indentation). With the fix (dict lookup), response
+    # should be much smaller.
+    response_kb = len(resp.data) / 1024
+    assert response_kb < 100, (
+        f"Response is {response_kb:.0f}KB; if this scales with task library "
+        "size, the O(assigned × library) loop is still present."
+    )
+
+
 def test_jobs_start_queues_job(app, client, tmp_path):
     admin = make_admin()
     login(client, admin)


### PR DESCRIPTION
## Summary
Part of issue #422 (defect 4 of 4). The job summary page's `jobs_summary` route loaded `Tasks.query.all()` — the entire task library — solely so the template could resolve each assigned task's name via a nested `{% for task in tasks %}` loop. Non-matching iterations still emitted their indentation whitespace, so the response grew as `assigned × total_tasks` (with 2 assigned and 2,000 in the library: ~998 KB, almost entirely blank lines).

- `hashview/jobs/routes.py` — replaced the full-table load with `Tasks.query.filter(Tasks.id.in_(assigned_task_ids)).all()`, building a `{task_id: name}` dict scoped to just the assigned tasks.
- `hashview/templates/jobs_summary.html.j2` — replaced the nested loop with a dict lookup (`task_names.get(a.task_id, '')`). Visual output (order numbering, task name, chunk-count suffix) is unchanged.
- Also fixed a duplicated `JobNotifications` query a few lines below (the first assignment was immediately overwritten — dead code).

**Note on behavior**: if an assigned task's row is ever deleted after assignment (edge case), the old nested loop silently skipped that row entirely; the dict-lookup version now renders a numbered row with an empty name instead of vanishing. Flagging this since it's a small observable difference, though arguably more correct.

**On the perf suite**: `tests/e2e/test_job_creation_perf.py::test_summary_payload_does_not_scale_with_task_table` is the `strict=True` xfail this defect maps to, but it's a Playwright + live-server test needing a seeded volume fixture I couldn't stand up in this environment. Left the marker in place rather than claim an unverified pass. Instead, I strengthened the existing unit test to inspect the actual SQL issued (same pattern as `tests/unit/test_rules_pagination.py`'s equivalent N+1 test) — the original assertions (absent unassigned-task names, response size < 100KB) couldn't actually distinguish the fix from the bug at unit-test fixture scale, since the old buggy code also never rendered unassigned names and 2×52 tasks is only ~4KB of whitespace either way. Verified this new assertion by temporarily reverting to the pre-fix route/template and confirming it fails with an unfiltered `select ... from tasks` and no WHERE clause, then reverted back and confirmed it passes.

Whoever runs the perf suite against a live stack should remove the xfail marker once confirmed.

Part of #422

## Test plan
- [x] ruff, bandit (vs baseline), openapi-spec-validator, `pytest tests/unit tests/security tests/agent_unit`: 1726 passed, 2 skipped, 61 xfailed
- [x] New unit test verified to genuinely discriminate fixed vs. buggy code (see above)
- [ ] `tests/e2e/test_job_creation_perf.py -m perf` not run — needs a seeded live stack