### PR TITLE
docs: fix stale inline comments found in a repo-wide accuracy sweep

### DIFF
--- a/hashview/hashfiles/forms.py
+++ b/hashview/hashfiles/forms.py
@@ -5,7 +5,7 @@ from wtforms.validators import DataRequired
 
 
 class HashfilesForm(FlaskForm):
-    """Class representing an Agent Forms"""
+    """Class representing a Hashfile upload form"""
 
     name = StringField('Hashfile Name', validator=[DataRequired()])
     hashfile = FileField('Upload Hashfile')

--- a/hashview/models.py
+++ b/hashview/models.py
@@ -244,7 +244,7 @@ class Agents(db.Model):
     name = db.Column(db.String(100), nullable=False)         # can probably be reduced
     src_ip = db.Column(db.String(15), nullable=False)
     uuid = db.Column(db.String(60), nullable=False)          # can probably be reduced
-    status = db.Column(db.String(20), nullable=False)        # Pending, Syncing, Working, Idle
+    status = db.Column(db.String(20), nullable=False)        # Pending, Authorized, Working, Idle
     hc_status = db.Column(db.String(6000))
     last_checkin = db.Column(db.DateTime)
     # True once an "agent offline" admin alert has been sent; reset when the agent

--- a/hashview/setup/__init__.py
+++ b/hashview/setup/__init__.py
@@ -268,7 +268,7 @@ _DYNAMIC_WORDLISTS = (
     ('(DYNAMIC) All Usernames',           'hashview/control/wordlists/dynamic-usernames.txt'),
     ('(DYNAMIC) All Customers',           'hashview/control/wordlists/dynamic-customers.txt'),
     ('(DYNAMIC) All NTLM Hashes',         'hashview/control/wordlists/dynamic-ntlm.txt'),
-    # Recovered passwords split into fixed length buckets (0-5, 6..8, 9+).
+    # Recovered passwords split into fixed length buckets (0-5, 6, 7, 8, 9+).
     *dynamic_password_length_wordlists(),
 )
 

--- a/hashview/utils/utils.py
+++ b/hashview/utils/utils.py
@@ -1478,8 +1478,9 @@ def _validate_hashfile(hashfile_path, line_validator):
     """Stream a hashfile and run line_validator(line, line_no) on each non-blank
     line; return the first error string, or False if every line passes.
 
-    Centralises shared robustness: safe decoding (latin-1 never raises on
-    binary/garbage uploads), streaming (no whole-file load into memory),
+    Centralises shared robustness: safe decoding (utf-8-sig with
+    errors='replace' never raises on binary/garbage uploads), streaming (no
+    whole-file load into memory),
     blank/whitespace-only line skipping, the per-line length cap, and an
     empty-file check.
     """

--- a/install/hashview-agent/hashview-agent.py
+++ b/install/hashview-agent/hashview-agent.py
@@ -593,8 +593,9 @@ def hashcatParser(filepath):
     with open(filepath, encoding='utf-8', errors='replace') as hashcat_output:
         for line in hashcat_output:
             # Iterate the whole file; the last valid status line wins. We read this
-            # while hashcat is still writing it (via tee), so a line can be partial
-            # or malformed -- skip those rather than aborting the status poll.
+            # while hashcat is still writing to it directly (no shell/tee involved,
+            # per #297), so a line can be partial or malformed -- skip those rather
+            # than aborting the status poll.
             if not line.startswith('{'):
                 continue
             try:


### PR DESCRIPTION
## Summary
Repo-wide sweep of inline `#` comments across `hashview/` and `install/hashview-agent/` for factual accuracy against current code. Five stale comments fixed:

- `hashview/models.py`: `Agents.status` comment listed `Syncing` (never assigned anywhere) and omitted `Authorized`; corrected to the actual set of assigned values (Pending/Authorized/Working/Idle).
- `hashview/setup/__init__.py`: password-length wordlist bucket comment said `(0-5, 6..8, 9+)` implying one combined 6-8 bucket; there are actually three separate buckets (6, 7, 8).
- `hashview/utils/utils.py`: `_validate_hashfile`'s docstring said latin-1 decoding; the code (and the comment directly beneath it) actually uses `utf-8-sig` with `errors='replace'`.
- `install/hashview-agent/hashview-agent.py`: `hashcatParser`'s comment still described hashcat's output as piped through `tee`; since the #297 argv/`shell=False` fix, hashcat's stdout is redirected directly with no shell/tee involved.
- `hashview/hashfiles/forms.py`: `HashfilesForm`'s docstring was a copy-paste leftover calling it an "Agent Forms" class.

No behavior changes — comment/docstring text only.

Three additional findings from this sweep turned out to be real bugs (not just stale comments) rather than doc-only issues, so they're filed as separate GitHub issues instead of bundled here: #469, #470, #471.

## Test plan
- [x] `ruff` clean
- [x] `bandit` vs. baseline clean
- [x] OpenAPI spec validates
- [x] Full unit/security/agent suite passing (same pass/xfail counts as main, comment-only diff)