### PR TITLE
feat(settings): hashes-table rollup in Data Management, with per-figu…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ Notable changes will be documented here
 **Encrypted Database Backup**
 - Download an encrypted `mysqldump` of the database from Settings -> Data Management, protected by a one-time password
 
+**Hashes Table Overview**
+- Settings -> Data Management now shows what the `hashes` table actually holds: total / recovered / unrecovered across the instance, then a per-hash-type breakdown naming each hashcat mode. Counts come from the `hashes` table alone -- one row per unique (sub_ciphertext, hash_type) -- so a hash shared by several hashfiles is counted once, unlike the per-customer, per-account figures on Analytics
+- Every figure in that table is a download link: click a total for those hashes, Recovered for `hash:plaintext` of the cracked ones, or Unrecovered for the hashes still outstanding. Each file holds exactly as many lines as the figure that linked to it. Exports are admin-only, audited, and streamed in primary-key pages so a full-corpus download doesn't buffer in the server's memory
+
 **hashcat Version Interoperability CI**
 - Added a hashcat version interoperability CI matrix: offline contract tests run Hashview's status/benchmark/outfile/flag parsers over committed captures from five hashcat releases on every PR, and a scheduled workflow re-runs them against the real binaries plus a live `--skip`/`--limit` slice check, filing an issue when a newer hashcat release appears.
 

--- a/hashview/customers/routes.py
+++ b/hashview/customers/routes.py
@@ -4,7 +4,6 @@ from flask_login import current_user, login_required
 from sqlalchemy import case, func
 
 from hashview.customers.forms import CustomersForm
-from hashview.jobs.forms import JobsNewHashFileForm
 from hashview.models import (
     Customers,
     Hashes,
@@ -14,23 +13,13 @@ from hashview.models import (
     db,
 )
 from hashview.utils.audit import log_event
+from hashview.utils.hashcat_modes import hash_type_names
 from hashview.utils.utils import purge_orphaned_hashes, try_commit
 
 
 def _hash_type_names():
     """Reverse-map hashcat modes -> friendly names from the new-hashfile form choices."""
-    names = {}
-    try:
-        f = JobsNewHashFileForm()
-        for sel in (f.hash_type, f.pwdump_hash_type, f.netntlm_hash_type,
-                    f.kerberos_hash_type, f.shadow_hash_type):
-            for v, lab in sel.choices:
-                if v is not None and str(v) and str(v).isdigit() and str(v) not in names:
-                    nm = lab.split(') ', 1)[1] if ') ' in lab else lab
-                    names[str(v)] = nm.split(' / ')[0].split(',')[0].strip()
-    except Exception:  # pragma: no cover - defensive
-        names = {}
-    return names
+    return hash_type_names()
 
 customers = Blueprint('customers', __name__)
 

--- a/hashview/notifications/routes.py
+++ b/hashview/notifications/routes.py
@@ -2,7 +2,6 @@
 from flask import Blueprint, flash, redirect, render_template, request, url_for
 from flask_login import current_user, login_required
 
-from hashview.jobs.forms import JobsNewHashFileForm
 from hashview.models import (
     Hashes,
     HashfileHashes,
@@ -13,6 +12,7 @@ from hashview.models import (
     Settings,
     db,
 )
+from hashview.utils.hashcat_modes import hash_type_names
 from hashview.utils.utils import try_commit
 
 notifications = Blueprint('notifications', __name__)
@@ -21,15 +21,7 @@ notifications = Blueprint('notifications', __name__)
 def _hash_type_names():
     """hashcat mode -> concise friendly name, derived from the job-hashfile
     form's own choices (same mapping the jobs views use) for the HASHTYPE badge."""
-    names = {}
-    form = JobsNewHashFileForm()
-    for sel in (form.hash_type, form.pwdump_hash_type, form.netntlm_hash_type,
-                form.kerberos_hash_type, form.shadow_hash_type):
-        for value, label in sel.choices:
-            if value is not None and str(value).isdigit() and str(value) not in names:
-                name = label.split(') ', 1)[1] if ') ' in label else label
-                names[str(value)] = name.split(' / ')[0].split(',')[0].strip()
-    return names
+    return hash_type_names()
 
 
 @notifications.route("/notifications", methods=['GET', 'POST'])

--- a/hashview/settings/routes.py
+++ b/hashview/settings/routes.py
@@ -5,6 +5,7 @@ from datetime import datetime
 
 from flask import (
     Blueprint,
+    Response,
     abort,
     current_app,
     flash,
@@ -13,9 +14,11 @@ from flask import (
     render_template,
     request,
     send_from_directory,
+    stream_with_context,
     url_for,
 )
 from flask_login import current_user, login_required
+from sqlalchemy import func
 
 import hashview
 from hashview.models import Hashes, Settings, db
@@ -26,10 +29,16 @@ from hashview.utils.backup import (
     create_encrypted_db_backup,
     purge_stale_backups,
 )
+from hashview.utils.hashcat_modes import hash_type_names
 from hashview.utils.utils import send_slack_channel
 
 # control/tmp filename of a generated backup, e.g. '1a2b3c4d5e6f7a8b.sql.gz.enc'
 _BACKUP_TOKEN_RE = re.compile(r'^[0-9a-f]{16}\.sql\.gz\.enc$')
+
+# A hashcat mode as it may arrive in a query string. ASCII digits only, and short
+# enough that the value stays inside MySQL's signed INT range -- see the comment in
+# settings_hashes_download for why neither half of that is optional.
+_MODE_RE = re.compile(r'^[0-9]{1,7}$')
 
 
 settings = Blueprint('settings', __name__)
@@ -43,6 +52,66 @@ def _human_size(num):
                 return '%d B' % num
             return (f'{num:.1f} {unit}').replace('.0 ', ' ')
         num /= 1024.0
+
+
+# Export flavours for the Data-management hashes table. Each maps to one column
+# of that table, so the link under a figure downloads exactly the rows it counts.
+_HASH_EXPORT_TYPES = ('all', 'found', 'left')
+
+# Exports are paged on the primary key rather than fetched in one go: this table
+# covers the whole corpus (869k rows on this instance) and the mysqlconnector
+# dialect reports supports_server_side_cursors = False, so yield_per() cannot
+# stop the driver from buffering the entire result set client-side -- measured at
+# a 114 MB peak for the largest export. Keyset paging keeps that flat at ~4 MB
+# for ~28% more wall-clock, and works the same on SQLite. 5,000 was measured
+# against 20,000, which cost 3x the memory for no time saved.
+_HASH_EXPORT_BATCH = 5000
+
+
+def _hashes_rollup():
+    """Per-hash_type totals straight from the ``hashes`` table.
+
+    No join to hashfile_hashes: `hashes` already holds one row per unique
+    (sub_ciphertext, hash_type), so a hash shared by several hashfiles is counted
+    once. That makes these figures deliberately different from the per-customer
+    numbers on /analytics, which count accounts.
+
+    Two grouped queries rather than one COUNT + SUM(CASE WHEN cracked). Measured
+    on a 869k-row table, the single-query form takes ~2.8s: it scans
+    ix_hashes_hash_type but has to fetch `cracked` from the clustered row for
+    every one of those rows. Splitting it lets each half stay index-only -- the
+    totals are covered by ix_hashes_hash_type, and the cracked counts range-scan
+    ix_hashes_cracked_recovered_at over the (much smaller) cracked partition.
+    Same numbers, ~400ms. Neither index is new; nothing on the insert path pays
+    for this page.
+
+    Returns ``(rows, total, cracked)`` with rows ordered by size, each a dict of
+    mode / name / total / cracked / uncracked.
+    """
+    names = hash_type_names(short=False)
+    totals = db.session.query(
+        Hashes.hash_type, func.count(Hashes.id),
+    ).group_by(Hashes.hash_type).all()
+    cracked_counts = dict(db.session.query(
+        Hashes.hash_type, func.count(Hashes.id),
+    ).filter(Hashes.cracked == 1).group_by(Hashes.hash_type).all())
+
+    rows = []
+    for hash_type, total in totals:
+        total = int(total or 0)
+        cracked = int(cracked_counts.get(hash_type) or 0)
+        mode = '' if hash_type is None else str(hash_type)
+        rows.append({
+            'mode': mode,
+            # LM (3000) is deliberately absent from the mode tables, and a row
+            # could carry any mode at all via the API, so fall back to the number.
+            'name': names.get(mode, 'mode ' + mode if mode else 'unknown'),
+            'total': total,
+            'cracked': cracked,
+            'uncracked': total - cracked,
+        })
+    rows.sort(key=lambda row: (-row['total'], row['mode']))
+    return rows, sum(r['total'] for r in rows), sum(r['cracked'] for r in rows)
 
 
 #############################################
@@ -128,6 +197,10 @@ def settings_list():
             hashview_form.azure_allowed_groups.data = settings.azure_allowed_groups
             # azure_client_secret is write-only — never echo it back to the page.
 
+        # Only on the render path -- a successful POST redirects, and this is the
+        # one part of the page that costs a couple of grouped queries.
+        hashes_rows, hashes_total, hashes_cracked = _hashes_rollup()
+
         try:
             database_version = db.session.execute('SELECT version_num FROM alembic_version LIMIT 1;').scalar()
         except Exception:
@@ -144,6 +217,9 @@ def settings_list():
             backupForm          = DatabaseBackupForm(),
             tmp_folder_size     = tmp_folder_size,
             audit_logs_size     = audit_logs_size,
+            hashes_rows         = hashes_rows,
+            hashes_total        = hashes_total,
+            hashes_cracked      = hashes_cracked,
             application_version = hashview.__version__,
             database_version    = database_version,
             default_azure_redirect = default_azure_redirect,
@@ -290,3 +366,92 @@ def clear_logs():
     log_event('logs.clear', detail=f'removed_backups={removed_backups}')
     flash('Audit and error logs cleared.', 'success')
     return redirect(url_for('settings.settings_list'))
+
+
+@settings.route('/settings/hashes/download', methods=['GET'])
+@login_required
+def settings_hashes_download():
+    """Stream the hashes behind one figure of the Data-management hashes table.
+
+    ``type`` picks the column -- ``all`` every hash, ``found`` the recovered ones
+    as ``ciphertext:plaintext``, ``left`` the ones still uncracked. ``mode``
+    narrows to a single hash_type; omitted, it exports every mode (the table's
+    summary tiles).
+
+    Straight off ``hashes`` with no hashfile join, so the file holds exactly as
+    many lines as the figure that linked to it: one per unique
+    (sub_ciphertext, hash_type). Usernames live on hashfile_hashes and are
+    therefore not in scope here -- /analytics is where per-customer,
+    username-bearing exports come from.
+    """
+    if not current_user.admin:
+        abort(403)
+
+    export_type = request.args.get('type', 'all')
+    if export_type not in _HASH_EXPORT_TYPES:
+        abort(400)
+
+    # Digits only, and converted to an int *here* rather than inside the generator.
+    # Everything below runs while the response body is being iterated, after the 200
+    # and the Content-Disposition header are already committed -- an exception there
+    # cannot become the abort(400) this guard intends. It degrades to a bare 500, or
+    # for a non-latin-1 filename it dies inside werkzeug's send_header and hangs the
+    # request. So the whole class is settled before the Response is constructed.
+    #
+    # str.isdigit() on its own is not that check. It is also true for superscript
+    # digits (U+00B2 SUPERSCRIPT TWO, which int() rejects outright) and for non-ASCII
+    # decimal digits (U+0662 ARABIC-INDIC TWO, which int() reads as 2 while the raw
+    # character stays in the filename). The 7-digit bound then keeps the value under
+    # MySQL's signed INT ceiling, past which the driver raises DataError; hashcat's
+    # highest real mode is five digits.
+    mode = request.args.get('mode', '')
+    if mode and not _MODE_RE.match(mode):
+        abort(400)
+    mode_int = int(mode) if mode else None
+
+    def page(after_id):
+        """One batch of rows with an id above ``after_id``, in id order.
+
+        Ordering on the PK makes this a plain index range scan: MySQL appends the
+        PK to every secondary index, so ix_hashes_hash_type already behaves as
+        (hash_type, id) for the per-mode exports.
+        """
+        query = db.session.query(Hashes.id, Hashes.ciphertext, Hashes.plaintext) \
+            .filter(Hashes.id > after_id)
+        if mode_int is not None:
+            query = query.filter(Hashes.hash_type == mode_int)
+        if export_type == 'found':
+            query = query.filter(Hashes.cracked == 1)
+        elif export_type == 'left':
+            query = query.filter(Hashes.cracked == 0)
+        return query.order_by(Hashes.id).limit(_HASH_EXPORT_BATCH).all()
+
+    log_event('hashes.export', detail=f'type={export_type} mode={mode or "all"}')
+
+    def generate():
+        after_id = 0
+        while True:
+            rows = page(after_id)
+            if not rows:
+                return
+            for row_id, ciphertext, plaintext in rows:
+                after_id = row_id
+                if ciphertext is None:
+                    continue
+                if export_type == 'found':
+                    # Cracked rows always carry a plaintext; an empty password is
+                    # a legitimate value, so only a genuine NULL is skipped.
+                    if plaintext is None:
+                        continue
+                    yield f'{ciphertext}:{plaintext}\n'
+                else:
+                    yield f'{ciphertext}\n'
+            if len(rows) < _HASH_EXPORT_BATCH:
+                return
+
+    filename = f'hashes_{mode or "all"}_{export_type}.txt'
+    return Response(
+        stream_with_context(generate()),
+        mimetype='text/plain',
+        headers={'Content-Disposition': f'attachment; filename="{filename}"'},
+    )

--- a/hashview/static/css/phosphor-app.css
+++ b/hashview/static/css/phosphor-app.css
@@ -418,3 +418,41 @@ html[data-sidebar="collapsed"] .user-chip > a { display: none; }
    signal it's a link. */
 .rec-x-link { color: inherit; text-decoration: none; cursor: pointer; }
 .rec-x-link:hover { text-decoration: underline; text-underline-offset: 2px; }
+
+/* Settings -> Data management: the hashes-table card. Colour follows the design
+   spec: the phosphor amber is reserved for Recovered, which is the one figure the
+   eye should land on. Everything else uses the ordinary body inks -- labels, Mode
+   and the card meta grey (--text-mute); the headline figures, Total and Hash type
+   white (--text); the Unrecovered figures a step back (--text-dim). Painting the
+   whole card amber flattens that hierarchy and was tried and reverted.
+
+   These are classes rather than inline styles only so the palette lives in one
+   place; each one restates what the design put inline. Scoped to .hv-hashes-card
+   because .kpi / .tbl / .field-hint are shared app-wide -- and deliberately silent
+   about .kpi-label, .kpi-foot, .kpi-value, .kpi-value.accent, .field-hint and
+   td.num, which already inherit exactly the ink the design asks for.            */
+.hv-hashes-card .hv-hashes-meta,
+.hv-hashes-card .hv-hashes-empty,
+.hv-hashes-card .hv-hash-mode { color: var(--text-mute); }
+.hv-hashes-card .hv-hash-name { color: var(--text); font-size: 12.5px; }
+.hv-hashes-card .hv-hashes-lit { color: var(--text-dim); }
+.hv-hashes-card .tbl td.hv-hash-found { color: var(--primary); text-shadow: var(--glow-text); }
+.hv-hashes-card .tbl td.num.hv-hash-left,
+.hv-hashes-card .hv-kpi-dim .kpi-value { color: var(--text-dim); }
+
+/* Every figure in the table is a link that downloads exactly the rows it counts.
+   A bare number in a cell doesn't read as clickable, so these carry a dotted
+   underline until hovered; the colour is inherited so each column keeps the ink
+   set above, and hover lifts just that one figure to the accent. */
+.hv-count-link {
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px dotted var(--border-bright);
+  cursor: pointer;
+}
+.hv-count-link:hover { color: var(--primary); border-bottom-color: var(--primary); }
+.hv-count-link:hover .ico { color: var(--primary); }
+/* A zero has nothing to download, so it isn't a link -- and in the Recovered
+   column it must not inherit that column's amber glow (the design switches the
+   glow off when there are no cracks). */
+.hv-hashes-card .hv-count-zero { color: var(--text-mute); text-shadow: none; }

--- a/hashview/templates/settings.html.j2
+++ b/hashview/templates/settings.html.j2
@@ -286,6 +286,80 @@
 
         {# ---- Data management ---- #}
         <div class="hv-settings-pane" data-pane="data" style="display:none;">
+
+            {# Rollup of the `hashes` table. Every figure links to the export of the
+               exact rows it counts: 'all' the ciphertexts, 'found' as
+               ciphertext:plaintext, 'left' the ciphertexts still uncracked. #}
+            {% macro count_link(value, mode, type, cls='') %}
+                {%- if value -%}
+                    <a class="hv-count-link {{ cls }}" href="{{ url_for('settings.settings_hashes_download', mode=mode or None, type=type) }}"
+                       title="Download these {{ value | commafy }} hash(es) as a .txt file">{{ value | commafy }}</a>
+                {%- else -%}
+                    <span class="{{ cls }} hv-count-zero">0</span>
+                {%- endif -%}
+            {% endmacro %}
+
+            <div class="card hv-hashes-card" style="margin-bottom:var(--gap);">
+                <div class="card-head">
+                    <span class="dot-led {{ 'on' if hashes_total else 'idle' }}"></span><h3>Hashes table</h3>
+                    <span class="mono hv-hashes-meta" style="margin-left:auto; font-size:10.5px;">{{ hashes_rows | length }} hash type{{ '' if hashes_rows | length == 1 else 's' }} · {{ hashes_total | commafy }} rows</span>
+                </div>
+                <div class="card-body">
+                    {% if not hashes_total %}
+                        <div class="mono hv-hashes-empty" style="padding:26px; text-align:center; font-size:12px;">no hashes imported yet</div>
+                    {% else %}
+                        {% set cracked_pct = hashes_cracked / hashes_total * 100 %}
+                        <div class="grid" style="grid-template-columns:repeat(3,1fr); margin-bottom:18px;">
+                            <div class="kpi">
+                                <div class="kpi-label">{{ icon('hash', size=13) }} Total hashes</div>
+                                <div class="kpi-value">{{ count_link(hashes_total, '', 'all') }}</div>
+                            </div>
+                            <div class="kpi">
+                                <div class="kpi-label">{{ icon('key', size=13) }} Recovered</div>
+                                <div class="kpi-value accent">{{ count_link(hashes_cracked, '', 'found') }}</div>
+                                <div class="kpi-foot mono">{{ cracked_pct | round(1) }}% of all hashes</div>
+                            </div>
+                            <div class="kpi hv-kpi-dim">
+                                <div class="kpi-label">{{ icon('lock', size=13) }} Unrecovered</div>
+                                <div class="kpi-value">{{ count_link(hashes_total - hashes_cracked, '', 'left') }}</div>
+                                <div class="kpi-foot mono">{{ (100 - cracked_pct) | round(1) }}% remaining</div>
+                            </div>
+                        </div>
+
+                        <div style="height:1px; background:var(--border-soft); margin:0 0 18px;"></div>
+
+                        <div style="overflow-x:auto;">
+                        <table class="tbl">
+                            <thead>
+                                <tr>
+                                    <th style="width:62px;">Mode</th>
+                                    <th>Hash type</th>
+                                    <th class="center">Total</th>
+                                    <th class="center">Recovered</th>
+                                    <th class="center">Unrecovered</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for row in hashes_rows %}
+                                <tr>
+                                    <td class="mono hv-hash-mode">{{ row.mode or '—' }}</td>
+                                    <td class="mono hv-hash-name">{{ row.name }}</td>
+                                    <td class="center num">{{ count_link(row.total, row.mode, 'all') }}</td>
+                                    <td class="center num hv-hash-found">{{ count_link(row.cracked, row.mode, 'found') }}</td>
+                                    <td class="center num hv-hash-left">{{ count_link(row.uncracked, row.mode, 'left') }}</td>
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                        </div>
+                        <div class="field-hint" style="margin-top:12px; display:flex; align-items:flex-start; gap:6px;">
+                            {{ icon('info', size=12) }}
+                            <span>Counts come from the <span class="mono hv-hashes-lit">hashes</span> table only — one row per unique (sub_ciphertext, hash_type), so a hash shared by several hashfiles is counted once. Click any figure to download those hashes as a text file; recovered exports are <span class="mono hv-hashes-lit">hash:plaintext</span>.</span>
+                        </div>
+                    {% endif %}
+                </div>
+            </div>
+
             <div class="card">
                 <div class="card-body">
                     {# Back up database (mysqldump -> gz -> AES-256 encrypted with a one-time password) #}

--- a/hashview/utils/hashcat_modes.py
+++ b/hashview/utils/hashcat_modes.py
@@ -830,3 +830,43 @@ HASH_ONLY_AUTO_RULES = {
     '29543': ('prefix', '$luks$'),
     '29700': ('prefix', '$keepass$'),
 }
+
+
+# The pwdump select is the one hashfile-form choice list that isn't a constant --
+# it offers NTLM only, and 1000 already appears in HASH_TYPE_CHOICES, so the
+# reverse map below doesn't need it.
+_NAME_CHOICE_LISTS = (
+    HASH_TYPE_CHOICES,
+    KERBEROS_HASH_TYPE_CHOICES,
+    NETNTLM_HASH_TYPE_CHOICES,
+    SHADOW_HASH_TYPE_CHOICES,
+)
+
+
+def hash_type_names(short=True):
+    """Reverse-map hashcat modes -> friendly names, from the form's own choices.
+
+    Keys are modes as ``str`` (the DB column is an Integer, so callers coerce).
+    Derived from the choice lists rather than a second hand-kept table, so the
+    names shown in the UI can never drift from the ones offered at import.
+
+    ``short=True`` (the default) truncates at the first ``,`` or ``/`` for
+    badge-sized labels -- the historical behaviour of the per-blueprint copies
+    this replaces. That truncation collapses whole families to one word
+    ("Kerberos 5" for 13100, 18200 and 19700 alike), so anything listing several
+    modes side by side wants ``short=False``, which keeps hashcat's full
+    description and only strips the redundant ``(mode) `` prefix.
+
+    Modes hashview deliberately doesn't offer (LM/3000) are absent; callers fall
+    back to the bare mode number.
+    """
+    names = {}
+    for choices in _NAME_CHOICE_LISTS:
+        for value, label in choices:
+            if value is None or not str(value).isdigit() or str(value) in names:
+                continue
+            name = label.split(') ', 1)[1] if ') ' in label else label
+            if short:
+                name = name.split(' / ')[0].split(',')[0]
+            names[str(value)] = name.strip()
+    return names

--- a/tests/unit/test_settings_hashes_table.py
+++ b/tests/unit/test_settings_hashes_table.py
@@ -1,0 +1,384 @@
+"""Unit tests for Settings -> Data management: the hashes-table rollup + exports.
+
+The card shows one row per hash_type straight off the `hashes` table, and every
+figure in it links to a .txt of exactly the rows it counts:
+
+    type=all   -> ciphertext per line
+    type=found -> ciphertext:plaintext (recovered only)
+    type=left  -> ciphertext (uncracked only)
+
+Uses the in-memory SQLite app from tests/unit/conftest.py.
+"""
+
+from hashview.models import Hashes, HashfileHashes, Hashfiles, Settings, Users, db
+from hashview.utils.utils import get_md5_hash
+
+
+def _admin(admin=True):
+    user = Users(first_name="A", last_name="D", email_address=f"{'adm' if admin else 'usr'}@e.com",
+                 password="x" * 60, admin=admin, api_key=f"key-{admin}")
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+def _login(client, user):
+    with client.session_transaction() as sess:
+        sess["_user_id"] = str(user.id)
+        sess["_fresh"] = True
+
+
+def _hash(ciphertext, hash_type=1000, plaintext=None):
+    row = Hashes(sub_ciphertext=get_md5_hash(ciphertext), ciphertext=ciphertext,
+                 hash_type=hash_type, cracked=plaintext is not None, plaintext=plaintext)
+    db.session.add(row)
+    db.session.commit()
+    return row
+
+
+def _raw(ciphertext, cracked, plaintext, hash_type=1000):
+    """A row with an arbitrary cracked/plaintext combination, so a test can tell
+    which of the two the export actually filters on."""
+    row = Hashes(sub_ciphertext=get_md5_hash(ciphertext), ciphertext=ciphertext,
+                 hash_type=hash_type, cracked=cracked, plaintext=plaintext)
+    db.session.add(row)
+    db.session.commit()
+    return row
+
+
+def _settings_row():
+    db.session.add(Settings(retention_period=30, max_runtime_jobs=0, max_runtime_tasks=0))
+    db.session.commit()
+
+
+def _lines(resp):
+    return [ln for ln in resp.get_data(as_text=True).split("\n") if ln]
+
+
+#############################################
+# The rollup
+#############################################
+
+def test_rollup_groups_by_hash_type_and_sorts_by_size(app):
+    from hashview.settings.routes import _hashes_rollup
+
+    for i in range(3):
+        _hash(f"ntlm{i}", 1000, plaintext="pw" if i < 2 else None)
+    _hash("krb", 13100)
+
+    rows, total, cracked = _hashes_rollup()
+
+    assert total == 4 and cracked == 2
+    assert [r["mode"] for r in rows] == ["1000", "13100"]     # biggest first
+    assert rows[0] == {"mode": "1000", "name": "NTLM", "total": 3, "cracked": 2, "uncracked": 1}
+    assert rows[1]["total"] == 1 and rows[1]["cracked"] == 0 and rows[1]["uncracked"] == 1
+
+
+def test_rollup_uses_full_mode_names_so_families_stay_distinct(app):
+    """The badge-sized names truncate at the first comma, which collapses every
+    Kerberos mode to 'Kerberos 5'. A table listing them side by side needs the
+    full hashcat description."""
+    from hashview.settings.routes import _hashes_rollup
+
+    _hash("tgs", 13100)
+    _hash("asrep", 18200)
+
+    names = {r["mode"]: r["name"] for r in _hashes_rollup()[0]}
+    assert names["13100"] == "Kerberos 5, etype 23, TGS-REP"
+    assert names["18200"] == "Kerberos 5, etype 23, AS-REP"
+    assert names["13100"] != names["18200"]
+
+
+def test_rollup_falls_back_to_the_mode_number_for_unlisted_modes(app):
+    """LM (3000) is deliberately absent from the mode tables, and /v1 will accept
+    any mode, so an unmapped hash_type must still get a row."""
+    from hashview.settings.routes import _hashes_rollup
+
+    _hash("lm", 3000)
+    assert _hashes_rollup()[0][0]["name"] == "mode 3000"
+
+
+def test_rollup_counts_each_hash_once_regardless_of_hashfiles(app):
+    """`hashes` holds one row per unique (sub_ciphertext, hash_type); the same
+    hash reached through two hashfiles must not double-count."""
+    from hashview.settings.routes import _hashes_rollup
+
+    row = _hash("shared", 1000, plaintext="pw")
+    for hf_id in (1, 2):
+        db.session.add(Hashfiles(id=hf_id, name=f"f{hf_id}", customer_id=1, owner_id=1))
+    db.session.commit()
+    for hf_id in (1, 2):
+        db.session.add(HashfileHashes(hash_id=row.id, hashfile_id=hf_id, username=f"u{hf_id}"))
+    db.session.commit()
+
+    rows, total, cracked = _hashes_rollup()
+    assert total == 1 and cracked == 1
+    assert rows[0]["total"] == 1
+
+
+def test_rollup_is_empty_on_a_fresh_instance(app):
+    from hashview.settings.routes import _hashes_rollup
+
+    assert _hashes_rollup() == ([], 0, 0)
+
+
+#############################################
+# The exports
+#############################################
+
+def test_export_all_serves_every_hash_of_that_mode(app, client):
+    _login(client, _admin())
+    _hash("aaa", 1000, plaintext="pw1")
+    _hash("bbb", 1000)
+    _hash("ccc", 13100)
+
+    resp = client.get("/settings/hashes/download?mode=1000&type=all")
+    assert resp.status_code == 200
+    assert sorted(_lines(resp)) == ["aaa", "bbb"]            # cracked and uncracked, no plaintext
+
+
+def test_export_found_serves_hash_colon_plaintext(app, client):
+    _login(client, _admin())
+    _hash("aaa", 1000, plaintext="Summer2024!")
+    _hash("bbb", 1000)
+
+    resp = client.get("/settings/hashes/download?mode=1000&type=found")
+    assert _lines(resp) == ["aaa:Summer2024!"]
+
+
+def test_export_left_serves_only_uncracked_ciphertexts(app, client):
+    _login(client, _admin())
+    _hash("aaa", 1000, plaintext="pw")
+    _hash("bbb", 1000)
+
+    resp = client.get("/settings/hashes/download?mode=1000&type=left")
+    assert _lines(resp) == ["bbb"]
+
+
+def test_export_partitions_on_the_cracked_flag_not_on_plaintext(app, client):
+    """`cracked` is what the Recovered/Unrecovered columns count, so it has to be
+    what the exports filter on. An inconsistent row (a plaintext left on an
+    uncracked hash, or a cracked hash with none) must follow the flag -- otherwise
+    a NULL check alone would look like it was doing the job."""
+    _login(client, _admin())
+    _raw("aaa", cracked=True, plaintext="pw")
+    _raw("bbb", cracked=False, plaintext="stale")     # not recovered, despite the plaintext
+    _raw("ccc", cracked=True, plaintext=None)         # recovered, but nothing to print
+
+    assert _lines(client.get("/settings/hashes/download?mode=1000&type=found")) == ["aaa:pw"]
+    assert sorted(_lines(client.get("/settings/hashes/download?mode=1000&type=left"))) == ["bbb"]
+
+
+def test_export_without_a_mode_covers_every_mode(app, client):
+    _login(client, _admin())
+    _hash("aaa", 1000, plaintext="pw")
+    _hash("ccc", 13100, plaintext="pw2")
+
+    assert sorted(_lines(client.get("/settings/hashes/download?type=all"))) == ["aaa", "ccc"]
+    assert sorted(_lines(client.get("/settings/hashes/download?type=found"))) == ["aaa:pw", "ccc:pw2"]
+
+
+def test_export_line_count_matches_the_figure_that_linked_to_it(app, client):
+    """The point of the links: the file holds exactly as many lines as the cell."""
+    from hashview.settings.routes import _hashes_rollup
+
+    _login(client, _admin())
+    for i in range(25):
+        _hash(f"h{i:03d}", 1000, plaintext="pw" if i % 5 else None)
+
+    row = _hashes_rollup()[0][0]
+    for export_type, expected in (("all", row["total"]), ("found", row["cracked"]),
+                                  ("left", row["uncracked"])):
+        resp = client.get(f"/settings/hashes/download?mode=1000&type={export_type}")
+        assert len(_lines(resp)) == expected, export_type
+
+
+def test_export_pages_through_every_row_exactly_once(app, client, monkeypatch):
+    """Exports are keyset-paged on the primary key (the driver can't do
+    server-side cursors), so the batch boundary has to be exercised: a lost or
+    repeated cursor advance would duplicate or drop rows."""
+    from hashview.settings import routes
+
+    _login(client, _admin())
+    monkeypatch.setattr(routes, "_HASH_EXPORT_BATCH", 3)
+    expected = [f"h{i:02d}" for i in range(10)]
+    for i, ciphertext in enumerate(expected):
+        # every third row is uncracked, so a page can also end on a skipped row
+        _hash(ciphertext, 1000, plaintext=None if i % 3 == 0 else "pw")
+
+    assert _lines(client.get("/settings/hashes/download?mode=1000&type=all")) == expected
+    assert _lines(client.get("/settings/hashes/download?mode=1000&type=found")) == [
+        f"{c}:pw" for i, c in enumerate(expected) if i % 3]
+
+
+def test_export_pages_are_ordered_and_bounded_in_sql(app, client, monkeypatch):
+    """Keyset paging is only correct if each page is ORDER BY id LIMIT n -- without
+    the ordering, MySQL may return any n matching rows and the cursor then skips
+    or repeats whole blocks. SQLite hands back insert order regardless, so this
+    invariant can only be pinned on the SQL the route actually emits."""
+    from sqlalchemy import event
+
+    from hashview.settings import routes
+
+    _login(client, _admin())
+    monkeypatch.setattr(routes, "_HASH_EXPORT_BATCH", 3)
+    for i in range(7):
+        _hash(f"h{i:02d}", 1000, plaintext="pw")
+
+    statements = []
+
+    def record(conn, cursor, statement, parameters, context, executemany):
+        statements.append(" ".join(statement.split()).upper())
+
+    event.listen(db.engine, "before_cursor_execute", record)
+    try:
+        assert len(_lines(client.get("/settings/hashes/download?mode=1000&type=all"))) == 7
+    finally:
+        event.remove(db.engine, "before_cursor_execute", record)
+
+    pages = [s for s in statements if s.startswith("SELECT") and " FROM HASHES" in s]
+    assert len(pages) >= 3                                   # it really paged
+    for statement in pages:
+        assert "ORDER BY HASHES.ID" in statement, statement
+        assert "LIMIT" in statement, statement
+
+
+def test_export_stops_cleanly_on_an_exact_multiple_of_the_batch(app, client, monkeypatch):
+    """The generator returns early on a short page; a full final page has to fall
+    through to the next (empty) one instead of looping forever."""
+    from hashview.settings import routes
+
+    _login(client, _admin())
+    monkeypatch.setattr(routes, "_HASH_EXPORT_BATCH", 5)
+    for i in range(10):
+        _hash(f"h{i:02d}", 1000, plaintext="pw")
+
+    assert len(_lines(client.get("/settings/hashes/download?mode=1000&type=all"))) == 10
+
+
+def test_export_keeps_an_empty_plaintext(app, client):
+    """An empty password is a legitimate recovered value -- only a NULL is skipped,
+    so the export can't be shorter than the Recovered count."""
+    _login(client, _admin())
+    _hash("aaa", 1000, plaintext="")
+
+    resp = client.get("/settings/hashes/download?mode=1000&type=found")
+    assert resp.get_data(as_text=True) == "aaa:\n"
+
+
+def test_export_sends_a_named_txt_attachment(app, client):
+    _login(client, _admin())
+    _hash("aaa", 1000, plaintext="pw")
+
+    resp = client.get("/settings/hashes/download?mode=1000&type=found")
+    assert resp.mimetype == "text/plain"
+    assert 'filename="hashes_1000_found.txt"' in resp.headers["Content-Disposition"]
+
+    resp = client.get("/settings/hashes/download?type=left")
+    assert 'filename="hashes_all_left.txt"' in resp.headers["Content-Disposition"]
+
+
+def test_export_rejects_a_bad_type_or_mode(app, client):
+    _login(client, _admin())
+    assert client.get("/settings/hashes/download?type=everything").status_code == 400
+    assert client.get("/settings/hashes/download?mode=1000%27&type=all").status_code == 400
+    assert client.get("/settings/hashes/download?mode=../../etc/passwd&type=all").status_code == 400
+
+
+def test_export_rejects_a_mode_that_is_digits_but_not_an_int(app, client):
+    """str.isdigit() is a wider set than int() accepts, and the mode reaches both a
+    Content-Disposition filename and an Integer column. Anything that slips past the
+    guard raises while the body is already streaming, which cannot become a 400: it
+    degrades to a bare 500, and a non-latin-1 filename hangs werkzeug's send_header
+    outright."""
+    _login(client, _admin())
+    _hash("aaa", 1000, plaintext="pw")
+
+    # U+00B2 SUPERSCRIPT TWO: isdigit() is True, int() raises ValueError
+    assert client.get("/settings/hashes/download?mode=\u00b2&type=all").status_code == 400
+    # U+0662 ARABIC-INDIC TWO: isdigit() is True and int() reads it as 2, so without
+    # the ASCII check this exported hash_type 2 under a non-latin-1 filename
+    assert client.get("/settings/hashes/download?mode=\u0662&type=all").status_code == 400
+    # ASCII digits, but past MySQL's signed INT ceiling -- DataError at the driver
+    assert client.get("/settings/hashes/download?mode=" + "9" * 25 + "&type=all").status_code == 400
+    assert client.get("/settings/hashes/download?mode=2147483648&type=all").status_code == 400
+
+    # a real mode still streams, and mode 0 (MD5) is not mistaken for "no mode"
+    assert client.get("/settings/hashes/download?mode=1000&type=all").status_code == 200
+    resp = client.get("/settings/hashes/download?mode=0&type=all")
+    assert resp.status_code == 200 and _lines(resp) == []
+    assert 'filename="hashes_0_all.txt"' in resp.headers["Content-Disposition"]
+
+
+def test_export_defaults_to_all_when_type_is_omitted(app, client):
+    _login(client, _admin())
+    _hash("aaa", 1000, plaintext="pw")
+    assert _lines(client.get("/settings/hashes/download")) == ["aaa"]
+
+
+def test_export_is_admin_only(app, client):
+    _login(client, _admin(admin=False))
+    _hash("aaa", 1000, plaintext="pw")
+    assert client.get("/settings/hashes/download?type=found").status_code == 403
+
+
+def test_export_requires_login(app, client):
+    _hash("aaa", 1000, plaintext="pw")
+    resp = client.get("/settings/hashes/download?type=found")
+    assert resp.status_code in (301, 302, 401)
+    assert "aaa" not in resp.get_data(as_text=True)
+
+
+#############################################
+# The rendered card
+#############################################
+
+def test_settings_page_renders_the_hashes_table_with_download_links(app, client):
+    _login(client, _admin())
+    _settings_row()
+    for i in range(1200):
+        _hash(f"h{i:04d}", 1000, plaintext="pw" if i < 400 else None)
+    _hash("krb", 13100)
+
+    html = client.get("/settings").get_data(as_text=True)
+
+    assert "Hashes table" in html
+    assert "2 hash types" in html
+    assert "1,201 rows" in html                              # commafied, per the UI convention
+    assert "Kerberos 5, etype 23, TGS-REP" in html
+    # every figure is a link to its own export
+    assert 'href="/settings/hashes/download?mode=1000&amp;type=all"' in html
+    assert 'href="/settings/hashes/download?mode=1000&amp;type=found"' in html
+    assert 'href="/settings/hashes/download?mode=1000&amp;type=left"' in html
+    assert 'href="/settings/hashes/download?type=found"' in html   # the summary tile
+    assert "1,200" in html and "800" in html                 # total / uncracked for mode 1000
+    # The card is rendered in the phosphor amber by rules scoped to these hooks
+    # (phosphor-app.css .hv-hashes-card ...), so losing them silently reverts the
+    # whole rollup to the default body ink.
+    for hook in ("hv-hashes-card", "hv-hash-mode", "hv-hash-name",
+                 "hv-hash-found", "hv-hash-left", "hv-kpi-dim", "hv-hashes-meta"):
+        assert hook in html, hook
+
+
+def test_settings_page_renders_zero_counts_as_plain_text(app, client):
+    """A zero has nothing to download, so it must not be a link."""
+    _login(client, _admin())
+    _settings_row()
+    _hash("aaa", 13100)
+
+    html = client.get("/settings").get_data(as_text=True)
+    assert 'href="/settings/hashes/download?mode=13100&amp;type=all"' in html
+    assert 'href="/settings/hashes/download?mode=13100&amp;type=found"' not in html
+    # ...but the figure is still rendered, in the muted span the CSS styles, so an
+    # empty Recovered cell can't be misread as missing data. Asserting only the
+    # absence of the link would pass if the zero branch emitted nothing at all.
+    assert '<td class="center num hv-hash-found"><span class=" hv-count-zero">0</span></td>' in html
+
+
+def test_settings_page_handles_an_empty_hashes_table(app, client):
+    _login(client, _admin())
+    _settings_row()
+
+    html = client.get("/settings").get_data(as_text=True)
+    assert "no hashes imported yet" in html
+    assert "0 hash types" in html


### PR DESCRIPTION
…re exports

Settings -> Data Management gains the hashes-table card from the design: total / recovered / unrecovered tiles, then a row per hash_type naming the hashcat mode. Every figure is a link that downloads exactly the rows it counts -- a total gives the ciphertexts, Recovered gives hash:plaintext, Unrecovered gives the ciphertexts still outstanding.

Counts come from `hashes` alone, with no join to hashfile_hashes, so a hash shared by several hashfiles is counted once. That is deliberately a different unit from /analytics, which counts accounts; the card says so in a footnote.

Three measurements shaped the implementation, all against the 869k-row instance:

- The obvious rollup -- one COUNT plus SUM(CASE WHEN cracked) grouped by hash_type -- took 2.8s. It scans ix_hashes_hash_type but must then fetch `cracked` from the clustered row for all 869k rows. Two grouped queries keep each half index-only (totals covered by ix_hashes_hash_type, cracked counts range-scanning ix_hashes_cracked_recovered_at) for the same numbers in ~400ms. No new index, so nothing on the import path pays for this page. It runs only on the render path, not on a POST that redirects.

- yield_per() cannot bound memory here: the mysqlconnector dialect reports supports_server_side_cursors = False, so the driver buffers the whole result set client-side -- 114 MB peak for the largest export. The exports are keyset-paged on the primary key instead, which holds peak at ~4 MB regardless of size for ~28% more wall-clock, and behaves the same on SQLite.

- The existing per-blueprint mode-name helper truncates at the first comma, which collapses 13100/18200/19700 to "Kerberos 5" -- fine for a badge, useless in a table listing them side by side. hash_type_names(short=False) keeps hashcat's full description. The two duplicate copies of that helper (customers, notifications) now delegate to one implementation in hashcat_modes.py rather than gaining a third.

Colour follows the design spec, which reserves the phosphor amber for Recovered -- the one figure the eye should land on. Labels, Mode and the card meta are grey, Total and Hash type keep the ordinary body ink, and the Unrecovered figures step back one shade. The classes exist so that palette sits in one place instead of a dozen inline styles, and are scoped to .hv-hashes-card because .kpi / .tbl / .field-hint are shared app-wide; they stay deliberately silent about .kpi-label, .kpi-value, .kpi-value.accent, .kpi-foot, .tbl th/td and .field-hint, which already inherit exactly the ink the spec asks for.

Exports are admin-only (like the rest of the pane) and audited via log_event.

The `mode` query param is validated with ^[0-9]{1,7}$ and converted to an int before the Response is built, not inside the generator. str.isdigit() is not that check on its own -- it is true for U+00B2 SUPERSCRIPT TWO, which int() rejects, and for U+0662 ARABIC-INDIC TWO, which int() reads as 2 while the raw character stays in the filename. Either one slipping through raises after the 200 and the Content-Disposition header are committed, where it cannot become the intended 400: it degrades to a bare 500, and the non-latin-1 filename hangs werkzeug's send_header outright. The digit bound keeps the value under MySQL's signed INT ceiling, past which the driver raises DataError the same way.