### PR TITLE
chore(hooks): allowlist the docker-analytics bugtest login literal

### DIFF
--- a/.githooks/safe-allowlist.txt
+++ b/.githooks/safe-allowlist.txt
@@ -119,3 +119,12 @@ api_key="user-api-key-
 # Not a credential -- it's a fixed dummy LM response reused across the file's
 # existing NetNTLM tests.
 1122334455667788AABBCCDDEEFF1122334455667788AABBCCDD
+
+# --- tests/integration/test_analytics_docker_bugs.py false positives ---
+# Throwaway login for the opt-in docker analytics bugtest. The module is gated
+# behind pytest.mark.docker_analytics and skips unless HASHVIEW_DOCKER_BASE_URL
+# is set, and everything it creates is prefixed zz-analytics-bugtest so teardown
+# deletes only its own rows. Not a credential. Anchored on the exact literal so
+# a real LOGIN_PASSWORD assignment still trips the generic secret-assign rule,
+# and the pattern matches its own line here, which that rule also flags.
+LOGIN_PASSWORD = "bugtest-password-123"


### PR DESCRIPTION
## Summary

`tests/integration/test_analytics_docker_bugs.py` defines a throwaway
`LOGIN_PASSWORD`, and the pre-push scanner's generic secret-assign rule flags it
on any branch whose diff includes that file. It blocked the #429 merge push
today, and it will block anyone else the same way. This adds the missing
allowlist entry so the rule stops firing on it.

The literal is not a credential. The module is gated behind
`pytest.mark.docker_analytics`, skips unless `HASHVIEW_DOCKER_BASE_URL` is set,
and creates only `zz-analytics-bugtest`-prefixed rows so its teardown deletes
exactly its own data.

The pattern is anchored on the exact literal rather than a general
`LOGIN_PASSWORD` shape, so a real credential assignment still trips the rule. It
also matches its own line, which the allowlist header notes is required, since
the generic rule flags the allowlist entry itself when that line is added.

Closes #

## Checklist

- [x] This PR targets `v0.8.3-dev` (the current dev branch), **not** `main`
- [x] Commit subjects follow `type(scope): subject` (see [CONTRIBUTING.md](../CONTRIBUTING.md#commit-messages))
- [ ] `scripts/preflight.sh` passes locally
- [x] Pushed through the pre-push hook (not `--no-verify`)
- [ ] New/changed behavior has test coverage
- [ ] If a route changed: `hashview/api_docs/openapi.yaml` is updated
- [ ] If a migration was added: it's MySQL/MariaDB-safe, and `DEV_HEAD` in
      `tests/run_migration_e2e.sh` is bumped
- [ ] If user-visible: `CHANGELOG.md` has an entry under `## Current Release`
- [x] N/A items above are just left unchecked, not deleted

## Testing

One-line change to a hook config file, so there is no code path to cover and
nothing user-visible to note in the changelog.

Verified by the pre-push hook itself, which is the thing under test here: the
push succeeded with `pre-push: all checks passed`, having run the sensitive
content scan, `ruff`, `bandit` against the baseline, and the full unit suite. A
clean scan is the proof the entry works, because without it the scanner would
have flagged the new allowlist line itself.

I left the `scripts/preflight.sh` box unchecked rather than claiming it: the
pre-push hook ran the equivalent gates, but I did not invoke that script
directly.
