### PR TITLE
API: PUT /v1/rules/<id> and /v1/wordlists/<id> to replace content in place (#399)

### DIFF
--- a/.githooks/safe-allowlist.txt
+++ b/.githooks/safe-allowlist.txt
@@ -104,3 +104,9 @@ FCF7C1B8749CF99D88E5F34271D636178FB5D130
 # the shared prefix so the pattern also matches this very line, which the
 # generic secret-assign rule flags whenever it is added or moved.
 api_key="user-api-key-
+
+# --- tests/unit/test_api_endpoints.py (issue #399 PUT rules/wordlists) ---
+# Dummy api_key literals for the owner/non-owner ownership-check fixtures.
+# Not real secrets.
+api_key="owner-key"
+api_key="other-key"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Notable changes will be documented here
 - `POST /v1/task_groups/add` -- create a task group and its ordered task membership in one call (#401)
 - `POST /v1/task_groups/<task_group_id>/tasks` -- replace or append a task group's task membership (#401)
 - `DELETE /v1/task_groups/<task_group_id>` -- delete a task group, owner/admin only (#401)
+- `PUT /v1/rules/<id>` and `PUT /v1/wordlists/<id>` to replace an existing rule's or static wordlist's content in place (same id, same name) — refused with 409 if a task using the resource has a currently running job (#399)
 
 **Encrypted Database Backup**
 - Download an encrypted `mysqldump` of the database from Settings -> Data Management, protected by a one-time password

--- a/hashview/api/routes.py
+++ b/hashview/api/routes.py
@@ -980,6 +980,95 @@ def v1_api_add_wordlist(wordlist_name):
     }
     return jsonify(message)
 
+# Replace an existing static wordlist's content in place (same id, same name)
+@api.route('/v1/wordlists/<int:wordlist_id>', methods=['PUT'])
+def v1_api_update_wordlist(wordlist_id):
+    # User-upload action — user-only, same reasoning as v1_api_update_rule.
+    if not is_authorized(user=True, agent=False, request=request):
+        return redirect("/v1/not_authorized")
+
+    user_uuid = request.cookies.get('uuid')
+    user = Users.query.filter_by(api_key=user_uuid).first()
+    if not user:
+        return jsonify({'status': 403, 'type': 'Error', 'msg': 'User not found'})
+
+    wordlist = Wordlists.query.get(wordlist_id)
+    if wordlist is None:
+        return jsonify({'status': 404, 'type': 'Error', 'msg': 'Wordlist not found'}), 404
+
+    # Dynamic lists are regenerated from the DB via /v1/updateWordlist/<id>;
+    # their content is not the caller's to set.
+    if wordlist.type == 'dynamic':
+        return jsonify({
+            'status': 400,
+            'type': 'Error',
+            'msg': 'Dynamic wordlists are regenerated from the database and cannot have their content replaced'
+        }), 400
+
+    if not (user.admin or wordlist.owner_id == user.id):
+        return jsonify({
+            'status': 403,
+            'type': 'Error',
+            'msg': 'You do not have rights to update this wordlist'
+        }), 403
+
+    if resource_in_running_task(wl_id=wordlist.id):
+        return jsonify({
+            'status': 409,
+            'type': 'Error',
+            'msg': 'Wordlist is in use by a currently running task'
+        }), 409
+
+    raw_content = request.get_data()
+    if not raw_content:
+        return jsonify({
+            'status': 400,
+            'type': 'Error',
+            'msg': 'Missing wordlist content in request body'
+        })
+
+    # Ingest into a brand-new compressed-at-rest file (same helper the add
+    # route uses), then repoint this row at it and drop the old file — DB-first,
+    # best-effort unlink, mirroring wordlists_delete's ordering.
+    tmp_path = os.path.abspath(os.path.join(current_app.root_path, 'control/tmp', secrets.token_hex(8)))
+    try:
+        with open(tmp_path, 'wb') as f:
+            f.write(raw_content)
+        replacement = ingest_static_wordlist_file(tmp_path, user.id, wordlist.name)
+    except Exception:
+        current_app.logger.exception('API /v1/wordlists: failed to process wordlist update')
+        return jsonify({
+            'status': 400,
+            'type': 'Error',
+            'msg': 'Failed to process wordlist (not valid text or gzip?).'
+        })
+    finally:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+
+    old_path = wordlist.path
+    wordlist.path = replacement.path
+    wordlist.size = replacement.size
+    wordlist.byte_size = replacement.byte_size
+    wordlist.checksum = replacement.checksum
+    db.session.commit()
+
+    if old_path and os.path.exists(old_path):
+        try:
+            os.remove(old_path)
+        except OSError:
+            current_app.logger.exception('Failed to remove old wordlist file: %s', old_path)
+
+    log_event('wordlist.update', actor=(user.email_address, user.id),
+              target=f'wordlist:{wordlist.id} {wordlist.name!r}')
+    message = {
+        'status': 200,
+        'type': 'message',
+        'msg': 'Wordlist updated',
+        'wordlist_id': wordlist.id
+    }
+    return jsonify(message)
+
 # force or restart a queue item
 # used when agent goes offline and comes back online
 # without a running hashcat cmd while task still assigned to them

--- a/hashview/api/routes.py
+++ b/hashview/api/routes.py
@@ -837,6 +837,7 @@ def v1_api_update_rule(rules_id):
         replace_file_atomic(tmp_final, rule.path)
         rule.size = get_linecount(rule.path)
         rule.checksum = get_filehash(rule.path)
+        rule.last_updated = datetime.utcnow()
         db.session.commit()
     except Exception:
         current_app.logger.exception('API /v1/rules: failed to swap in rule update')
@@ -1051,7 +1052,19 @@ def v1_api_update_wordlist(wordlist_id):
     wordlist.size = replacement.size
     wordlist.byte_size = replacement.byte_size
     wordlist.checksum = replacement.checksum
-    db.session.commit()
+    wordlist.last_updated = datetime.utcnow()
+    try:
+        db.session.commit()
+    except Exception:
+        db.session.rollback()
+        current_app.logger.exception('API /v1/wordlists: failed to save wordlist update')
+        if os.path.exists(replacement.path):
+            os.remove(replacement.path)
+        return jsonify({
+            'status': 500,
+            'type': 'Error',
+            'msg': 'Failed to save wordlist update.'
+        })
 
     if old_path and os.path.exists(old_path):
         try:

--- a/hashview/api/routes.py
+++ b/hashview/api/routes.py
@@ -53,6 +53,8 @@ from hashview.utils.utils import (
     process_recovered_hash_notifications,
     rechunk_queued_tasks_for_hashtype,
     remove_file,
+    replace_file_atomic,
+    resource_in_running_task,
     send_generated_file,
     slowest_benchmark,
     text_from_field,
@@ -759,6 +761,89 @@ def v1_api_add_rule(rule_name):
         'status': 200,
         'type': 'message',
         'msg': 'Rule added',
+        'rule_id': rule.id
+    }
+    return jsonify(message)
+
+
+# Replace an existing rule's content in place (same id, same name)
+@api.route('/v1/rules/<int:rule_id>', methods=['PUT'])
+def v1_api_update_rule(rule_id):
+    # User-upload action (resolves the caller to a Users row by api_key), so
+    # it's user-only — the agent only GETs rules, it never PUTs here.
+    if not is_authorized(user=True, agent=False, request=request):
+        return redirect("/v1/not_authorized")
+
+    user_uuid = request.cookies.get('uuid')
+    user = Users.query.filter_by(api_key=user_uuid).first()
+    if not user:
+        return jsonify({'status': 403, 'type': 'Error', 'msg': 'User not found'})
+
+    rule = Rules.query.get(rule_id)
+    if rule is None:
+        return jsonify({'status': 404, 'type': 'Error', 'msg': 'Rule not found'}), 404
+
+    if not (user.admin or rule.owner_id == user.id):
+        return jsonify({
+            'status': 403,
+            'type': 'Error',
+            'msg': 'You do not have rights to update this rule'
+        }), 403
+
+    # Swapping content out from under an in-flight crack changes what that
+    # run is actually doing; refuse rather than silently changing the input.
+    if resource_in_running_task(rule_id=rule.id):
+        return jsonify({
+            'status': 409,
+            'type': 'Error',
+            'msg': 'Rule is in use by a currently running task'
+        }), 409
+
+    raw_content = request.get_data()
+    if not raw_content:
+        return jsonify({
+            'status': 400,
+            'type': 'Error',
+            'msg': 'Missing rule content in request body'
+        })
+
+    # Land the replacement in control/tmp first; only swap it onto rule.path
+    # (same filename, same row) once it's known-good, so a bad upload leaves
+    # the existing file intact.
+    tmp_path = os.path.abspath(os.path.join(current_app.root_path, 'control/tmp', secrets.token_hex(8)))
+    tmp_final = os.path.abspath(os.path.join(current_app.root_path, 'control/tmp', secrets.token_hex(8) + '.txt'))
+    try:
+        with open(tmp_path, 'wb') as f:
+            f.write(raw_content)
+        if is_gzip(tmp_path):
+            # Raises on a malformed gzip stream, which doubles as validation
+            decompress_gz(tmp_path, tmp_final)
+        else:
+            os.rename(tmp_path, tmp_final)
+    except Exception:
+        current_app.logger.exception('API /v1/rules: failed to process rule update')
+        if os.path.exists(tmp_final):
+            os.remove(tmp_final)
+        return jsonify({
+            'status': 400,
+            'type': 'Error',
+            'msg': 'Failed to process rule (not valid text or gzip?).'
+        })
+    finally:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+
+    replace_file_atomic(tmp_final, rule.path)
+    rule.size = get_linecount(rule.path)
+    rule.checksum = get_filehash(rule.path)
+    db.session.commit()
+
+    log_event('rule.update', actor=(user.email_address, user.id),
+              target=f'rule:{rule.id} {rule.name!r}')
+    message = {
+        'status': 200,
+        'type': 'message',
+        'msg': 'Rule updated',
         'rule_id': rule.id
     }
     return jsonify(message)

--- a/hashview/api/routes.py
+++ b/hashview/api/routes.py
@@ -767,8 +767,8 @@ def v1_api_add_rule(rule_name):
 
 
 # Replace an existing rule's content in place (same id, same name)
-@api.route('/v1/rules/<int:rule_id>', methods=['PUT'])
-def v1_api_update_rule(rule_id):
+@api.route('/v1/rules/<int:rules_id>', methods=['PUT'])
+def v1_api_update_rule(rules_id):
     # User-upload action (resolves the caller to a Users row by api_key), so
     # it's user-only — the agent only GETs rules, it never PUTs here.
     if not is_authorized(user=True, agent=False, request=request):
@@ -779,7 +779,7 @@ def v1_api_update_rule(rule_id):
     if not user:
         return jsonify({'status': 403, 'type': 'Error', 'msg': 'User not found'})
 
-    rule = Rules.query.get(rule_id)
+    rule = Rules.query.get(rules_id)
     if rule is None:
         return jsonify({'status': 404, 'type': 'Error', 'msg': 'Rule not found'}), 404
 
@@ -833,10 +833,20 @@ def v1_api_update_rule(rule_id):
         if os.path.exists(tmp_path):
             os.remove(tmp_path)
 
-    replace_file_atomic(tmp_final, rule.path)
-    rule.size = get_linecount(rule.path)
-    rule.checksum = get_filehash(rule.path)
-    db.session.commit()
+    try:
+        replace_file_atomic(tmp_final, rule.path)
+        rule.size = get_linecount(rule.path)
+        rule.checksum = get_filehash(rule.path)
+        db.session.commit()
+    except Exception:
+        current_app.logger.exception('API /v1/rules: failed to swap in rule update')
+        if os.path.exists(tmp_final):
+            os.remove(tmp_final)
+        return jsonify({
+            'status': 500,
+            'type': 'Error',
+            'msg': 'Failed to save rule update.'
+        })
 
     log_event('rule.update', actor=(user.email_address, user.id),
               target=f'rule:{rule.id} {rule.name!r}')

--- a/hashview/api_docs/openapi.yaml
+++ b/hashview/api_docs/openapi.yaml
@@ -482,6 +482,61 @@ paths:
               example: {status: 404, type: Error, msg: Rule not found}
         '302':
           $ref: '#/components/responses/NotAuthorizedRedirect'
+    put:
+      tags: [Rules]
+      summary: Replace a rule's content in place
+      description: >-
+        Overwrites the rule's file content without changing its id or name.
+        The request body is the RAW file bytes (NOT multipart/form-data):
+        plain text or a gzip stream (decompressed server-side; rules are
+        stored plaintext at rest). Refused with 409 if a Task using this
+        rule has a currently Running JobTasks entry.
+      operationId: updateRule
+      x-audience: user
+      security:
+        - userApiKey: []
+      parameters:
+        - name: rules_id
+          in: path
+          required: true
+          schema: {type: integer}
+      requestBody:
+        required: true
+        content:
+          text/plain:
+            schema: {type: string}
+          application/gzip:
+            schema: {type: string, format: binary}
+      responses:
+        '200':
+          description: >-
+            HTTP 200 with `rule_id`, 400 on an empty body or invalid gzip,
+            403 if the key resolves to no user or the caller doesn't own the
+            rule, 409 if a Running task uses this rule.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/RuleAddedResponse'
+                  - $ref: '#/components/schemas/ApiError'
+              examples:
+                updated: {value: {status: 200, type: message, msg: Rule updated, rule_id: 4}}
+        '404':
+          description: Unknown rule id.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+              example: {status: 404, type: Error, msg: Rule not found}
+        '409':
+          description: A Task using this rule has a currently Running JobTasks entry.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+              example: {status: 409, type: Error, msg: Rule is in use by a currently running task}
+        '302':
+          $ref: '#/components/responses/NotAuthorizedRedirect'
 
   /v1/rules/add/{rule_name}:
     post:
@@ -579,6 +634,63 @@ paths:
               schema:
                 $ref: '#/components/schemas/ApiError'
               example: {status: 404, type: Error, msg: Wordlist not found}
+        '302':
+          $ref: '#/components/responses/NotAuthorizedRedirect'
+    put:
+      tags: [Wordlists]
+      summary: Replace a static wordlist's content in place
+      description: >-
+        Overwrites the wordlist's stored file without changing its id or
+        name. The request body is the RAW file bytes (NOT multipart/form-data):
+        plain text or a gzip stream — either way it is stored gzip-compressed
+        at rest and `size`/`byte_size`/`checksum` are recomputed. Refused with
+        400 for a `type: dynamic` wordlist (those are regenerated from the
+        database) and with 409 if a Task using this wordlist has a currently
+        Running JobTasks entry.
+      operationId: updateWordlist
+      x-audience: user
+      security:
+        - userApiKey: []
+      parameters:
+        - name: wordlist_id
+          in: path
+          required: true
+          schema: {type: integer}
+      requestBody:
+        required: true
+        content:
+          text/plain:
+            schema: {type: string}
+          application/gzip:
+            schema: {type: string, format: binary}
+      responses:
+        '200':
+          description: >-
+            HTTP 200 with `wordlist_id`, 400 on an empty body, invalid gzip,
+            or a dynamic wordlist, 403 if the key resolves to no user or the
+            caller doesn't own the wordlist, 409 if a Running task uses it.
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: '#/components/schemas/WordlistAddedResponse'
+                  - $ref: '#/components/schemas/ApiError'
+              examples:
+                updated: {value: {status: 200, type: message, msg: Wordlist updated, wordlist_id: 6}}
+        '404':
+          description: Unknown wordlist id.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+              example: {status: 404, type: Error, msg: Wordlist not found}
+        '409':
+          description: A Task using this wordlist has a currently Running JobTasks entry.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+              example: {status: 409, type: Error, msg: Wordlist is in use by a currently running task}
         '302':
           $ref: '#/components/responses/NotAuthorizedRedirect'
 
@@ -1508,7 +1620,7 @@ components:
       properties:
         status:
           type: integer
-          enum: [400, 403, 404, 426, 500]
+          enum: [400, 403, 404, 409, 426, 500]
         type:
           type: string
           enum: [Error, message]

--- a/hashview/rules/routes.py
+++ b/hashview/rules/routes.py
@@ -21,6 +21,7 @@ from hashview.utils.utils import (
     apply_name_filter,
     get_filehash,
     get_linecount,
+    resource_in_running_task,
     save_file,
     try_commit,
 )
@@ -193,6 +194,9 @@ def rules_view(rule_id):
     if request.method == 'POST':
         if not can_edit:
             flash('Unauthorized action!', 'danger')
+            return redirect(url_for('rules.rules_view', rule_id=rule.id))
+        if resource_in_running_task(rule_id=rule.id):
+            flash('Rule is in use by a currently running task and cannot be edited.', 'danger')
             return redirect(url_for('rules.rules_view', rule_id=rule.id))
         new_content = request.form.get('content')
         try:

--- a/hashview/utils/utils.py
+++ b/hashview/utils/utils.py
@@ -1,12 +1,14 @@
 """Flask routes to handle utils"""
 import _md5
 import binascii
+import errno
 import gzip
 import hashlib
 import json
 import os
 import re
 import secrets
+import shutil
 import struct
 from datetime import datetime
 
@@ -240,6 +242,41 @@ def ingest_static_wordlist_file(src_path, owner_id, name):
         size=size,
         byte_size=get_filesize(final_gz),
     )
+
+def resource_in_running_task(rule_id=None, wl_id=None):
+    """Return True if a rule or wordlist is referenced by a Task that has a
+    currently Running JobTasks row.
+
+    Swapping a rule/wordlist's file contents out from under an in-flight
+    crack would silently change what that run is actually doing; callers use
+    this to refuse the swap (409) instead. wl_id checks BOTH Tasks.wl_id and
+    Tasks.wl_id_2 (a task can reference a second wordlist for combinator-style
+    attacks).
+    """
+    if rule_id is not None:
+        task_ids = [t.id for t in Tasks.query.filter_by(rule_id=rule_id).all()]
+    elif wl_id is not None:
+        task_ids = [t.id for t in Tasks.query.filter(
+            (Tasks.wl_id == wl_id) | (Tasks.wl_id_2 == wl_id)).all()]
+    else:
+        return False
+    if not task_ids:
+        return False
+    return JobTasks.query.filter(
+        JobTasks.task_id.in_(task_ids), JobTasks.status == 'Running').first() is not None
+
+
+def replace_file_atomic(src_path, dst_path):
+    """Move src_path onto dst_path, tolerating control/ being a separate mount
+    point. os.replace() raises EXDEV across filesystems; fall back to a
+    copy + unlink in that case (see issue #395)."""
+    try:
+        os.replace(src_path, dst_path)
+    except OSError as error:
+        if error.errno != errno.EXDEV:
+            raise
+        shutil.copyfile(src_path, dst_path)
+        os.remove(src_path)
 
 def get_agent_timeout_minutes():
     """Minutes Hashview waits for an agent check-in before considering it offline.

--- a/hashview/utils/utils.py
+++ b/hashview/utils/utils.py
@@ -268,14 +268,19 @@ def resource_in_running_task(rule_id=None, wl_id=None):
 
 def replace_file_atomic(src_path, dst_path):
     """Move src_path onto dst_path, tolerating control/ being a separate mount
-    point. os.replace() raises EXDEV across filesystems; fall back to a
-    copy + unlink in that case (see issue #395)."""
+    point. os.replace() raises EXDEV across filesystems; fall back to copying
+    into a same-directory temp file and os.replace()-ing THAT onto dst_path
+    (see issue #395), so a copy that fails partway never leaves dst_path
+    truncated -- the original dst_path is untouched until the copy is known
+    good."""
     try:
         os.replace(src_path, dst_path)
     except OSError as error:
         if error.errno != errno.EXDEV:
             raise
-        shutil.copyfile(src_path, dst_path)
+        dst_tmp = dst_path + '.tmp' + secrets.token_hex(8)
+        shutil.copyfile(src_path, dst_tmp)
+        os.replace(dst_tmp, dst_path)
         os.remove(src_path)
 
 def get_agent_timeout_minutes():

--- a/tests/unit/test_api_endpoints.py
+++ b/tests/unit/test_api_endpoints.py
@@ -1073,6 +1073,141 @@ def test_rules_add_bad_gzip_returns_400(
 
 
 @pytest.mark.security
+def test_rules_put_replaces_content_keeps_id_and_name(
+    client, app, admin_user, tmp_path, monkeypatch
+):
+    """PUT /v1/rules/<id> overwrites the file in place: same id, same name,
+    same path, new size/checksum."""
+    import hashlib
+
+    _rules_dirs(app, tmp_path, monkeypatch)
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+
+    add_resp = client.post("/v1/rules/add/my-rules", data="$1\n$2",
+                           content_type="text/plain")
+    rule_id = _json_body(add_resp)["rule_id"]
+    row_before = Rules.query.get(rule_id)
+    old_path = row_before.path
+
+    new_body = b"^a\n^b\n^c"
+    resp = client.put(f"/v1/rules/{rule_id}", data=new_body,
+                      content_type="text/plain")
+    body = _json_body(resp)
+    assert body["status"] == 200
+    assert body["rule_id"] == rule_id
+
+    row_after = Rules.query.get(rule_id)
+    assert row_after.id == rule_id
+    assert row_after.name == "my-rules"
+    assert row_after.path == old_path
+    with open(row_after.path, "rb") as fh:
+        assert fh.read() == new_body
+    assert row_after.size == 3
+    assert row_after.checksum == hashlib.sha256(new_body).hexdigest()
+
+
+@pytest.mark.security
+def test_rules_put_gzip_body_decompressed(client, app, admin_user, tmp_path, monkeypatch):
+    import gzip
+
+    _rules_dirs(app, tmp_path, monkeypatch)
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    add_resp = client.post("/v1/rules/add/gz-rules", data="$1",
+                           content_type="text/plain")
+    rule_id = _json_body(add_resp)["rule_id"]
+
+    plain = b"^a\n^b\n^c"
+    resp = client.put(f"/v1/rules/{rule_id}", data=gzip.compress(plain),
+                      content_type="application/octet-stream")
+    assert _json_body(resp)["status"] == 200
+    row = Rules.query.get(rule_id)
+    with open(row.path, "rb") as fh:
+        assert fh.read() == plain
+
+
+@pytest.mark.security
+def test_rules_put_not_found_returns_404(client, admin_user):
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    resp = client.put("/v1/rules/424242", data="x", content_type="text/plain")
+    assert resp.status_code == 404
+    assert _json_body(resp)["status"] == 404
+
+
+@pytest.mark.security
+def test_rules_put_empty_body_returns_400(client, app, admin_user, tmp_path, monkeypatch):
+    _rules_dirs(app, tmp_path, monkeypatch)
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    add_resp = client.post("/v1/rules/add/my-rules", data="$1",
+                           content_type="text/plain")
+    rule_id = _json_body(add_resp)["rule_id"]
+
+    resp = client.put(f"/v1/rules/{rule_id}", data="", content_type="text/plain")
+    body = _json_body(resp)
+    assert body["status"] == 400
+    assert "Missing" in body["msg"]
+
+
+@pytest.mark.security
+def test_rules_put_non_owner_non_admin_returns_403(client, app, tmp_path, monkeypatch):
+    _rules_dirs(app, tmp_path, monkeypatch)
+    owner = Users(first_name="Own", last_name="Er", email_address="owner@example.test",
+                 password="x" * 60, admin=True, api_key="owner-key")
+    other = Users(first_name="Ot", last_name="Her", email_address="other@example.test",
+                 password="x" * 60, admin=False, api_key="other-key")
+    _db.session.add_all([owner, other])
+    _db.session.commit()
+
+    client.set_cookie("uuid", owner.api_key, domain="localhost.test")
+    add_resp = client.post("/v1/rules/add/my-rules", data="$1",
+                           content_type="text/plain")
+    rule_id = _json_body(add_resp)["rule_id"]
+
+    client.set_cookie("uuid", other.api_key, domain="localhost.test")
+    resp = client.put(f"/v1/rules/{rule_id}", data="$3", content_type="text/plain")
+    assert resp.status_code == 403
+    assert _json_body(resp)["status"] == 403
+
+
+@pytest.mark.security
+def test_rules_put_refused_when_running_job_returns_409(
+    client, app, admin_user, tmp_path, monkeypatch
+):
+    _rules_dirs(app, tmp_path, monkeypatch)
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    add_resp = client.post("/v1/rules/add/my-rules", data="$1",
+                           content_type="text/plain")
+    rule_id = _json_body(add_resp)["rule_id"]
+
+    task = Tasks(name="t", owner_id=admin_user.id, rule_id=rule_id,
+                 hc_attackmode=0, loopback=False)
+    _db.session.add(task)
+    _db.session.commit()
+    jt = JobTasks(job_id=1, task_id=task.id, status="Running")
+    _db.session.add(jt)
+    _db.session.commit()
+
+    resp = client.put(f"/v1/rules/{rule_id}", data="$2", content_type="text/plain")
+    assert resp.status_code == 409
+    assert _json_body(resp)["status"] == 409
+
+
+@pytest.mark.security
+def test_rules_put_agent_cookie_rejected(client, authorized_agent, app, admin_user,
+                                         tmp_path, monkeypatch):
+    """Agents only GET rules; PUT must reject an agent uuid."""
+    _rules_dirs(app, tmp_path, monkeypatch)
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    add_resp = client.post("/v1/rules/add/my-rules", data="$1",
+                           content_type="text/plain")
+    rule_id = _json_body(add_resp)["rule_id"]
+
+    client.set_cookie("uuid", authorized_agent.uuid, domain="localhost.test")
+    resp = client.put(f"/v1/rules/{rule_id}", data="$2", content_type="text/plain")
+    assert 300 <= resp.status_code < 400
+    assert "not_authorized" in resp.headers.get("Location", "")
+
+
+@pytest.mark.security
 def test_rules_download_missing_returns_404(client, admin_user):
     """GET /v1/rules/<id> for a nonexistent rule returns a 404 JSON error
     (previously an AttributeError -> 500 HTML page)."""

--- a/tests/unit/test_api_endpoints.py
+++ b/tests/unit/test_api_endpoints.py
@@ -193,6 +193,110 @@ def test_wordlists_add_writes_file_and_creates_row(
 
 
 @pytest.mark.security
+def test_wordlists_put_replaces_content_keeps_id_and_name(
+    client, app, admin_user, tmp_path, monkeypatch
+):
+    """PUT /v1/wordlists/<id> ingests new content, keeps the row's id/name,
+    and removes the old on-disk file."""
+    import gzip
+
+    monkeypatch.setattr(app, "root_path", str(tmp_path))
+    os.makedirs(os.path.join(str(tmp_path), "control", "wordlists"), exist_ok=True)
+    os.makedirs(os.path.join(str(tmp_path), "control", "tmp"), exist_ok=True)
+
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    add_resp = client.post("/v1/wordlists/add/my-list", data="alpha\nbeta\n",
+                           content_type="text/plain")
+    wl_id = _json_body(add_resp)["wordlist_id"]
+    old_path = Wordlists.query.get(wl_id).path
+
+    new_body = "gamma\ndelta\nepsilon\n"
+    resp = client.put(f"/v1/wordlists/{wl_id}", data=new_body,
+                      content_type="text/plain")
+    body = _json_body(resp)
+    assert body["status"] == 200
+    assert body["wordlist_id"] == wl_id
+
+    row = Wordlists.query.get(wl_id)
+    assert row.id == wl_id
+    assert row.name == "my-list"
+    assert row.path != old_path
+    assert not os.path.exists(old_path)
+    with gzip.open(row.path, "rb") as fh:
+        assert fh.read() == new_body.encode()
+    assert row.size == 4
+
+
+@pytest.mark.security
+def test_wordlists_put_dynamic_returns_400(client, app, admin_user, tmp_path, monkeypatch):
+    monkeypatch.setattr(app, "root_path", str(tmp_path))
+    os.makedirs(os.path.join(str(tmp_path), "control", "wordlists"), exist_ok=True)
+    os.makedirs(os.path.join(str(tmp_path), "control", "tmp"), exist_ok=True)
+
+    dyn = Wordlists(name="dyn", owner_id=admin_user.id, type="dynamic",
+                    path="/tmp/dyn.txt", size=0, byte_size=0, checksum="c" * 64)
+    _db.session.add(dyn)
+    _db.session.commit()
+
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    resp = client.put(f"/v1/wordlists/{dyn.id}", data="x", content_type="text/plain")
+    body = _json_body(resp)
+    assert resp.status_code == 400
+    assert body["status"] == 400
+
+
+@pytest.mark.security
+def test_wordlists_put_not_found_returns_404(client, admin_user):
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    resp = client.put("/v1/wordlists/424242", data="x", content_type="text/plain")
+    assert resp.status_code == 404
+    assert _json_body(resp)["status"] == 404
+
+
+@pytest.mark.security
+def test_wordlists_put_empty_body_returns_400(client, app, admin_user, tmp_path, monkeypatch):
+    monkeypatch.setattr(app, "root_path", str(tmp_path))
+    os.makedirs(os.path.join(str(tmp_path), "control", "wordlists"), exist_ok=True)
+    os.makedirs(os.path.join(str(tmp_path), "control", "tmp"), exist_ok=True)
+
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    add_resp = client.post("/v1/wordlists/add/my-list", data="alpha\n",
+                           content_type="text/plain")
+    wl_id = _json_body(add_resp)["wordlist_id"]
+
+    resp = client.put(f"/v1/wordlists/{wl_id}", data="", content_type="text/plain")
+    body = _json_body(resp)
+    assert body["status"] == 400
+    assert "Missing" in body["msg"]
+
+
+@pytest.mark.security
+def test_wordlists_put_refused_when_running_job_returns_409(
+    client, app, admin_user, tmp_path, monkeypatch
+):
+    monkeypatch.setattr(app, "root_path", str(tmp_path))
+    os.makedirs(os.path.join(str(tmp_path), "control", "wordlists"), exist_ok=True)
+    os.makedirs(os.path.join(str(tmp_path), "control", "tmp"), exist_ok=True)
+
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    add_resp = client.post("/v1/wordlists/add/my-list", data="alpha\n",
+                           content_type="text/plain")
+    wl_id = _json_body(add_resp)["wordlist_id"]
+
+    task = Tasks(name="t", owner_id=admin_user.id, wl_id=wl_id,
+                 hc_attackmode=0, loopback=False)
+    _db.session.add(task)
+    _db.session.commit()
+    jt = JobTasks(job_id=1, task_id=task.id, status="Running")
+    _db.session.add(jt)
+    _db.session.commit()
+
+    resp = client.put(f"/v1/wordlists/{wl_id}", data="beta\n", content_type="text/plain")
+    assert resp.status_code == 409
+    assert _json_body(resp)["status"] == 409
+
+
+@pytest.mark.security
 def test_jobs_start_rejects_agent_cookie(client, authorized_agent):
     """POST /v1/jobs/start/<id> with an agent cookie redirects to not_authorized.
 

--- a/tests/unit/test_api_endpoints.py
+++ b/tests/unit/test_api_endpoints.py
@@ -1148,6 +1148,35 @@ def test_rules_put_empty_body_returns_400(client, app, admin_user, tmp_path, mon
 
 
 @pytest.mark.security
+def test_rules_put_bad_gzip_leaves_original_intact(
+    client, app, admin_user, tmp_path, monkeypatch
+):
+    """A malformed gzip body is rejected with 400, the existing rule file is
+    left untouched, and no orphan temp file remains in control/tmp."""
+    _rules_dirs(app, tmp_path, monkeypatch)
+    client.set_cookie("uuid", admin_user.api_key, domain="localhost.test")
+    add_resp = client.post("/v1/rules/add/my-rules", data="$1\n$2",
+                           content_type="text/plain")
+    rule_id = _json_body(add_resp)["rule_id"]
+    row_before = Rules.query.get(rule_id)
+    original_content = open(row_before.path, "rb").read()
+    original_checksum = row_before.checksum
+
+    resp = client.put(f"/v1/rules/{rule_id}",
+                      data=b"\x1f\x8bthis is not a real gzip stream",
+                      content_type="application/octet-stream")
+    body = _json_body(resp)
+    assert body["status"] == 400
+
+    row_after = Rules.query.get(rule_id)
+    assert row_after.checksum == original_checksum
+    with open(row_after.path, "rb") as fh:
+        assert fh.read() == original_content
+    tmp_dir = os.path.join(str(tmp_path), "control", "tmp")
+    assert os.listdir(tmp_dir) == []
+
+
+@pytest.mark.security
 def test_rules_put_non_owner_non_admin_returns_403(client, app, tmp_path, monkeypatch):
     _rules_dirs(app, tmp_path, monkeypatch)
     owner = Users(first_name="Own", last_name="Er", email_address="owner@example.test",

--- a/tests/unit/test_api_endpoints.py
+++ b/tests/unit/test_api_endpoints.py
@@ -224,6 +224,8 @@ def test_wordlists_put_replaces_content_keeps_id_and_name(
     assert not os.path.exists(old_path)
     with gzip.open(row.path, "rb") as fh:
         assert fh.read() == new_body.encode()
+    # The replacement is applied to the EXISTING row, not added as a second one.
+    assert Wordlists.query.filter_by(name="my-list").count() == 1
     assert row.size == 4
 
 
@@ -243,6 +245,9 @@ def test_wordlists_put_dynamic_returns_400(client, app, admin_user, tmp_path, mo
     body = _json_body(resp)
     assert resp.status_code == 400
     assert body["status"] == 400
+    # Refused before any file I/O -- nothing landed in control/wordlists.
+    wl_dir = os.path.join(str(tmp_path), "control", "wordlists")
+    assert os.listdir(wl_dir) == []
 
 
 @pytest.mark.security

--- a/tests/unit/test_rules_searches_notifications_branches.py
+++ b/tests/unit/test_rules_searches_notifications_branches.py
@@ -17,6 +17,7 @@ from hashview.models import (
     Hashfiles,
     HashNotifications,
     JobNotifications,
+    JobTasks,
     Rules,
     Settings,
     Tasks,
@@ -250,6 +251,24 @@ class TestRulesView:
                            follow_redirects=True)
         # Flash 'Unauthorized action!' and redirect
         assert b"Unauthorized" in resp.data or resp.status_code in (301, 302)
+        assert open(path).read() == "original\n"
+
+    def test_view_post_refused_when_running_job(self, app, client, tmp_path):
+        """A rule referenced by a Task with a Running JobTasks row cannot be
+        edited in place — same guard as the API's PUT /v1/rules/<id>."""
+        admin = _admin()
+        _login(client, admin)
+        path = _make_rule_file(tmp_path, content="original\n")
+        rule = _make_rule(admin.id, path)
+        task = _make_task_using_rule(admin.id, rule.id)
+        jt = JobTasks(job_id=1, task_id=task.id, status="Running")
+        db.session.add(jt)
+        db.session.commit()
+
+        resp = client.post(f"/rules/edit/{rule.id}",
+                           data={"content": "hacked\n"},
+                           follow_redirects=True)
+        assert b"running task" in resp.data.lower() or resp.status_code in (301, 302)
         assert open(path).read() == "original\n"
 
     def test_view_post_not_found_redirects(self, app, client):

--- a/tests/unit/test_utils_misc.py
+++ b/tests/unit/test_utils_misc.py
@@ -6,7 +6,10 @@ wordlist_import.run_import_async. External boundaries (Flask-Mail, the Pushover
 HTTP call, the import worker, threads) are mocked.
 """
 
+import errno
 import os
+
+import pytest
 
 import hashview.utils.utils as u
 import hashview.utils.wordlist_import as wi
@@ -173,3 +176,116 @@ def test_run_import_async_runs_within_app_context(app, monkeypatch):
     assert result == {"ok": True}
     assert seen["ctx"] is True
     assert seen["args"] == (["a.txt"], 7)
+
+
+# --- resource_in_running_task -----------------------------------------------
+
+from hashview.models import JobTasks, Rules, Tasks, Wordlists  # noqa: E402
+
+
+def _rule(owner_id, **kw):
+    defaults = dict(name="r", owner_id=owner_id, path="/tmp/x.rule", size=1, checksum="a" * 64)
+    defaults.update(kw)
+    row = Rules(**defaults)
+    db.session.add(row)
+    db.session.commit()
+    return row
+
+
+def _wordlist(owner_id, **kw):
+    defaults = dict(name="w", owner_id=owner_id, type="static", path="/tmp/x.gz",
+                     size=1, byte_size=1, checksum="b" * 64)
+    defaults.update(kw)
+    row = Wordlists(**defaults)
+    db.session.add(row)
+    db.session.commit()
+    return row
+
+
+def _task(owner_id, **kw):
+    defaults = dict(name="t", owner_id=owner_id, hc_attackmode=0, loopback=False)
+    defaults.update(kw)
+    row = Tasks(**defaults)
+    db.session.add(row)
+    db.session.commit()
+    return row
+
+
+def _jobtask(task_id, status):
+    jt = JobTasks(job_id=1, task_id=task_id, status=status)
+    db.session.add(jt)
+    db.session.commit()
+    return jt
+
+
+def test_resource_in_running_task_false_when_unreferenced(app):
+    user = _user()
+    _rule(user.id)
+    assert u.resource_in_running_task(rule_id=999999) is False
+    assert u.resource_in_running_task(wl_id=999999) is False
+
+
+def test_resource_in_running_task_false_when_no_running_jobtask(app):
+    user = _user()
+    rule = _rule(user.id)
+    task = _task(user.id, rule_id=rule.id)
+    _jobtask(task.id, "Queued")
+    assert u.resource_in_running_task(rule_id=rule.id) is False
+
+
+def test_resource_in_running_task_true_for_rule(app):
+    user = _user()
+    rule = _rule(user.id)
+    task = _task(user.id, rule_id=rule.id)
+    _jobtask(task.id, "Running")
+    assert u.resource_in_running_task(rule_id=rule.id) is True
+
+
+def test_resource_in_running_task_true_for_wordlist_wl_id_2(app):
+    """wl_id_2 (the second wordlist slot, e.g. combinator attacks) counts too."""
+    user = _user()
+    wl = _wordlist(user.id)
+    task = _task(user.id, wl_id_2=wl.id)
+    _jobtask(task.id, "Running")
+    assert u.resource_in_running_task(wl_id=wl.id) is True
+
+
+# --- replace_file_atomic -----------------------------------------------------
+
+def test_replace_file_atomic_same_filesystem(tmp_path):
+    src = tmp_path / "src.txt"
+    dst = tmp_path / "dst.txt"
+    src.write_text("new content")
+    dst.write_text("old content")
+    u.replace_file_atomic(str(src), str(dst))
+    assert dst.read_text() == "new content"
+    assert not src.exists()
+
+
+def test_replace_file_atomic_falls_back_on_exdev(tmp_path, monkeypatch):
+    src = tmp_path / "src.txt"
+    dst = tmp_path / "dst.txt"
+    src.write_text("new content")
+    dst.write_text("old content")
+
+    def _raise_exdev(a, b):
+        raise OSError(errno.EXDEV, "cross-device link")
+
+    monkeypatch.setattr(u.os, "replace", _raise_exdev)
+    u.replace_file_atomic(str(src), str(dst))
+    assert dst.read_text() == "new content"
+    assert not src.exists()
+
+
+def test_replace_file_atomic_reraises_other_oserror(tmp_path, monkeypatch):
+    src = tmp_path / "src.txt"
+    dst = tmp_path / "dst.txt"
+    src.write_text("new content")
+    dst.write_text("old content")
+
+    def _raise_other(a, b):
+        raise OSError(errno.EACCES, "permission denied")
+
+    monkeypatch.setattr(u.os, "replace", _raise_other)
+    with pytest.raises(OSError):
+        u.replace_file_atomic(str(src), str(dst))

--- a/tests/unit/test_utils_misc.py
+++ b/tests/unit/test_utils_misc.py
@@ -13,7 +13,7 @@ import pytest
 
 import hashview.utils.utils as u
 import hashview.utils.wordlist_import as wi
-from hashview.models import Users, db
+from hashview.models import JobTasks, Rules, Tasks, Users, Wordlists, db
 
 
 def _user(**kw):
@@ -180,9 +180,6 @@ def test_run_import_async_runs_within_app_context(app, monkeypatch):
 
 # --- resource_in_running_task -----------------------------------------------
 
-from hashview.models import JobTasks, Rules, Tasks, Wordlists  # noqa: E402
-
-
 def _rule(owner_id, **kw):
     defaults = dict(name="r", owner_id=owner_id, path="/tmp/x.rule", size=1, checksum="a" * 64)
     defaults.update(kw)
@@ -263,18 +260,27 @@ def test_replace_file_atomic_same_filesystem(tmp_path):
 
 
 def test_replace_file_atomic_falls_back_on_exdev(tmp_path, monkeypatch):
+    """Only the FIRST os.replace (src -> dst) is cross-device; the fallback's
+    own os.replace(tmp, dst) is same-directory and must succeed normally."""
     src = tmp_path / "src.txt"
     dst = tmp_path / "dst.txt"
     src.write_text("new content")
     dst.write_text("old content")
 
-    def _raise_exdev(a, b):
-        raise OSError(errno.EXDEV, "cross-device link")
+    real_replace = u.os.replace
+    calls = []
 
-    monkeypatch.setattr(u.os, "replace", _raise_exdev)
+    def _replace_first_call_exdev(a, b):
+        calls.append((a, b))
+        if len(calls) == 1:
+            raise OSError(errno.EXDEV, "cross-device link")
+        return real_replace(a, b)
+
+    monkeypatch.setattr(u.os, "replace", _replace_first_call_exdev)
     u.replace_file_atomic(str(src), str(dst))
     assert dst.read_text() == "new content"
     assert not src.exists()
+    assert len(calls) == 2
 
 
 def test_replace_file_atomic_reraises_other_oserror(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Closes #399. Adds a way to replace the *contents* of an existing rule or wordlist without deleting/recreating it — previously the only write routes were `POST /v1/rules/add/<name>` and `POST /v1/wordlists/add/<name>`, both of which always mint a new row, and delete is blocked precisely when a resource is wired into a task (the case that most needs refreshing).

- `PUT /v1/rules/<int:rules_id>` — overwrites the rule file in place (same id, same name, same path); body may be plain text or gzip (decompressed server-side, rules are plaintext at rest).
- `PUT /v1/wordlists/<int:wordlist_id>` — re-ingests the body via the existing `ingest_static_wordlist_file` helper, repoints the row (same id/name), and removes the old on-disk file; refuses `type: dynamic` wordlists with 400 (those are regenerated from the DB).
- Both refuse with **409** if a `Tasks` row using the resource has a currently `Running` `JobTasks` entry — swapping content out from under an in-flight crack would silently change what that run is doing. New shared helper: `resource_in_running_task(rule_id=..., wl_id=...)`.
- The existing web UI rule editor (`/rules/edit/<id>`) gets the same 409-equivalent guard — it previously had none.
- New shared helper `replace_file_atomic()` handles the `control/tmp` → live-path swap, tolerating `control/` being a separate mount point (`os.replace` raising `EXDEV`, see #395) via a same-directory copy + replace rather than a truncate-in-place copy.
- OpenAPI spec (`hashview/api_docs/openapi.yaml`) updated with both new operations; CHANGELOG updated.

## Test plan

- [x] `pytest tests/unit -q` — 1700 passed, 2 skipped, 61 xfailed, 1 xpassed (pre-existing, unrelated: a `Query` vs `int` comparison bug in `customers/routes.py`), 0 failed
- [x] `ruff check` clean on all touched files
- [x] New unit coverage: helper functions (`resource_in_running_task`, `replace_file_atomic` incl. EXDEV fallback), both PUT routes (success/404/403/409/400-empty-body/400-bad-gzip/400-dynamic/agent-rejected), and the web UI edit-guard regression test
- [x] `tests/unit/test_openapi_spec.py` — spec/route parity passes with the new PUT operations