### PR TITLE
perf(#422): add missing indexes on job_tasks and hashes.task_id

### DIFF
--- a/hashview/models.py
+++ b/hashview/models.py
@@ -188,8 +188,8 @@ class JobTasks(db.Model):
     """Class object to represent JobTasks"""
 
     id = db.Column(db.Integer, primary_key=True)
-    job_id = db.Column(db.Integer, nullable=False)
-    task_id = db.Column(db.Integer, nullable=False)
+    job_id = db.Column(db.Integer, nullable=False, index=True)
+    task_id = db.Column(db.Integer, nullable=False, index=True)
     priority = db.Column(db.Integer, nullable=False, default=3)
     command = db.Column(db.String(1024))
     # status: Running/Paused/Not Started/Completed/Queued/Canceled/Importing
@@ -349,7 +349,7 @@ class Hashes(db.Model):
     hash_type = db.Column(db.Integer, nullable=False, index=True)
     cracked = db.Column(db.Boolean, nullable=False)
     recovered_at = db.Column(db.DateTime, nullable=True)
-    task_id = db.Column(db.Integer, nullable=True)
+    task_id = db.Column(db.Integer, nullable=True, index=True)
     recovered_by = db.Column(db.Integer, nullable=True)
     plaintext = db.Column(db.String(256), index=True)
 

--- a/migrations/versions/a8c4d2e1f5b3_add_job_tasks_and_hashes_task_id_indexes.py
+++ b/migrations/versions/a8c4d2e1f5b3_add_job_tasks_and_hashes_task_id_indexes.py
@@ -1,0 +1,60 @@
+"""add indexes on job_tasks and hashes.task_id
+
+Revision ID: a8c4d2e1f5b3
+Revises: b5c8d9e1f2a4
+Create Date: 2026-09-05 00:00:00.000000
+
+Adds three indexes that close the remaining index gaps in the job wizard and task-level
+queries (issue #422):
+
+  ix_job_tasks_job_id         job_tasks(job_id)
+      -> job wizard's SELECT * FROM job_tasks WHERE job_id = ? queries.
+  ix_job_tasks_task_id        job_tasks(task_id)
+      -> job wizard's SELECT * FROM job_tasks WHERE task_id = ? queries.
+  ix_hashes_task_id           hashes(task_id)
+      -> per-task hash lookups (WHERE task_id = ?) without relying on the composite
+         ix_hashes_cracked_task_id, which requires the leading cracked column.
+
+Note: hash_notifications.hash_id and hashes.cracked were already indexed before this
+migration (as documented in migrations/versions/f1a2b3c4d5e6_add_perf_indexes.py and
+the Hashes.__table_args__ in models.py), so issue #422's claim about those was stale.
+This migration only closes the three genuine gaps.
+
+Each index is guarded on apply so it is idempotent under schema drift (a fresh
+create_all already builds these from the models).
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'a8c4d2e1f5b3'
+down_revision = 'b5c8d9e1f2a4'
+branch_labels = None
+depends_on = None
+
+# (index name, table, [columns]) -- names match the model declarations so a
+# model-built (create_all) schema and this migration agree.
+_INDEXES = [
+    ('ix_job_tasks_job_id', 'job_tasks', ['job_id']),
+    ('ix_job_tasks_task_id', 'job_tasks', ['task_id']),
+    ('ix_hashes_task_id', 'hashes', ['task_id']),
+]
+
+
+def _has_index(table, name):
+    import sqlalchemy as sa
+    insp = sa.inspect(op.get_bind())
+    if table not in insp.get_table_names():
+        return True  # table absent -> nothing to create; treat as "present" to skip
+    return any(ix['name'] == name for ix in insp.get_indexes(table))
+
+
+def upgrade():
+    for name, table, cols in _INDEXES:
+        if not _has_index(table, name):
+            op.create_index(name, table, cols, unique=False)
+
+
+def downgrade():
+    for name, table, _cols in reversed(_INDEXES):
+        if _has_index(table, name):
+            op.drop_index(name, table_name=table)

--- a/tests/integration/test_migration_e2e.py
+++ b/tests/integration/test_migration_e2e.py
@@ -12,7 +12,7 @@ from sqlalchemy import create_engine, text
 
 from tests.migration.expected_hex import PLAINTEXT_CASES, USERNAME_CASES
 
-DEV_HEAD = "b5c8d9e1f2a4"
+DEV_HEAD = "a8c4d2e1f5b3"
 
 pytestmark = [pytest.mark.mysql, pytest.mark.migration]
 

--- a/tests/run_migration_e2e.sh
+++ b/tests/run_migration_e2e.sh
@@ -20,7 +20,7 @@ export DOCKER_PLATFORM="${DOCKER_PLATFORM:-linux/amd64}"
 COMPOSE="${COMPOSE_BIN:-docker compose} -f docker-compose.migration.yml"
 KEEP="${HASHVIEW_MIGRATION_KEEP:-0}"
 MAIN_REF="${HASHVIEW_MAIN_REF:-origin/main}"
-DEV_HEAD="b5c8d9e1f2a4"
+DEV_HEAD="a8c4d2e1f5b3"
 
 TMP_ROOT="$(mktemp -d)"
 MAIN_WT="$TMP_ROOT/hv-main"

--- a/tests/unit/test_migration_drift_idempotency.py
+++ b/tests/unit/test_migration_drift_idempotency.py
@@ -24,7 +24,7 @@ from sqlalchemy import text
 
 MIGRATIONS_DIR = str(Path(__file__).resolve().parents[2] / "migrations")
 BASE_REV = "8027c2d2b40a"      # what the drifted field DB was stamped at
-DEV_HEAD = "b5c8d9e1f2a4"
+DEV_HEAD = "a8c4d2e1f5b3"
 
 
 def _drifted_app(tmp_path, drop_columns=()):


### PR DESCRIPTION
## Summary
Closes out issue #422's index-gap claims. Corrects two of them: `hash_notifications.hash_id` and `hashes.cracked` were already indexed before this migration (the former via `index=True` in the model, the latter via two composite indexes leading with `cracked`) — the issue's claim about those two was stale. The three genuine gaps:

- `job_tasks.job_id`, `job_tasks.task_id` — no index at all.
- `hashes.task_id` — only a trailing column in the composite `ix_hashes_cracked_task_id`, so a bare `WHERE task_id = ?` without a `cracked` predicate can't use it.

- `hashview/models.py` — `index=True` on all three columns.
- New migration `a8c4d2e1f5b3` (chained onto head `b5c8d9e1f2a4`), following the exact guarded/idempotent pattern of the precedent migration `f1a2b3c4d5e6_add_perf_indexes.py`.
- `DEV_HEAD` bumped to `a8c4d2e1f5b3` in `tests/run_migration_e2e.sh`, `tests/unit/test_migration_drift_idempotency.py`, `tests/integration/test_migration_e2e.py`.

Closes #422 (index gaps)

## Test plan
- [x] ruff, bandit (vs baseline), openapi-spec-validator, `pytest tests/unit tests/security tests/agent_unit`: 1766 passed, 2 skipped, 61 xfailed
- [x] Confirmed a single Alembic head, correct down_revision chain
- [x] Forced the real DDL to execute (not just guard-skip) via a downgrade(-1)/upgrade(+1) cycle on a fresh SQLite DB stamped at the pre-dev-tail base — confirmed via `sqlalchemy.inspect` that all three indexes are dropped on downgrade and recreated with the correct column lists on upgrade
- [x] `tests/unit/test_migration_drift_idempotency.py` (which drops `hashes.task_id` to simulate schema drift) genuinely exercises this migration's create path, not just its guard-skip path