### PR TITLE
perf(#422): hashfile picker uses one grouped query instead of one per hashfile

### DIFF
--- a/hashview/jobs/routes.py
+++ b/hashview/jobs/routes.py
@@ -273,14 +273,13 @@ def jobs_assigned_hashfile(job_id):
     """Function to manage assigning hashfile to job"""
 
     job = Jobs.query.get(job_id)
-    hashfiles = Hashfiles.query.filter_by(customer_id=job.customer_id)
+    hashfiles = Hashfiles.query.filter_by(customer_id=job.customer_id).all()
     jobs_new_hashfile_form = JobsNewHashFileForm()
     # The import-progress modal posts the upload/paste form via XHR (so it can
     # show live upload + import status) and sets this header; for those requests
     # we answer with JSON instead of flash+redirect. A plain (no-JS) form post
     # still falls through to the original flash/redirect behaviour.
     is_ajax = request.headers.get('X-Requested-With') == 'fetch'
-    hashfile_cracked_rate = {}
     hashfile_info = {}
 
     # Reverse-map hashcat modes -> concise friendly names from the form's own choices.
@@ -300,18 +299,29 @@ def jobs_assigned_hashfile(job_id):
         flash('You can not edit a running or queued job. First stop and remove job from queue before editing.', 'danger')
         return redirect(url_for('jobs.jobs_list'))
 
-    for hashfile in hashfiles:
-        # one aggregated query per hashfile: total hashes, cracked count, representative mode
-        agg = db.session.query(
+    # --- per-hashfile facts for this customer's hashfiles ---
+    # Count / cracked-count / representative hash type computed in ONE grouped
+    # query over the hashfile ids instead of one query per hashfile (the old N+1
+    # pattern).
+    hashfile_ids = {hf.id for hf in hashfiles}
+    _hf_stats = {}
+    if hashfile_ids:
+        for hfid, total, cracked, mode in db.session.query(
+            HashfileHashes.hashfile_id,
             func.count(Hashes.id),
             func.coalesce(func.sum(case((Hashes.cracked == True, 1), else_=0)), 0),
-            func.min(Hashes.hash_type)
-        ).join(HashfileHashes, Hashes.id == HashfileHashes.hash_id) \
-         .filter(HashfileHashes.hashfile_id == hashfile.id).first()
-        total = agg[0] or 0
-        cracked_cnt = int(agg[1] or 0)
-        ht = str(agg[2]) if agg[2] is not None else ''
-        hashfile_cracked_rate[hashfile.id] = "(" + str(cracked_cnt) + "/" + str(total) + ")"
+            func.min(Hashes.hash_type),
+        ).join(Hashes, Hashes.id == HashfileHashes.hash_id) \
+         .filter(HashfileHashes.hashfile_id.in_(hashfile_ids)) \
+         .group_by(HashfileHashes.hashfile_id).all():
+            _hf_stats[hfid] = {'total': total or 0, 'cracked': int(cracked or 0), 'mode': mode}
+
+    # Assemble per-hashfile display data from the batched facts above.
+    for hashfile in hashfiles:
+        stats = _hf_stats.get(hashfile.id)
+        total = stats['total'] if stats else 0
+        cracked_cnt = stats['cracked'] if stats else 0
+        ht = str(stats['mode']) if stats and stats['mode'] is not None else ''
         if total:
             _pct = (cracked_cnt / total) * 100
             pct_str = '<1%' if 0 < _pct < 1 else ('%d%%' % round(_pct))
@@ -468,7 +478,7 @@ def jobs_assigned_hashfile(job_id):
         # Non-AJAX submit: fall through and re-render the page — WTForms shows the
         # field errors inline, so there's nothing to print to the console.
 
-    return render_template('jobs_assigned_hashfiles.html.j2', title='Jobs Assigned Hashfiles', hashfiles=hashfiles, job=job, jobsNewHashFileForm=jobs_new_hashfile_form, hashfile_cracked_rate=hashfile_cracked_rate, hashfile_info=hashfile_info)
+    return render_template('jobs_assigned_hashfiles.html.j2', title='Jobs Assigned Hashfiles', hashfiles=hashfiles, job=job, jobsNewHashFileForm=jobs_new_hashfile_form, hashfile_info=hashfile_info)
 
 @jobs.route("/jobs/<int:job_id>/assigned_hashfile/<int:hashfile_id>", methods=['GET'])
 @login_required

--- a/hashview/templates/jobs_assigned_hashfiles.html.j2
+++ b/hashview/templates/jobs_assigned_hashfiles.html.j2
@@ -30,7 +30,7 @@
         '1700': '82a9dda829eb7f8ffe9fbe49e45d47d2dad9664fbb7adf72492e3c81ebd3e29134d9bc12212bf83c6840f10e8246b9db54a4859b7ccd0123d86e5872c1e5082f'
     };
     var HV_PASTE_DEFAULT = 'Paste one hash per line…';
-    var HV_HAS_EXISTING = {{ 'true' if hashfiles.count() else 'false' }};
+    var HV_HAS_EXISTING = {{ 'true' if hashfiles|length else 'false' }};
     var HV_DEFAULT_TAB = "{{ default_tab }}";
 
     // Disable Next until the active tab's required fields are valid. The button
@@ -245,7 +245,7 @@
         {# Use existing #}
         <div id="pane-existing" style="display:{{ 'block' if default_tab == 'existing' else 'none' }};">
             <form action='' id='hf_form_existing' method='post' name='hf_form'>
-                {% if hashfiles.count() %}
+                {% if hashfiles|length %}
                 {% set ns = namespace(has_match=false) %}
                 {% for hashfile in hashfiles %}{% if hashfile.id == job.hashfile_id %}{% set ns.has_match = true %}{% endif %}{% endfor %}
                 <table class="tbl">
@@ -284,7 +284,7 @@
 <div class="wizard-nav">
     <a class="btn" href="{{ url_for('jobs.jobs_list') }}">{{ icon('arrowLeft', size=15) }} Back</a>
     <span class="spacer"></span>
-    <button type="submit" id="hf_next" form="{{ 'hf_form_existing' if default_tab == 'existing' else 'hf_form' }}" class="btn btn-primary"{% if default_tab == 'existing' and not hashfiles.count() %} style="display:none;"{% endif %}>Next {{ icon('arrowRight', size=15) }}</button>
+    <button type="submit" id="hf_next" form="{{ 'hf_form_existing' if default_tab == 'existing' else 'hf_form' }}" class="btn btn-primary"{% if default_tab == 'existing' and not hashfiles|length %} style="display:none;"{% endif %}>Next {{ icon('arrowRight', size=15) }}</button>
 </div>
 
 {# ---- hashfile import progress modal (opened when the Upload/Paste form submits) ----

--- a/tests/unit/test_jobs_assigned_hashfile.py
+++ b/tests/unit/test_jobs_assigned_hashfile.py
@@ -10,6 +10,7 @@ pin ACTUAL behavior against the in-memory app; app source is never modified.
 import os
 
 import pytest
+from sqlalchemy import event
 
 from hashview.models import Hashes, HashfileHashes, Hashfiles, Jobs, db
 from tests.unit.helpers import login, make_admin, make_customer
@@ -310,3 +311,115 @@ def test_custom_hash_type_missing_number_fails_validation(app, client, tmp_snaps
 
     assert Hashfiles.query.filter_by(name="NoCustomModeHF").first() is None
     assert _new_files(tmp_dir, before) == set()
+
+
+def test_hashfile_picker_n_plus_one_fixed(app, client):
+    """Verify that the GET hashfile-picker route (jobs_assigned_hashfile) uses
+    ONE grouped query to fetch hashfile stats (total, cracked, mode) instead of
+    one query per hashfile. Issue #422, defect 2.
+
+    Seeds multiple hashfiles with varying cracked/total counts, fetches the
+    hashfile-picker page, and inspects SQL statements to prove the aggregate
+    query runs once per set of hashfiles, grouped by hashfile_id, not once per
+    hashfile in the loop.
+    """
+    admin = make_admin()
+    login(client, admin)
+    cust = make_customer()
+    job = _job(admin, cust)
+
+    # Seed 3 hashfiles with varying stats
+    hf1 = Hashfiles(name="hf1", customer_id=cust.id, owner_id=admin.id)
+    hf2 = Hashfiles(name="hf2", customer_id=cust.id, owner_id=admin.id)
+    hf3 = Hashfiles(name="hf3", customer_id=cust.id, owner_id=admin.id)
+    db.session.add_all([hf1, hf2, hf3])
+    db.session.commit()
+
+    # Populate hf1 with 10 hashes, 3 cracked
+    for i in range(10):
+        h = Hashes(
+            sub_ciphertext=f"sub_{hf1.id}_{i}",
+            ciphertext=f"hash_{hf1.id}_{i}",
+            cracked=(i < 3),
+            hash_type=1000,
+        )
+        db.session.add(h)
+        db.session.flush()
+        db.session.add(HashfileHashes(hash_id=h.id, hashfile_id=hf1.id, username=f"user{i}"))
+
+    # Populate hf2 with 5 hashes, all cracked
+    for i in range(5):
+        h = Hashes(
+            sub_ciphertext=f"sub_{hf2.id}_{i}",
+            ciphertext=f"hash_{hf2.id}_{i}",
+            cracked=True,
+            hash_type=100,
+        )
+        db.session.add(h)
+        db.session.flush()
+        db.session.add(HashfileHashes(hash_id=h.id, hashfile_id=hf2.id, username=f"user{i}"))
+
+    # Populate hf3 with 8 hashes, none cracked
+    for i in range(8):
+        h = Hashes(
+            sub_ciphertext=f"sub_{hf3.id}_{i}",
+            ciphertext=f"hash_{hf3.id}_{i}",
+            cracked=False,
+            hash_type=500,
+        )
+        db.session.add(h)
+        db.session.flush()
+        db.session.add(HashfileHashes(hash_id=h.id, hashfile_id=hf3.id, username=f"user{i}"))
+
+    db.session.commit()
+
+    # Capture all SQL statements during the GET request
+    statements = []
+
+    def record(conn, cursor, statement, parameters, context, executemany):
+        statements.append(" ".join(statement.split()).lower())
+
+    engine = db.engine
+    event.listen(engine, "before_cursor_execute", record)
+    try:
+        resp = client.get(f"/jobs/{job.id}/assigned_hashfile/")
+    finally:
+        event.remove(engine, "before_cursor_execute", record)
+
+    # Verify the response is successful
+    assert resp.status_code == 200
+    body = resp.data
+
+    # The route should render hashfile stats in the template.
+    # Check that the stats appear in the page (confirms data is populated).
+    assert b"hf1" in body or b"hf2" in body or b"hf3" in body
+
+    # Find the grouped query that fetches hashfile stats.
+    # It should:
+    # 1. Join HashfileHashes and Hashes
+    # 2. Filter by hashfile_id IN (list of ids)
+    # 3. Group by HashfileHashes.hashfile_id
+    # 4. Select count, sum (for cracked), and min (for mode)
+    grouped_agg_queries = [
+        s for s in statements
+        if s.startswith("select")
+        and "from hashfile_hashes" in s
+        and "join hashes" in s
+        and "group by" in s
+        and "count(" in s
+    ]
+
+    # There should be exactly ONE such grouped query (not one per hashfile).
+    assert len(grouped_agg_queries) == 1, (
+        f"Expected exactly 1 grouped aggregate query, got {len(grouped_agg_queries)}. "
+        f"This suggests the N+1 pattern (one query per hashfile) is still present. "
+        f"Queries found:\n" + "\n".join(grouped_agg_queries)
+    )
+
+    # Verify the query shape: it should select the hashfile_id, so we can
+    # correlate results back.
+    agg_query = grouped_agg_queries[0]
+    assert "hashfile_id" in agg_query, (
+        f"Grouped query should select hashfile_id for result mapping. "
+        f"Query: {agg_query}"
+    )


### PR DESCRIPTION
## Summary
Part of issue #422 (defect 2 of 4). The hashfile-picker route (`jobs_assigned_hashfile`) issued one aggregate query per hashfile (total count, cracked count, representative hash type) — an N+1 pattern that scales linearly with a customer's hashfile count, running on every request including POSTs, before validation.

- `hashview/jobs/routes.py` — replaced the per-hashfile loop with one grouped query (`GROUP BY HashfileHashes.hashfile_id`), mirroring the exact pattern already used for the same three aggregates on the `/jobs` list route.
- `hashfiles = Hashfiles.query.filter_by(...)` is now executed once via `.all()` instead of left as a re-runnable `Query` object, which the template was calling `.count()` on repeatedly and iterating multiple times (each a fresh query).
- `hashview/templates/jobs_assigned_hashfiles.html.j2` — updated the three `.count()` call sites to `|length`, which works identically against a plain list.
- Removed `hashfile_cracked_rate` — built but never read by the template (it consumes `hashfile_info` instead).

Closes #422 (defect 2)

## Test plan
- [x] ruff, bandit (vs baseline), openapi-spec-validator, `pytest tests/unit tests/security tests/agent_unit`: 1726 passed, 2 skipped, 61 xfailed
- [x] New unit test inspects the actual SQL issued (same pattern as `tests/unit/test_rules_pagination.py`'s equivalent N+1 test) and asserts exactly one grouped aggregate query runs, not one per hashfile. Verified this genuinely discriminates: temporarily reverted to the pre-fix route/template and confirmed the test fails (0 grouped queries found, since the old per-hashfile queries carry no `GROUP BY`), then restored the fix and confirmed it passes.
- [ ] `tests/e2e/test_job_creation_perf.py::test_hashfile_picker_cost_per_hashfile_is_bounded` (the companion strict-xfail perf test) not run — needs a seeded live Playwright stack unavailable in this environment. Left the marker in place; whoever runs it against a live stack should remove it once confirmed.